### PR TITLE
Hide map toolbar on desktop

### DIFF
--- a/app/frontend/containers/NavBarContainer.js
+++ b/app/frontend/containers/NavBarContainer.js
@@ -7,7 +7,8 @@ const mapStateToProps = state => {
   return {
     mapsTabActive: state.shared.mapsTabActive,
     previousLocation: state.shared.previousLocation,
-    isMapDetail: state.shared.isMapDetail
+    isMapDetail: state.shared.isMapDetail,
+    large: state.shared.large
   };
 };
 


### PR DESCRIPTION
デスクトップでマップ詳細画面を開いた際に Map Toolbar が二重に表示されてしまう問題を修正しました。