### PR TITLE
Fix sign out flow

### DIFF
--- a/app/frontend/containers/NavBarContainer.js
+++ b/app/frontend/containers/NavBarContainer.js
@@ -49,18 +49,20 @@ const mapDispatchToProps = dispatch => {
 
     signOut: async () => {
       dispatch(requestStart());
+
+      if ('serviceWorker' in navigator && 'PushManager' in window) {
+        const messaging = firebase.messaging();
+        const registrationToken = await messaging.getToken();
+        if (registrationToken) {
+          const client = new ApiClient();
+          await client.deleteRegistrationToken(registrationToken);
+        }
+      }
+
       await firebase.auth().signOut();
       dispatch(push('/login'));
       dispatch(signOut());
       dispatch(requestFinish());
-
-      const client = new ApiClient();
-      const messaging = firebase.messaging();
-      const registrationToken = await messaging.getToken();
-      if (!registrationToken) {
-        return;
-      }
-      await client.deleteRegistrationToken(registrationToken);
     },
 
     readNotifications: async notifications => {


### PR DESCRIPTION
サインアウトする前に FCM の登録トークン削除リクエストを送信するように修正しました。
(サインアウトしたことで currentUser のトークンが取れなくなってしまったために、削除リクエストが実行できなくなっていました)。