### PR TITLE
Use redirect as sign in flow on iOS

### DIFF
--- a/app/frontend/containers/Utils.js
+++ b/app/frontend/containers/Utils.js
@@ -3,6 +3,28 @@ import 'firebase/storage';
 import uuidv1 from 'uuid/v1';
 import 'blueimp-canvas-to-blob';
 
+export const detectDevice = () => {
+  return window.navigator.userAgent.toLowerCase();
+};
+
+export const useIOS = () => {
+  const userAgent = detectDevice();
+  if (userAgent.indexOf('iphone') != -1 || userAgent.indexOf('ipad') != -1) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+export const useAndroid = () => {
+  const userAgent = detectDevice();
+  if (userAgent.indexOf('android') != -1) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
 export const fetchCurrentPosition = (options = {}) => {
   return new Promise((resolve, reject) => {
     navigator.geolocation.getCurrentPosition(resolve, reject, options);

--- a/app/frontend/ui/Discover.jsx
+++ b/app/frontend/ui/Discover.jsx
@@ -71,9 +71,6 @@ const styles = {
   reviewCard: {
     margin: 3
   },
-  profileImage: {
-    width: 40
-  },
   cardContentLarge: {
     paddingTop: 0,
     paddingRight: 120
@@ -287,13 +284,7 @@ export default class Discover extends React.Component {
         <Card style={styles.reviewCard}>
           <CardHeader
             avatar={
-              <Avatar>
-                <img
-                  src={review.author.profile_image_url}
-                  alt={review.author.name}
-                  style={styles.profileImage}
-                />
-              </Avatar>
+              <Avatar src={review.author.profile_image_url} />
             }
             title={review.author.name}
             subheader={moment(review.created_at, 'YYYY-MM-DDThh:mm:ss.SSSZ')

--- a/app/frontend/ui/LoginButtons.jsx
+++ b/app/frontend/ui/LoginButtons.jsx
@@ -3,6 +3,7 @@ import firebase from 'firebase/app';
 import 'firebase/auth';
 import firebaseui from 'firebaseui';
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
+import { useIOS } from '../containers/Utils';
 
 class LoginButtons extends React.Component {
   componentWillMount() {
@@ -12,7 +13,7 @@ class LoginButtons extends React.Component {
           this.props.signIn(authResult, redirectUrl);
         }
       },
-      signInFlow: 'popup',
+      signInFlow: useIOS() ? 'redirect' : 'popup',
       signInSuccessUrl: process.env.ENDPOINT,
       signInOptions: [
         firebase.auth.GoogleAuthProvider.PROVIDER_ID,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-copy-to-clipboard": "^5.0.0",
     "react-dom": "^16.4.0",
     "react-facebook": "^5.0.3",
-    "react-firebaseui": "^3.0.4",
+    "react-firebaseui": "^3.0.6",
     "react-google-maps": "^9.4.5",
     "react-helmet": "^5.2.0",
     "react-redux": "^5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3578,9 +3578,9 @@ firebase@^5.2.0:
     "@firebase/polyfill" "0.3.3"
     "@firebase/storage" "0.2.3"
 
-firebaseui@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/firebaseui/-/firebaseui-3.2.0.tgz#950a04fd9ff18efd8f4169726380cb7da77c4409"
+firebaseui@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/firebaseui/-/firebaseui-3.3.0.tgz#59c360963f988c80f1dc60fe34598f57fb315d15"
   dependencies:
     dialog-polyfill "^0.4.7"
 
@@ -6394,11 +6394,11 @@ react-facebook@^5.0.3:
     prop-types "^15.6.1"
     react-spinner-children "^1.0.8"
 
-react-firebaseui@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-firebaseui/-/react-firebaseui-3.0.4.tgz#faeef2cee1aa681d832ffd9d28fdf69789b2abf2"
+react-firebaseui@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/react-firebaseui/-/react-firebaseui-3.0.6.tgz#8b5c83725464168394a9b43f732d1d35bfa2c575"
   dependencies:
-    firebaseui "^3.0.0"
+    firebaseui "^3.2.0"
 
 react-google-maps@^9.4.5:
   version "9.4.5"


### PR DESCRIPTION
* iOS 端末の場合は popup ではなく redirect でサインインするようにしました。これにより iOS PWA でのサインインができるようになるはず (なんか 2 回ログインボタン押さないといけないっぽい)。
* firebase-ui をアップグレードしました (サインイン時の挙動が若干改善されました)。
