### PR TITLE
Use dotenv on cloud functions

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,6 +15,7 @@
     "@google-cloud/storage": "^2.5.0",
     "@slack/client": "^5.0.1",
     "child-process-promise": "^2.2.1",
+    "dotenv": "^8.0.0",
     "ejs": "^2.6.1",
     "express": "^4.16.4",
     "firebase-admin": "^7.3.0",

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -812,6 +812,11 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"
+  integrity sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==
+
 duplexify@^3.5.0, duplexify@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.0.tgz#592903f5d80b38d037220541264d69a198fb3410"


### PR DESCRIPTION
cloud functions の依存ライブラリとして dotenv を使用していたところを誤って削除してしまっていたのでもとに戻しました。