### PR TITLE
Fix node version to v8.11.3 for firebase functions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.7.0-alpine
+FROM node:8.11.3-alpine
 
 RUN mkdir /qoodish-web
 WORKDIR /qoodish-web

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "author": "Yusuke Suzuki",
   "license": "MIT",
   "engines": {
-    "node": "10.7.0",
-    "yarn": "1.7.0"
+    "node": "8.11.3"
   },
   "scripts": {
     "build": "webpack --colors --progress --mode development",


### PR DESCRIPTION
node v10.7.0 だと `firebase serve` が動かないので v8.11.3 に修正しました。