### PR TITLE
Extend cashing period

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -19,7 +19,7 @@
         "headers": [
           {
             "key": "Cache-Control",
-            "value": "max-age=86400"
+            "value": "max-age=2592000"
           }
         ]
       }


### PR DESCRIPTION
JS ファイルをキャッシュしておく期間を 1 日 → 30 日に延長しました。
ハッシュ値をつけているのでファイルが更新されれば再取得されます。