### PR TITLE
Remove animateHeight

### DIFF
--- a/app/frontend/ui/Maps.jsx
+++ b/app/frontend/ui/Maps.jsx
@@ -73,7 +73,6 @@ export default class Maps extends React.PureComponent {
       <div style={this.props.large ? styles.rootLarge : styles.rootSmall}>
         {this.renderHelmet()}
         <SwipeableViews
-          animateHeight
           index={this.props.tabValue}
           onChangeIndex={this.handleTabChange}
         >

--- a/app/frontend/ui/Profile.jsx
+++ b/app/frontend/ui/Profile.jsx
@@ -186,7 +186,6 @@ class Profile extends React.PureComponent {
         {this.props.currentUser.name && this.renderHelmet(this.props.currentUser)}
         {this.renderProfileCard(this.props.currentUser)}
         <SwipeableViews
-          animateHeight
           index={this.state.tabValue}
           onChangeIndex={this.handleChangeIndex}
         >


### PR DESCRIPTION
animateHeight を使っていると高さの計算がバグっているのかコンテンツが隠れてしまうという問題が起きていたので使わないようにしました。