### PR TITLE
Clean old bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ const serviceWorkerPlugins = [
 ];
 
 const plugins = [
-  new CleanWebpackPlugin(['./functions/hosting/bundle.js', './functions/hosting/index.html'], {}),
+  new CleanWebpackPlugin(['./functions/hosting/*.bundle.js', './functions/hosting/index.html'], {}),
   new HtmlWebpackPlugin({
     template: 'app/views/index.html',
     hash: true,


### PR DESCRIPTION
webpack 実行時に削除する古い bundle ファイルのパスが更新されていなかったので修正しました。