### PR TITLE
Fix style of open summary button

### DIFF
--- a/app/frontend/ui/MapBottomSeat.jsx
+++ b/app/frontend/ui/MapBottomSeat.jsx
@@ -20,7 +20,7 @@ const styles = {
   },
   expandButtonContainer: {
     width: '100%',
-    position: 'inherit',
+    position: 'fixed',
     bottom: 116,
     textAlign: 'center'
   },


### PR DESCRIPTION
`position: inherit` が効かない一部のブラウザでマップサマリーを開くボタンが隠れてしまう問題を修正しました。