### PR TITLE
Fix transition of Review dialog

### DIFF
--- a/src/frontend/components/Routes.js
+++ b/src/frontend/components/Routes.js
@@ -151,7 +151,6 @@ const Routes = () => {
 
     const unlisten = history.listen((location, action) => {
       setCurrentLocation(location);
-      dispatch(locationChange(location));
     });
 
     return () => {
@@ -167,6 +166,7 @@ const Routes = () => {
       if (initialRoute) {
         setInitialRoute(false);
       }
+      dispatch(locationChange(currentLocation));
     },
     [currentLocation]
   );

--- a/src/frontend/components/organisms/IssueDialog.js
+++ b/src/frontend/components/organisms/IssueDialog.js
@@ -33,7 +33,7 @@ const IssueDialog = () => {
     mapState
   );
 
-  const [value, setValue] = useState(value);
+  const [value, setValue] = useState(undefined);
 
   const handleRequestDialogClose = useCallback(() => {
     dispatch(closeIssueDialog());

--- a/src/frontend/components/organisms/ReviewDialog.js
+++ b/src/frontend/components/organisms/ReviewDialog.js
@@ -8,7 +8,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import Slide from '@material-ui/core/Slide';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
-import CloseIcon from '@material-ui/icons/Close';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 
@@ -36,7 +36,8 @@ const styles = {
 };
 
 const Transition = props => {
-  return <Slide direction="up" {...props} />;
+  const large = useMediaQuery('(min-width: 600px)');
+  return <Slide direction={large ? 'up' : 'left'} {...props} />;
 };
 
 const ReviewDialog = () => {
@@ -68,7 +69,7 @@ const ReviewDialog = () => {
         <AppBar style={styles.appbar} color="primary">
           <Toolbar style={styles.toolbar}>
             <IconButton color="inherit" onClick={handleRequestDialogClose}>
-              <CloseIcon />
+              <ArrowBackIcon />
             </IconButton>
             <Typography variant="h6" color="inherit" style={styles.flex}>
               {I18n.t('report')}


### PR DESCRIPTION
* モバイル時のレポートダイアログについて、画面右側からスライド表示するようにしました。
* レポートダイアログを閉じるボタンを矢印に変更しました。
* レポートダイアログの開いた際にページタイトルが更新されてしまう問題を修正しました。