### PR TITLE
Hide add report button on personal maps

### DIFF
--- a/app/frontend/containers/SpotCardContainer.js
+++ b/app/frontend/containers/SpotCardContainer.js
@@ -18,7 +18,8 @@ const mapStateToProps = state => {
     open: state.spotCard.spotCardOpen,
     currentSpot: state.spotCard.currentSpot,
     large: state.shared.large,
-    spotReviews: state.mapSummary.spotReviews
+    spotReviews: state.mapSummary.spotReviews,
+    currentMap: state.mapDetail.currentMap,
   };
 };
 

--- a/app/frontend/reducers/appReducer.js
+++ b/app/frontend/reducers/appReducer.js
@@ -17,7 +17,8 @@ const reducer = (state = initialState, action) => {
     case SIGN_IN:
       return Object.assign({}, state, {
         currentUser: action.payload.user,
-        registrationToken: null
+        registrationToken: null,
+        linkedProviders: []
       });
     case SIGN_OUT:
       return Object.assign({}, state, {

--- a/app/frontend/ui/SpotCard.jsx
+++ b/app/frontend/ui/SpotCard.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import Card from '@material-ui/core/Card';
-import CardMedia from '@material-ui/core/CardMedia';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
 import DirectionsIcon from '@material-ui/icons/Directions';
@@ -149,9 +148,9 @@ const SpotCardHeader = (props) => {
       </ListItem>
     </List>
   );
-}
+};
 
-const SpotCardSmall = (props) => {
+const SpotCardSmall = props => {
   return (
     <div>
       <CardContent style={styles.cardContentSmall}>
@@ -164,19 +163,21 @@ const SpotCardSmall = (props) => {
           cellHeight={100}
           style={styles.gridList}
         >
-          <GridListTile
-            key="add-review"
-            onClick={() => props.handleCreateReviewClick(props.currentSpot)}
-          >
-            <img src={process.env.SUBSTITUTE_URL} />
-            <GridListTileBar
-              style={styles.createReviewTile}
-              title={
-                <AddIcon fontSize="large" />
-              }
-              subtitle={I18n.t('create new report')}
-            />
-          </GridListTile>
+          {props.currentMap.postable && props.currentMap.following && (
+            <GridListTile
+              key="add-review"
+              onClick={() => props.handleCreateReviewClick(props.currentSpot)}
+            >
+              <img src={process.env.SUBSTITUTE_URL} />
+              <GridListTileBar
+                style={styles.createReviewTile}
+                title={
+                  <AddIcon fontSize="large" />
+                }
+                subtitle={I18n.t('create new report')}
+              />
+            </GridListTile>
+          )}
           {props.spotReviews.map(review => (
             <GridListTile
               key={review.id}


### PR DESCRIPTION
スポットカード上のレポート投稿ボタンについて、パーソナルマップ等ユーザーが投稿できないマップの場合はボタンを表示しないよう修正しました。