### PR TITLE
Functions: set default region

### DIFF
--- a/app/functions/index.js
+++ b/app/functions/index.js
@@ -39,9 +39,9 @@ app.get(pageRoutes, async (req, res) => {
   }
 });
 
-exports.host = functions.region('asia-northeast1').https.onRequest(app);
+exports.host = functions.https.onRequest(app);
 
-exports.generateThumbnail = functions.region('asia-northeast1').storage.bucket(process.env.FIREBASE_IMAGE_BUCKET_NAME).object().onFinalize((object) => {
+exports.generateThumbnail = functions.storage.bucket(process.env.FIREBASE_IMAGE_BUCKET_NAME).object().onFinalize((object) => {
   const fileBucket = object.bucket;
   const filePath = object.name;
   const contentType = object.contentType;


### PR DESCRIPTION
firebase hosting から Tokyo リージョンに上げた functions にリダイレクトさせたいのに、なぜかいくらやっても US リージョンの functions にリダイレクトしようとして Error になってしまう (Error の前に謎の Google アカウント認証画面が表示される) ため、リージョン指定を断念しました。
function 名はリージョンごとに固有らしいので rename や旧 function の削除等も試したのですがだめでした。
https://firebase.google.com/docs/hosting/functions?hl=ja
