### PR TITLE
Refactoring: Messaging

### DIFF
--- a/src/frontend/utils/initializeFirebaseApp.js
+++ b/src/frontend/utils/initializeFirebaseApp.js
@@ -1,6 +1,4 @@
 import getFirebase from './getFirebase';
-import getFirebaseMessaging from './getFirebaseMessaging';
-import I18n from './I18n';
 
 const initializeFirebaseApp = async () => {
   const firebase = await getFirebase();
@@ -16,48 +14,16 @@ const initializeFirebaseApp = async () => {
   firebase.initializeApp(config);
 
   if ('serviceWorker' in navigator) {
-    initializeServiceWorker(firebase);
+    initializeServiceWorker();
   }
 };
 
-const initializeServiceWorker = async firebase => {
+const initializeServiceWorker = async () => {
   const registration = await navigator.serviceWorker.register('/sw.js');
   console.log(
     'ServiceWorker registration successful with scope: ',
     registration.scope
   );
-  console.log(navigator.serviceWorker);
-
-  await getFirebaseMessaging();
-  const messaging = firebase.messaging();
-
-  messaging.onMessage(payload => {
-    console.log('Message received. ', payload);
-
-    registration.showNotification(
-      notificationTitle(payload.data),
-      notificationOptions(payload.data)
-    );
-  });
-};
-
-const notificationTitle = data => {
-  return 'Qoodish';
-};
-
-const notificationOptions = data => {
-  return {
-    body: notificationBody(data),
-    icon: data.icon,
-    click_action: data.click_action,
-    color: '#ffc107',
-    badge: data.badge
-  };
-};
-
-const notificationBody = data => {
-  const message = I18n.t(`${data.key} ${data.notifiable_type}`);
-  return `${data.notifier_name} ${message}`;
 };
 
 export default initializeFirebaseApp;


### PR DESCRIPTION
* プッシュ通知の処理は Service Worker 側で集中して行うようにしました (クライアント側での処理を廃止しました)。
* FCM の `setBackgroundMessageHandler ` ではなく、Service Worker で `push` イベントを拾ってプッシュ通知の処理を行うようにしました。