### PR TITLE
Fix react-swipeable-views v0.12.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.3.1",
     "react-router-redux": "^5.0.0-alpha.9",
-    "react-swipeable-views": "^0.12.16",
+    "react-swipeable-views": "0.12.14",
     "recompose": "^0.27.1",
     "redux": "^4.0.0",
     "redux-localstorage": "^0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6502,14 +6502,14 @@ react-spinner-children@^1.0.8:
     prop-types "^15.6.0"
     spin.js "^2.3.2"
 
-react-swipeable-views-core@^0.12.16:
+react-swipeable-views-core@^0.12.14, react-swipeable-views-core@^0.12.16:
   version "0.12.16"
   resolved "https://registry.yarnpkg.com/react-swipeable-views-core/-/react-swipeable-views-core-0.12.16.tgz#f7ded6feb154ade2ad5529f11db0c5caab613061"
   dependencies:
     "@babel/runtime" "7.0.0-beta.42"
     warning "^4.0.1"
 
-react-swipeable-views-utils@^0.12.16:
+react-swipeable-views-utils@^0.12.14:
   version "0.12.16"
   resolved "https://registry.yarnpkg.com/react-swipeable-views-utils/-/react-swipeable-views-utils-0.12.16.tgz#f64f0ab0efaa8717ccd1471c8b7293728833c0b2"
   dependencies:
@@ -6520,15 +6520,15 @@ react-swipeable-views-utils@^0.12.16:
     react-event-listener "^0.6.0"
     react-swipeable-views-core "^0.12.16"
 
-react-swipeable-views@^0.12.16:
-  version "0.12.16"
-  resolved "https://registry.yarnpkg.com/react-swipeable-views/-/react-swipeable-views-0.12.16.tgz#b1be94acbfd60bb3df55571dfc452b231e80db3b"
+react-swipeable-views@0.12.14:
+  version "0.12.14"
+  resolved "https://registry.yarnpkg.com/react-swipeable-views/-/react-swipeable-views-0.12.14.tgz#71722be23491ef500c42e86bafb838d45a69ffe1"
   dependencies:
-    "@babel/runtime" "7.0.0-beta.42"
+    "@babel/runtime" "^7.0.0-beta.42"
     dom-helpers "^3.2.1"
     prop-types "^15.5.4"
-    react-swipeable-views-core "^0.12.16"
-    react-swipeable-views-utils "^0.12.16"
+    react-swipeable-views-core "^0.12.14"
+    react-swipeable-views-utils "^0.12.14"
     warning "^4.0.1"
 
 react-transition-group@^2.2.1:


### PR DESCRIPTION
最新バージョンでもやっぱり `animateHeight` の高さの計算が直っていなかったので戻す。