### PR TITLE
Set cache-control to review images

### DIFF
--- a/app/frontend/containers/Utils.js
+++ b/app/frontend/containers/Utils.js
@@ -14,7 +14,8 @@ export const uploadToStorage = image => {
     const storageRef = storage.ref();
     let fileName = `${uuidv1()}.jpg`;
     const metadata = {
-      contentType: 'image/jpeg'
+      contentType: 'image/jpeg',
+      cacheControl: 'public,max-age=86400',
     };
     const uploadTask = storageRef
       .child('images/' + fileName)

--- a/app/frontend/ui/App.jsx
+++ b/app/frontend/ui/App.jsx
@@ -137,6 +137,7 @@ class App extends Component {
         title="Qoodish"
         meta={[
           { name: 'title', content: 'Qoodish' },
+          { name: 'theme-color', content: '#ffc107' },
           {
             name: 'description',
             content:

--- a/app/functions/Utils.js
+++ b/app/functions/Utils.js
@@ -61,6 +61,7 @@ export const generateMetadata = async (req) => {
       description = json.description;
       imageUrl = json.image_url;
       pageUrl = req.originalUrl;
+      twitterCard = 'summary_large_image';
     }
   }
 


### PR DESCRIPTION
レポートの画像がキャッシュされるように設定しました (とりあえず一日)。
既存の画像については↓で設定。
`gsutil -m setmeta -h "Cache-Control:public, max-age=86400" gs://<バケット>/*`