### PR TITLE
Fetch map reviews on page mounted

### DIFF
--- a/app/frontend/containers/MapDetailContainer.js
+++ b/app/frontend/containers/MapDetailContainer.js
@@ -11,6 +11,7 @@ import getMapBasePosition from '../actions/getMapBasePosition';
 import requestMapBase from '../actions/requestMapBase';
 import fetchSpots from '../actions/fetchSpots';
 import clearMapState from '../actions/clearMapState';
+import fetchMapReviews from '../actions/fetchMapReviews';
 
 const mapStateToProps = state => {
   return {
@@ -58,6 +59,15 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       if (response.ok) {
         let spots = await response.json();
         dispatch(fetchSpots(spots));
+      }
+    },
+
+    fetchMapReviews: async () => {
+      const client = new ApiClient();
+      let response = await client.fetchMapReviews(ownProps.match.params.mapId);
+      if (response.ok) {
+        let reviews = await response.json();
+        dispatch(fetchMapReviews(reviews));
       }
     },
 

--- a/app/frontend/containers/MapReviewsListContainer.js
+++ b/app/frontend/containers/MapReviewsListContainer.js
@@ -3,8 +3,6 @@ import MapReviewsList from '../ui/MapReviewsList';
 import requestMapCenter from '../actions/requestMapCenter';
 import openReviewDialog from '../actions/openReviewDialog';
 import selectSpot from '../actions/selectSpot';
-import fetchMapReviews from '../actions/fetchMapReviews';
-import ApiClient from './ApiClient';
 
 const mapStateToProps = state => {
   return {
@@ -12,17 +10,8 @@ const mapStateToProps = state => {
   };
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = (dispatch) => {
   return {
-    fetchMapReviews: async () => {
-      const client = new ApiClient();
-      let response = await client.fetchMapReviews(ownProps.mapId);
-      if (response.ok) {
-        let reviews = await response.json();
-        dispatch(fetchMapReviews(reviews));
-      }
-    },
-
     handleReviewClick: (review) => {
       dispatch(selectSpot(review.spot));
       dispatch(requestMapCenter(review.spot.lat, review.spot.lng));

--- a/app/frontend/containers/MapSummaryContainer.js
+++ b/app/frontend/containers/MapSummaryContainer.js
@@ -9,7 +9,7 @@ const mapStateToProps = state => {
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = (dispatch, ownProps) => {
   return {
   };
 };

--- a/app/frontend/ui/MapDetail.jsx
+++ b/app/frontend/ui/MapDetail.jsx
@@ -31,6 +31,7 @@ const styles = {
 export default class MapDetail extends React.PureComponent {
   async componentWillMount() {
     this.props.fetchSpots();
+    this.props.fetchMapReviews();
 
     if (!this.props.currentMap) {
       await this.props.fetchMap();

--- a/app/frontend/ui/MapReviewsList.jsx
+++ b/app/frontend/ui/MapReviewsList.jsx
@@ -20,10 +20,6 @@ const styles = {
 };
 
 export default class MapReviewsList extends React.PureComponent {
-  componentWillMount() {
-    this.props.fetchMapReviews(this.props.mapId);
-  }
-
   render() {
     return (
       <List disablePadding>


### PR DESCRIPTION
子コンポーネントをマウントしたタイミングではなく、親のマップ詳細画面をマウントしたタイミングでマップ下のレビュー一覧を取得するように修正しました。
※ モバイル画面で子コンポーネントがマウントされず、スポットカードを開いたときにコンテンツが表示されなくなっていました。