### PR TITLE
Set Cache-Ctrl of JS files

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,6 +12,17 @@
         "source": "**",
         "function": "host"
       }
+    ],
+    "headers": [
+      {
+        "source": "**/*.*.@(js)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "max-age=86400"
+          }
+        ]
+      }
     ]
   },
   "storage": {


### PR DESCRIPTION
firebase hosting で配信している JS ファイルについて、86400 秒キャッシュされるようにしました。