### PR TITLE
Set locale for metadata

### DIFF
--- a/app/frontend/containers/LeaveMapDialogContainer.js
+++ b/app/frontend/containers/LeaveMapDialogContainer.js
@@ -38,7 +38,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         let collaborators = await colloboratorsResponse.json();
         dispatch(fetchCollaborators(collaborators));
       } else {
-        dispatch(openToast('Failed to join map'));
+        dispatch(openToast('Failed to leave map'));
       }
     }
   }

--- a/app/models/QoodishClient.js
+++ b/app/models/QoodishClient.js
@@ -426,24 +426,26 @@ class QoodishClient {
     }
   }
 
-  async fetchMapMetadata(mapId) {
+  async fetchMapMetadata(mapId, locale) {
     const url = `${process.env.API_ENDPOINT}/maps/${mapId}/metadata`;
     let options = {
       method: 'GET',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Accept-Language': locale
       }
     };
     const response = await fetch(url, options);
     return response;
   }
 
-  async fetchReviewMetadata(reviewId) {
+  async fetchReviewMetadata(reviewId, locale) {
     const url = `${process.env.API_ENDPOINT}/reviews/${reviewId}/metadata`;
     let options = {
       method: 'GET',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Accept-Language': locale
       }
     };
     const response = await fetch(url, options);

--- a/app/models/Utils.js
+++ b/app/models/Utils.js
@@ -42,7 +42,7 @@ export const detectLanguage = (request) => {
   }
 }
 
-export const generateMetadata = async (request, params) => {
+export const generateMetadata = async (request, params, locale) => {
   let title = 'Qoodish (β)';
   let description = 'Qoodish では友だちとマップを作成してお気に入りのお店や観光スポットなどの情報をシェアすることができます。';
   let pageUrl = process.env.ENDPOINT;
@@ -53,7 +53,7 @@ export const generateMetadata = async (request, params) => {
     let response;
     let json;
     if (params.reviewId) {
-      response = await client.fetchReviewMetadata(params.reviewId);
+      response = await client.fetchReviewMetadata(params.reviewId, locale);
       if (response.ok) {
         json = await response.json();
         title = `${json.title} | Qoodish (β)`
@@ -62,7 +62,7 @@ export const generateMetadata = async (request, params) => {
         pageUrl = request.originalUrl;
       }
     } else if (params.mapId) {
-      response = await client.fetchMapMetadata(params.mapId);
+      response = await client.fetchMapMetadata(params.mapId, locale);
       if (response.ok) {
         json = await response.json();
         title = `${json.title} | Qoodish (β)`

--- a/routes.js
+++ b/routes.js
@@ -32,7 +32,7 @@ const routes = (app) => {
   ];
 
   router.get(pageRoutes, async (ctx, next) => {
-    let metadata = await generateMetadata(ctx.request, ctx.params);
+    let metadata = await generateMetadata(ctx.request, ctx.params, detectLanguage(ctx.request));
     let assetPath;
     if (process.env.NODE_ENV === 'production') {
       assetPath = process.env.ASSET_PATH;


### PR DESCRIPTION
Twitter や Facebook で URL を展開した際に、クライアントが日本語設定でも英語のスポット名が出力されてしまっていたので修正。