### PR TITLE
Fix open map summary button

### DIFF
--- a/app/frontend/containers/ExpandMapSummaryButtonContainer.js
+++ b/app/frontend/containers/ExpandMapSummaryButtonContainer.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import ExpandMapSummaryButton from '../ui/ExpandMapSummaryButton';
+import switchSummary from '../actions/switchSummary';
+
+const mapStateToProps = state => {
+  return {
+  };
+};
+
+const mapDispatchToProps = dispatch => {
+  return {
+    handleShowTimelineClick: () => {
+      dispatch(switchSummary());
+    }
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExpandMapSummaryButton);

--- a/app/frontend/containers/NavBarContainer.js
+++ b/app/frontend/containers/NavBarContainer.js
@@ -77,12 +77,6 @@ const mapDispatchToProps = dispatch => {
       });
     },
 
-    handleNotificationClick: notification => {
-      dispatch(push(notification.click_action, {
-        previous: true
-      }));
-    },
-
     handleBackButtonClick: (previous) => {
       if (previous) {
         dispatch(goBack());

--- a/app/frontend/ui/ExpandMapSummaryButton.jsx
+++ b/app/frontend/ui/ExpandMapSummaryButton.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
+
+const styles = {
+  expandButtonContainer: {
+    width: '100%',
+    position: 'fixed',
+    bottom: 116,
+    textAlign: 'center',
+    zIndex: 1300
+  },
+  expandButton: {
+    boxShadow: '0px 1px 5px 0px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 3px 1px -2px rgba(0, 0, 0, 0.12)'
+  }
+};
+
+export default class ExpandMapSummaryButton extends React.Component {
+  render() {
+    return (
+      <div style={styles.expandButtonContainer}>
+        <Button
+          variant="fab"
+          style={styles.expandButton}
+          onClick={this.props.handleShowTimelineClick}
+          mini={true}
+          color="primary"
+        >
+          <ExpandLessIcon />
+        </Button>
+      </div>
+    );
+  }
+}

--- a/app/frontend/ui/MapBottomSeat.jsx
+++ b/app/frontend/ui/MapBottomSeat.jsx
@@ -7,8 +7,6 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Avatar from '@material-ui/core/Avatar';
-import Button from '@material-ui/core/Button';
-import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import FollowMapButtonContainer from '../containers/FollowMapButtonContainer';
 
 const styles = {
@@ -17,15 +15,6 @@ const styles = {
   },
   listItem: {
     padding: 0
-  },
-  expandButtonContainer: {
-    width: '100%',
-    position: 'fixed',
-    bottom: 116,
-    textAlign: 'center'
-  },
-  expandButton: {
-    boxShadow: '0px 1px 5px 0px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 3px 1px -2px rgba(0, 0, 0, 0.12)'
   },
   cardContent: {
     paddingTop: 24,
@@ -53,25 +42,8 @@ class MapBottomSeat extends React.Component {
         anchor="bottom"
         open={true}
       >
-        {this.renderExpandButton()}
         {this.renderSummaryCard()}
       </Drawer>
-    );
-  }
-
-  renderExpandButton() {
-    return (
-      <div style={styles.expandButtonContainer}>
-        <Button
-          variant="fab"
-          style={styles.expandButton}
-          onClick={this.props.handleShowTimelineClick}
-          mini={true}
-          color="primary"
-        >
-          <ExpandLessIcon />
-        </Button>
-      </div>
     );
   }
 

--- a/app/frontend/ui/MapDetail.jsx
+++ b/app/frontend/ui/MapDetail.jsx
@@ -9,6 +9,7 @@ import {
 } from 'react-google-maps';
 import { compose } from 'recompose';
 import MapSummaryContainer from '../containers/MapSummaryContainer';
+import ExpandMapSummaryButtonContainer from '../containers/ExpandMapSummaryButtonContainer';
 import MapBottomSeatContainer from '../containers/MapBottomSeatContainer';
 import DeleteMapDialogContainer from '../containers/DeleteMapDialogContainer';
 import InviteTargetDialogContainer from '../containers/InviteTargetDialogContainer';
@@ -242,6 +243,7 @@ export default class MapDetail extends React.Component {
         <div style={this.props.large ? styles.containerLarge : styles.containerSmall}>
           {this.renderGoogleMap()}
         </div>
+        <ExpandMapSummaryButtonContainer />
         <MapBottomSeatContainer currentMap={this.props.currentMap} />
         {this.renderMapSummaryDrawer()}
       </div>

--- a/app/frontend/ui/NavBar.jsx
+++ b/app/frontend/ui/NavBar.jsx
@@ -31,6 +31,7 @@ import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import MapToolbarContainer from '../containers/MapToolbarContainer';
 import I18n from '../containers/I18n';
+import ButtonBase from '@material-ui/core/ButtonBase';
 
 const styles = {
   title: {
@@ -493,12 +494,11 @@ class NavBar extends React.Component {
   renderNotifications(notifications) {
     return notifications.map(notification => (
       <MenuItem
-        onClick={() => {
-          this.handleRequestNotificationClose();
-          this.props.handleNotificationClick(notification);
-        }}
+        onClick={this.handleRequestNotificationClose}
         key={notification.id}
         style={styles.notificationMenuItem}
+        component={Link}
+        to={notification.click_action}
       >
         <Avatar src={notification.notifier.profile_image_url} />
         <ListItemText
@@ -511,7 +511,13 @@ class NavBar extends React.Component {
         />
         {notification.notifiable.thumbnail_url && (
           <ListItemSecondaryAction>
-            <Avatar src={notification.notifiable.thumbnail_url} style={styles.secondaryAvatar} />
+            <ButtonBase
+              component={Link}
+              to={notification.click_action}
+              onClick={this.handleRequestNotificationClose}
+            >
+              <Avatar src={notification.notifiable.thumbnail_url} style={styles.secondaryAvatar} />
+            </ButtonBase>
           </ListItemSecondaryAction>
         )}
       </MenuItem>


### PR DESCRIPTION
* iOS 端末 (のブラウザ全般) で、Map Summary を開くボタンがマップの下に隠れてしまっていた問題を修正しました。
* PC 版の Navbar 上の通知欄で、画像をクリックしても対象のリソースのページに遷移しない問題を修正しました。