### PR TITLE
Add polyfill for canvas.toBlob

### DIFF
--- a/app/frontend/containers/Utils.js
+++ b/app/frontend/containers/Utils.js
@@ -1,5 +1,6 @@
 import firebase from 'firebase';
 import uuidv1 from 'uuid/v1';
+import 'blueimp-canvas-to-blob';
 
 export const fetchCurrentPosition = (options = {}) => {
   return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "upload": "node tasks/upload_assets_to_s3.js"
   },
   "dependencies": {
+    "blueimp-canvas-to-blob": "^3.14.0",
     "es6-error": "^4.0.2",
     "firebase": "^4.2.0",
     "firebaseui": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1026,6 +1026,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+blueimp-canvas-to-blob@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.14.0.tgz#ea075ffbfb1436607b0c75e951fb1ceb3ca0288e"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"


### PR DESCRIPTION
safari あたりが対応してないようなので polyfill 追加。
https://developer.mozilla.org/ja/docs/Web/API/HTMLCanvasElement/toBlob
https://github.com/blueimp/JavaScript-Canvas-to-Blob