### PR TITLE
Add googlebot to bot list

### DIFF
--- a/functions/server/utils/isBot.js
+++ b/functions/server/utils/isBot.js
@@ -13,7 +13,8 @@ const BOTS = [
   'telegrambot',
   'applebot',
   'pingdom',
-  'tumblr '
+  'tumblr ',
+  'googlebot'
 ];
 
 const IS_BOT_REGEXP = new RegExp('^.*(' + BOTS.join('|') + ').*$');


### PR DESCRIPTION
googlebot は JS を実行してくれるものの、react-helmet (JS) による head タグ内の変更は検知できていないようで、検索結果に meta タグおよび title タグを正しく反映できていませんでした。
そのため、googlebot に対しても他の bot と同様に、サーバサイドで生成した metadata.html を返すようにしました。