### PR TITLE
Tablet mobile UI

### DIFF
--- a/src/frontend/components/molecules/CreateReviewTile.js
+++ b/src/frontend/components/molecules/CreateReviewTile.js
@@ -1,0 +1,46 @@
+import React, { useCallback } from 'react';
+import { useDispatch } from 'redux-react-hook';
+
+import AddIcon from '@material-ui/icons/Add';
+import GridListTileBar from '@material-ui/core/GridListTileBar';
+
+import openPlaceSelectDialog from '../../actions/openPlaceSelectDialog';
+import selectPlaceForReview from '../../actions/selectPlaceForReview';
+import I18n from '../../utils/I18n';
+
+const styles = {
+  createReviewTile: {
+    height: '100%',
+    textAlign: 'center'
+  }
+};
+
+const CreateReviewTile = props => {
+  const dispatch = useDispatch();
+  const { currentSpot } = props;
+
+  const handleCreateReviewClick = useCallback(() => {
+    if (currentSpot) {
+      dispatch(
+        selectPlaceForReview({
+          description: currentSpot.name,
+          placeId: currentSpot.place_id
+        })
+      );
+    } else {
+      dispatch(openPlaceSelectDialog());
+    }
+  });
+
+  return (
+    <div key="add-review" onClick={handleCreateReviewClick}>
+      <GridListTileBar
+        style={styles.createReviewTile}
+        title={<AddIcon fontSize="large" />}
+        subtitle={I18n.t('create new report')}
+      />
+    </div>
+  );
+};
+
+export default React.memo(CreateReviewTile);

--- a/src/frontend/components/molecules/LocationButton.js
+++ b/src/frontend/components/molecules/LocationButton.js
@@ -2,12 +2,15 @@ import React, { useCallback } from 'react';
 import { useDispatch } from 'redux-react-hook';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
+import Tooltip from '@material-ui/core/Tooltip';
 import Fab from '@material-ui/core/Fab';
 import MyLocationIcon from '@material-ui/icons/MyLocation';
 
 import fetchCurrentPosition from '../../utils/fetchCurrentPosition';
 import getCurrentPosition from '../../actions/getCurrentPosition';
 import requestCurrentPosition from '../../actions/requestCurrentPosition';
+
+import I18n from '../../utils/I18n';
 
 const styles = {
   buttonLarge: {
@@ -39,12 +42,14 @@ const LocationButton = () => {
   });
 
   return (
-    <Fab
-      style={large ? styles.buttonLarge : styles.buttonSmall}
-      onClick={handleButtonClick}
-    >
-      <MyLocationIcon />
-    </Fab>
+    <Tooltip title={I18n.t('button current location')}>
+      <Fab
+        style={large ? styles.buttonLarge : styles.buttonSmall}
+        onClick={handleButtonClick}
+      >
+        <MyLocationIcon />
+      </Fab>
+    </Tooltip>
   );
 };
 

--- a/src/frontend/components/molecules/MapShareMenu.js
+++ b/src/frontend/components/molecules/MapShareMenu.js
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { useDispatch, useMappedState } from 'redux-react-hook';
 
+import Tooltip from '@material-ui/core/Tooltip';
 import ShareIcon from '@material-ui/icons/Share';
 import IconButton from '@material-ui/core/IconButton';
 import Menu from '@material-ui/core/Menu';
@@ -44,17 +45,19 @@ const MapShareMenu = () => {
 
   return (
     <div>
-      <IconButton
-        aria-label="More share"
-        aria-owns={menuOpen ? 'share-menu' : null}
-        aria-haspopup="true"
-        onClick={e => {
-          setAnchorEl(e.currentTarget);
-          setMenuOpen(true);
-        }}
-      >
-        <ShareIcon style={styles.mapMenuIcon} />
-      </IconButton>
+      <Tooltip title={I18n.t('button share')}>
+        <IconButton
+          aria-label="More share"
+          aria-owns={menuOpen ? 'share-menu' : null}
+          aria-haspopup="true"
+          onClick={e => {
+            setAnchorEl(e.currentTarget);
+            setMenuOpen(true);
+          }}
+        >
+          <ShareIcon style={styles.mapMenuIcon} />
+        </IconButton>
+      </Tooltip>
 
       <Menu
         id="share-menu"

--- a/src/frontend/components/molecules/MapToolbar.js
+++ b/src/frontend/components/molecules/MapToolbar.js
@@ -53,7 +53,8 @@ const isInvitable = map => {
 
 const MapToolbar = () => {
   const dispatch = useDispatch();
-  const large = useMediaQuery('(min-width: 600px)');
+  const lgUp = useMediaQuery('(min-width: 1280px)');
+  const smUp = useMediaQuery('(min-width: 600px)');
 
   const mapState = useCallback(
     state => ({
@@ -69,7 +70,7 @@ const MapToolbar = () => {
   );
 
   const handleBackButtonClick = useCallback(() => {
-    if (large) {
+    if (lgUp) {
       if (previousLocation && !previousLocation.state) {
         history.goBack();
       } else {
@@ -93,11 +94,11 @@ const MapToolbar = () => {
   });
 
   return (
-    <Toolbar style={large ? styles.toolbarLarge : styles.toolbarSmall}>
+    <Toolbar style={lgUp ? styles.toolbarLarge : styles.toolbarSmall}>
       <IconButton
         color="inherit"
         onClick={handleBackButtonClick}
-        style={large ? styles.backButtonLarge : styles.backButtonSmall}
+        style={lgUp ? styles.backButtonLarge : styles.backButtonSmall}
       >
         <ArrowBackIcon />
       </IconButton>
@@ -112,7 +113,7 @@ const MapToolbar = () => {
       )}
       {map && (
         <Typography
-          variant={large ? 'h6' : 'subtitle1'}
+          variant={smUp ? 'h6' : 'subtitle1'}
           color="inherit"
           noWrap
           style={styles.mapName}

--- a/src/frontend/components/molecules/MapToolbar.js
+++ b/src/frontend/components/molecules/MapToolbar.js
@@ -10,6 +10,7 @@ import LockIcon from '@material-ui/icons/Lock';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import PersonAddIcon from '@material-ui/icons/PersonAdd';
 import Tooltip from '@material-ui/core/Tooltip';
+
 import I18n from '../../utils/I18n';
 import switchMap from '../../actions/switchMap';
 
@@ -123,9 +124,11 @@ const MapToolbar = () => {
       )}
       <div style={styles.toolbarActions}>
         {isInvitable(map) && (
-          <IconButton color="inherit" onClick={handleInviteButtonClick}>
-            <PersonAddIcon />
-          </IconButton>
+          <Tooltip title={I18n.t('button invite')}>
+            <IconButton color="inherit" onClick={handleInviteButtonClick}>
+              <PersonAddIcon />
+            </IconButton>
+          </Tooltip>
         )}
         <MapShareMenu />
         {!map ? (

--- a/src/frontend/components/molecules/ReactionsCount.js
+++ b/src/frontend/components/molecules/ReactionsCount.js
@@ -8,20 +8,29 @@ import openLikesDialog from '../../actions/openLikesDialog';
 import { useDispatch } from 'redux-react-hook';
 
 const styles = {
-  reactionsCount: {
+  disablePadding: {
     paddingBottom: 0,
     display: 'flex'
   },
+  reactionsCount: {
+    paddingBottom: 16,
+    display: 'flex'
+  },
   comment: {
-    marginRight: 16
+    marginRight: 16,
+    height: '0.875rem'
   },
   like: {
-    cursor: 'pointer'
+    cursor: 'pointer',
+    height: '0.875rem'
+  },
+  empty: {
+    height: '0.875rem'
   }
 };
 
 const ReactionsCount = props => {
-  const { review } = props;
+  const { review, disablePadding } = props;
   const dispatch = useDispatch();
 
   const handleLikesClick = useCallback(async () => {
@@ -35,32 +44,40 @@ const ReactionsCount = props => {
     });
   });
 
-  if (review.comments.length < 1 && review.likes_count < 1) {
-    return null;
-  }
-
   return (
-    <CardContent style={styles.reactionsCount}>
-      {review.comments.length > 0 && (
+    <CardContent
+      style={disablePadding ? styles.disablePadding : styles.reactionsCount}
+    >
+      {!review || (review.comments.length < 1 && review.likes_count < 1) ? (
         <Typography
           variant="subtitle2"
           color="textSecondary"
           gutterBottom
-          style={styles.comment}
+          style={styles.empty}
         >
-          {`${review.comments.length} ${I18n.t('comment count')}`}
+          {``}
         </Typography>
-      )}
-      {review.likes_count > 0 && (
-        <Typography
-          variant="subtitle2"
-          color="textSecondary"
-          gutterBottom
-          style={styles.like}
-          onClick={handleLikesClick}
-        >
-          {`${review.likes_count} ${I18n.t('likes count')}`}
-        </Typography>
+      ) : (
+        <React.Fragment>
+          <Typography
+            variant="subtitle2"
+            color="textSecondary"
+            gutterBottom
+            style={styles.comment}
+          >
+            {`${review.comments.length} ${I18n.t('comment count')}`}
+          </Typography>
+
+          <Typography
+            variant="subtitle2"
+            color="textSecondary"
+            gutterBottom
+            style={styles.like}
+            onClick={handleLikesClick}
+          >
+            {`${review.likes_count} ${I18n.t('likes count')}`}
+          </Typography>
+        </React.Fragment>
       )}
     </CardContent>
   );

--- a/src/frontend/components/molecules/ReviewCard.js
+++ b/src/frontend/components/molecules/ReviewCard.js
@@ -156,7 +156,7 @@ const ReviewCard = props => {
       <ReviewCardHeader {...props} />
       <ReviewCardContent {...props} />
       {props.currentReview.image ? <ReviewCardMedia {...props} /> : <Divider />}
-      <ReactionsCount review={props.currentReview} />
+      <ReactionsCount review={props.currentReview} disablePadding />
       {props.currentReview.comments.length > 0 && (
         <ReviewComments comments={props.currentReview.comments} />
       )}

--- a/src/frontend/components/molecules/SharedLikeActions.js
+++ b/src/frontend/components/molecules/SharedLikeActions.js
@@ -1,23 +1,34 @@
 import React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder';
 
+import I18n from '../../utils/I18n';
+
 const SharedLikeActions = props => {
   return (
-    <IconButton
-      onClick={() => {
+    <Tooltip
+      title={
         props.target && props.target.liked
-          ? props.handleUnlikeButtonClick()
-          : props.handleLikeButtonClick();
-      }}
+          ? I18n.t('button unlike')
+          : I18n.t('button like')
+      }
     >
-      {props.target && props.target.liked ? (
-        <FavoriteIcon color="error" />
-      ) : (
-        <FavoriteBorderIcon style={props.style} />
-      )}
-    </IconButton>
+      <IconButton
+        onClick={() => {
+          props.target && props.target.liked
+            ? props.handleUnlikeButtonClick()
+            : props.handleLikeButtonClick();
+        }}
+      >
+        {props.target && props.target.liked ? (
+          <FavoriteIcon color="error" />
+        ) : (
+          <FavoriteBorderIcon style={props.style} />
+        )}
+      </IconButton>
+    </Tooltip>
   );
 };
 

--- a/src/frontend/components/organisms/CreateActions.js
+++ b/src/frontend/components/organisms/CreateActions.js
@@ -20,6 +20,7 @@ import closeCreateActions from '../../actions/closeCreateActions';
 const ActionsList = () => {
   const mapState = useCallback(state => state.spotDetail.currentSpot, []);
   const spot = useMappedState(mapState);
+
   const dispatch = useDispatch();
 
   const handleCreateReviewButtonClick = useCallback(() => {

--- a/src/frontend/components/organisms/GMap.js
+++ b/src/frontend/components/organisms/GMap.js
@@ -37,6 +37,9 @@ const styles = {
     left: 380,
     marginTop: 64
   },
+  mapWrapperMd: {
+    height: '100%'
+  },
   mapWrapperSmall: {
     height: '100%'
   },
@@ -55,7 +58,9 @@ const styles = {
 const GMap = () => {
   const theme = useTheme();
   const dispatch = useDispatch();
-  const large = useMediaQuery('(min-width: 600px)');
+  const smUp = useMediaQuery('(min-width: 600px)');
+  const mdUp = useMediaQuery('(min-width: 960px)');
+  const lgUp = useMediaQuery('(min-width: 1280px)');
 
   const [gMap, setGMap] = useState(undefined);
   const [googleMapsApi, setGoogleMapsApi] = useState(undefined);
@@ -128,7 +133,7 @@ const GMap = () => {
       },
       streetViewControl: true,
       streetViewControlOptions: {
-        position: large
+        position: mdUp
           ? googleMapsApi.ControlPosition.RIGHT_TOP
           : googleMapsApi.ControlPosition.LEFT_TOP
       },
@@ -194,7 +199,7 @@ const GMap = () => {
   const onSpotMarkerClick = useCallback(async (e, spot) => {
     dispatch(selectSpot(spot));
 
-    if (large) {
+    if (mdUp) {
       setAnchorEl(e.currentTarget);
       setWindowOpen(true);
     } else {
@@ -203,8 +208,16 @@ const GMap = () => {
   });
 
   return (
-    <div style={large ? styles.mapWrapperLarge : styles.mapWrapperSmall}>
-      <div id="map" style={large ? styles.mapLarge : styles.mapSmall} />
+    <div
+      style={
+        lgUp
+          ? styles.mapWrapperLarge
+          : smUp
+          ? styles.mapWrapperMd
+          : styles.mapWrapperSmall
+      }
+    >
+      <div id="map" style={lgUp ? styles.mapLarge : styles.mapSmall} />
       <Popover
         id="spot-info-window"
         anchorEl={anchorEl}
@@ -239,7 +252,7 @@ const GMap = () => {
                 <SpotMarker
                   spot={spot}
                   onClick={e => onSpotMarkerClick(e, spot)}
-                  large={large}
+                  large={mdUp}
                   aria-label="Info window"
                   aria-owns={windowOpen ? 'spot-info-window' : null}
                   aria-haspopup="true"
@@ -261,7 +274,7 @@ const GMap = () => {
           gMap={gMap}
         >
           <React.Suspense fallback={null}>
-            <CurrentPositionIcon currentUser={currentUser} large={large} />
+            <CurrentPositionIcon currentUser={currentUser} large={mdUp} />
           </React.Suspense>
         </OverlayView>
       )}

--- a/src/frontend/components/organisms/MapSpotDrawer.js
+++ b/src/frontend/components/organisms/MapSpotDrawer.js
@@ -13,16 +13,14 @@ import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import IconButton from '@material-ui/core/IconButton';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import DragHandleIcon from '@material-ui/icons/DragHandle';
-import AddIcon from '@material-ui/icons/Add';
 import GridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';
 
 import openSpotCard from '../../actions/openSpotCard';
 import closeSpotCard from '../../actions/closeSpotCard';
-import selectPlaceForReview from '../../actions/selectPlaceForReview';
-import I18n from '../../utils/I18n';
 import Link from '../molecules/Link';
+import CreateReviewTile from '../molecules/CreateReviewTile';
 
 const styles = {
   drawerPaperLarge: {
@@ -72,10 +70,6 @@ const styles = {
     height: 30,
     marginLeft: 8,
     marginRight: 8
-  },
-  createReviewTile: {
-    height: '100%',
-    textAlign: 'center'
   },
   tileBar: {
     height: 50
@@ -143,14 +137,6 @@ const SpotCardContent = () => {
   );
   const { currentSpot, spotReviews, currentMap } = useMappedState(mapState);
 
-  const handleCreateReviewClick = useCallback(() => {
-    let place = {
-      description: currentSpot.name,
-      placeId: currentSpot.place_id
-    };
-    dispatch(selectPlaceForReview(place));
-  });
-
   return (
     <div>
       <CardContent style={styles.cardContentSmall}>
@@ -164,13 +150,8 @@ const SpotCardContent = () => {
           style={styles.gridList}
         >
           {currentMap.postable && (
-            <GridListTile key="add-review" onClick={handleCreateReviewClick}>
-              <img src={process.env.SUBSTITUTE_URL} />
-              <GridListTileBar
-                style={styles.createReviewTile}
-                title={<AddIcon fontSize="large" />}
-                subtitle={I18n.t('create new report')}
-              />
+            <GridListTile key="add-review">
+              <CreateReviewTile currentSpot={currentSpot} />
             </GridListTile>
           )}
           {spotReviews.map(review => (

--- a/src/frontend/components/organisms/MapSpotDrawer.js
+++ b/src/frontend/components/organisms/MapSpotDrawer.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useMappedState } from 'redux-react-hook';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
@@ -89,7 +90,16 @@ const SpotCardHeader = props => {
 
   return (
     <List disablePadding>
-      <ListItem disableGutters style={styles.listItem}>
+      <ListItem
+        button
+        disableGutters
+        style={styles.listItem}
+        component={Link}
+        to={{
+          pathname: currentSpot ? `/spots/${currentSpot.place_id}` : '',
+          state: { modal: true, spot: currentSpot }
+        }}
+      >
         <ListItemText
           disableTypography
           primary={
@@ -121,6 +131,7 @@ const SpotCardHeader = props => {
 };
 
 const SpotCardContent = () => {
+  const smUp = useMediaQuery('(min-width: 600px)');
   const dispatch = useDispatch();
   const mapState = useCallback(
     state => ({
@@ -147,7 +158,11 @@ const SpotCardContent = () => {
           <DragHandleIcon color="disabled" />
         </div>
         <SpotCardHeader currentSpot={currentSpot} />
-        <GridList cols={2.5} cellHeight={100} style={styles.gridList}>
+        <GridList
+          cols={smUp ? 4.5 : 2.5}
+          cellHeight={100}
+          style={styles.gridList}
+        >
           {currentMap.postable && (
             <GridListTile key="add-review" onClick={handleCreateReviewClick}>
               <img src={process.env.SUBSTITUTE_URL} />
@@ -226,14 +241,11 @@ const MapSpotDrawer = () => {
     dispatch(closeSpotCard());
   });
 
-  useEffect(
-    () => {
-      if (spotReviews.length < 1) {
-        handleClose();
-      }
-    },
-    [spotReviews]
-  );
+  useEffect(() => {
+    if (spotReviews.length < 1) {
+      handleClose();
+    }
+  }, [spotReviews]);
 
   const dialogOpen = reviewDialogOpen || spotDialogOpen || mapSummaryOpen;
 

--- a/src/frontend/components/organisms/MapSummary.js
+++ b/src/frontend/components/organisms/MapSummary.js
@@ -78,14 +78,14 @@ const styles = {
 };
 
 const MapBottomNav = React.memo(() => {
-  const large = useMediaQuery('(min-width: 600px)');
+  const smUp = useMediaQuery('(min-width: 600px)');
   const currentMap = useMappedState(
     useCallback(state => state.mapSummary.currentMap, [])
   );
 
   return (
     <Paper style={styles.bottomNav} square elevation={1}>
-      <Toolbar style={large ? styles.toolbarLarge : styles.toolbarSmall}>
+      <Toolbar style={smUp ? styles.toolbarLarge : styles.toolbarSmall}>
         <div style={styles.followMapButton}>
           <FollowMapButton currentMap={currentMap} />
         </div>
@@ -95,26 +95,27 @@ const MapBottomNav = React.memo(() => {
 });
 
 const MapTabs = React.memo(props => {
-  const large = useMediaQuery('(min-width: 600px)');
+  const lgUp = useMediaQuery('(min-width: 1280px)');
+  const smUp = useMediaQuery('(min-width: 600px)');
 
   return (
     <Tabs
       value={props.tabValue}
       onChange={props.handleTabChange}
-      style={large ? styles.tabsLarge : styles.tabsSmall}
-      variant={large ? 'fullWidth' : 'standard'}
-      indicatorColor={large ? 'primary' : 'secondary'}
-      textColor={large ? 'primary' : 'inherit'}
+      style={smUp ? styles.tabsLarge : styles.tabsSmall}
+      variant={lgUp ? 'fullWidth' : 'standard'}
+      indicatorColor={lgUp ? 'primary' : 'secondary'}
+      textColor={lgUp ? 'primary' : 'inherit'}
     >
       <Tab
-        icon={large ? <HomeIcon style={styles.tabIcon} /> : null}
-        label={large ? null : I18n.t('basic info')}
-        style={large ? styles.tabLarge : styles.tabSmall}
+        icon={lgUp ? <HomeIcon style={styles.tabIcon} /> : null}
+        label={lgUp ? null : I18n.t('basic info')}
+        style={smUp ? styles.tabLarge : styles.tabSmall}
       />
       <Tab
-        icon={large ? <TimelineIcon style={styles.tabIcon} /> : null}
-        label={large ? null : I18n.t('timeline')}
-        style={large ? styles.tabLarge : styles.tabSmall}
+        icon={lgUp ? <TimelineIcon style={styles.tabIcon} /> : null}
+        label={lgUp ? null : I18n.t('timeline')}
+        style={smUp ? styles.tabLarge : styles.tabSmall}
       />
     </Tabs>
   );
@@ -122,15 +123,16 @@ const MapTabs = React.memo(props => {
 
 const MapSummary = () => {
   const [tabValue, setTabValue] = useState(0);
-  const large = useMediaQuery('(min-width: 600px)');
+  const lgUp = useMediaQuery('(min-width: 1280px)');
+  const smUp = useMediaQuery('(min-width: 600px)');
 
   const handleTabChange = useCallback((e, value) => {
     setTabValue(value);
   });
 
   return (
-    <div style={large ? styles.containerLarge : styles.containerSmall}>
-      {!large && (
+    <div style={lgUp ? styles.containerLarge : styles.containerSmall}>
+      {lgUp ? null : (
         <AppBar position="absolute">
           <MapToolbar />
           <Toolbar>
@@ -138,11 +140,11 @@ const MapSummary = () => {
           </Toolbar>
         </AppBar>
       )}
-      <div style={large ? styles.tabContentsLarge : styles.tabContentsSmall}>
+      <div style={smUp ? styles.tabContentsLarge : styles.tabContentsSmall}>
         {tabValue === 0 && <MapSummaryCard />}
         {tabValue === 1 && <MapReviewsList />}
       </div>
-      {large && (
+      {smUp && (
         <Paper style={styles.toolbarContainerLarge} square elevation={0}>
           <Toolbar disableGutters>
             <MapTabs tabValue={tabValue} handleTabChange={handleTabChange} />

--- a/src/frontend/components/organisms/MapSummary.js
+++ b/src/frontend/components/organisms/MapSummary.js
@@ -52,8 +52,7 @@ const styles = {
     height: 64,
     minHeight: 64,
     width: '20%',
-    minWidth: 'auto',
-    paddingTop: 0
+    minWidth: 'auto'
   },
   tabSmall: {
     height: 56

--- a/src/frontend/components/organisms/RecentReviews.js
+++ b/src/frontend/components/organisms/RecentReviews.js
@@ -3,6 +3,7 @@ import { useMappedState, useDispatch } from 'redux-react-hook';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import Link from '../molecules/Link';
 
+import CardMedia from '@material-ui/core/CardMedia';
 import GridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';
 import Card from '@material-ui/core/Card';
@@ -12,7 +13,6 @@ import Typography from '@material-ui/core/Typography';
 import Avatar from '@material-ui/core/Avatar';
 import PersonIcon from '@material-ui/icons/Person';
 import Chip from '@material-ui/core/Chip';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import NoContents from '../molecules/NoContents';
 import moment from 'moment';
 
@@ -20,12 +20,10 @@ import I18n from '../../utils/I18n';
 import fetchRecentReviews from '../../actions/fetchRecentReviews';
 import openToast from '../../actions/openToast';
 import { ReviewsApi } from 'qoodish_api';
+import ReactionsCount from '../molecules/ReactionsCount';
 
 const styles = {
-  gridListLarge: {
-    width: '100%'
-  },
-  gridListSmall: {
+  gridList: {
     flexWrap: 'nowrap',
     transform: 'translateZ(0)',
     width: '100%'
@@ -36,14 +34,6 @@ const styles = {
   },
   reviewCard: {
     margin: 3
-  },
-  cardContentLarge: {
-    paddingTop: 0,
-    paddingRight: 120
-  },
-  cardContentSmall: {
-    paddingTop: 0,
-    paddingRight: 112
   },
   reviewImage: {
     width: '100%'
@@ -84,6 +74,20 @@ const styles = {
   skeltonAvatar: {
     width: 40,
     height: 40
+  },
+  cardMedia: {
+    marginBottom: -5
+  },
+  cardContent: {
+    paddingBottom: 0
+  },
+  reviewImage: {
+    width: '100%',
+    height: 180,
+    objectFit: 'cover'
+  },
+  author: {
+    width: '90%'
   }
 };
 
@@ -140,10 +144,10 @@ const RecentReviews = () => {
   } else {
     return (
       <GridList
-        cols={large ? 2 : 1.2}
-        style={large ? styles.gridListLarge : styles.gridListSmall}
+        cols={large ? 2.5 : 1.2}
+        style={styles.gridList}
         spacing={large ? 20 : 10}
-        cellHeight={240}
+        cellHeight={475}
       >
         {loading
           ? Array.from(new Array(8)).map((v, i) => (
@@ -158,11 +162,10 @@ const RecentReviews = () => {
                     title={<Chip style={styles.skeltonTextSecondary} />}
                     subheader={<Chip style={styles.skeltonTextSecondary} />}
                   />
-                  <CardContent
-                    style={
-                      large ? styles.cardContentLarge : styles.cardContentSmall
-                    }
-                  >
+                  <CardMedia style={styles.cardMedia}>
+                    <div style={styles.reviewImage} />
+                  </CardMedia>
+                  <CardContent style={styles.cardContent}>
                     <Typography
                       variant="subtitle1"
                       color="primary"
@@ -179,6 +182,7 @@ const RecentReviews = () => {
                       <Chip style={styles.skeltonTextComment} />
                     </Typography>
                   </CardContent>
+                  <ReactionsCount />
                 </Card>
               </GridListTile>
             ))
@@ -200,7 +204,16 @@ const RecentReviews = () => {
                         alt={review.author.name}
                       />
                     }
-                    title={review.author.name}
+                    title={
+                      <Typography
+                        variant="subtitle2"
+                        color="textPrimary"
+                        noWrap
+                        style={styles.author}
+                      >
+                        {review.author.name}
+                      </Typography>
+                    }
                     subheader={moment(
                       review.created_at,
                       'YYYY-MM-DDThh:mm:ss.SSSZ'
@@ -208,11 +221,18 @@ const RecentReviews = () => {
                       .locale(window.currentLocale)
                       .fromNow()}
                   />
-                  <CardContent
-                    style={
-                      large ? styles.cardContentLarge : styles.cardContentSmall
-                    }
-                  >
+                  <CardMedia style={styles.cardMedia}>
+                    <img
+                      src={
+                        review.image
+                          ? review.image.url
+                          : process.env.SUBSTITUTE_URL
+                      }
+                      alt={review.image && review.spot.name}
+                      style={styles.reviewImage}
+                    />
+                  </CardMedia>
+                  <CardContent style={styles.cardContent}>
                     <Typography
                       variant="subtitle1"
                       color="primary"
@@ -228,20 +248,8 @@ const RecentReviews = () => {
                       {review.comment}
                     </Typography>
                   </CardContent>
+                  <ReactionsCount review={review} />
                 </Card>
-                {review.image && (
-                  <ListItemSecondaryAction>
-                    <Avatar
-                      src={review.image.thumbnail_url}
-                      alt={review.spot.name}
-                      style={
-                        large
-                          ? styles.secondaryAvatarLarge
-                          : styles.secondaryAvatarSmall
-                      }
-                    />
-                  </ListItemSecondaryAction>
-                )}
               </GridListTile>
             ))}
       </GridList>

--- a/src/frontend/components/organisms/ReviewDialog.js
+++ b/src/frontend/components/organisms/ReviewDialog.js
@@ -43,6 +43,13 @@ const ReviewDialog = () => {
   );
   const { dialogOpen, currentReview, history } = useMappedState(mapState);
 
+  if (dialogOpen && currentReview) {
+    gtag('config', process.env.GA_TRACKING_ID, {
+      page_path: `/maps/${currentReview.map.id}/reports/${currentReview.id}`,
+      page_title: `${currentReview.spot.name} - ${currentReview.map.name} | Qoodish`
+    });
+  }
+
   const handleRequestDialogClose = useCallback(() => {
     history.goBack();
   });

--- a/src/frontend/components/organisms/ReviewTiles.js
+++ b/src/frontend/components/organisms/ReviewTiles.js
@@ -60,6 +60,7 @@ const ReviewTiles = props => {
                 pathname: `/maps/${review.map.id}/reports/${review.id}`,
                 state: { modal: true, review: review }
               }}
+              title={review.spot.name}
             >
               {review.image ? (
                 <img src={review.image.thumbnail_url} alt={review.spot.name} />

--- a/src/frontend/components/organisms/SpotDialog.js
+++ b/src/frontend/components/organisms/SpotDialog.js
@@ -38,6 +38,13 @@ const SpotDialog = () => {
   );
   const { dialogOpen, currentSpot, history } = useMappedState(mapState);
 
+  if (dialogOpen && currentSpot) {
+    gtag('config', process.env.GA_TRACKING_ID, {
+      page_path: `/spots/${currentSpot.place_id}`,
+      page_title: `${currentSpot.name} | Qoodish`
+    });
+  }
+
   const handleRequestDialogClose = useCallback(() => {
     history.goBack();
   });

--- a/src/frontend/components/organisms/SpotHorizontalList.js
+++ b/src/frontend/components/organisms/SpotHorizontalList.js
@@ -5,7 +5,8 @@ import {
   GridListTile,
   GridListTileBar,
   Typography,
-  Avatar
+  Avatar,
+  useMediaQuery
 } from '@material-ui/core';
 import selectSpot from '../../actions/selectSpot';
 import openSpotCard from '../../actions/openSpotCard';
@@ -14,7 +15,7 @@ import I18n from '../../utils/I18n';
 
 const styles = {
   root: {
-    position: 'absolute',
+    position: 'fixed',
     bottom: 0,
     width: '100%',
     height: 124,
@@ -65,6 +66,7 @@ const Reviewers = props => {
 
 const SpotHorizontalList = () => {
   const dispatch = useDispatch();
+  const smUp = useMediaQuery('(min-width: 600px)');
 
   const mapState = useCallback(
     state => ({
@@ -86,7 +88,7 @@ const SpotHorizontalList = () => {
       <div style={styles.container}>
         <GridList
           spacing={12}
-          cols={2.5}
+          cols={smUp ? 4.5 : 2.5}
           cellHeight={100}
           style={styles.gridList}
         >

--- a/src/frontend/components/organisms/SpotHorizontalList.js
+++ b/src/frontend/components/organisms/SpotHorizontalList.js
@@ -12,6 +12,7 @@ import selectSpot from '../../actions/selectSpot';
 import openSpotCard from '../../actions/openSpotCard';
 import requestMapCenter from '../../actions/requestMapCenter';
 import I18n from '../../utils/I18n';
+import CreateReviewTile from '../molecules/CreateReviewTile';
 
 const styles = {
   root: {
@@ -92,30 +93,36 @@ const SpotHorizontalList = () => {
           cellHeight={100}
           style={styles.gridList}
         >
-          {spots.map(spot => (
-            <GridListTile
-              key={spot.place_id}
-              onClick={() => handleSpotClick(spot)}
-            >
-              <div style={styles.reviewerContainer}>
-                <Reviewers spot={spot} />
-              </div>
-              <img src={spot.image_url} alt={spot.name} />
-              <GridListTileBar
-                style={styles.tileBar}
-                title={
-                  <Typography variant="subtitle2" color="inherit" noWrap>
-                    {spot.name}
-                  </Typography>
-                }
-                subtitle={
-                  <Typography variant="caption" color="inherit" noWrap>
-                    {`${spot.reviews.length} ${I18n.t('reviews count')}`}
-                  </Typography>
-                }
-              />
+          {spots.length > 0 ? (
+            spots.map(spot => (
+              <GridListTile
+                key={spot.place_id}
+                onClick={() => handleSpotClick(spot)}
+              >
+                <div style={styles.reviewerContainer}>
+                  <Reviewers spot={spot} />
+                </div>
+                <img src={spot.image_url} alt={spot.name} />
+                <GridListTileBar
+                  style={styles.tileBar}
+                  title={
+                    <Typography variant="subtitle2" color="inherit" noWrap>
+                      {spot.name}
+                    </Typography>
+                  }
+                  subtitle={
+                    <Typography variant="caption" color="inherit" noWrap>
+                      {`${spot.reviews.length} ${I18n.t('reviews count')}`}
+                    </Typography>
+                  }
+                />
+              </GridListTile>
+            ))
+          ) : (
+            <GridListTile key="add-review">
+              <CreateReviewTile />
             </GridListTile>
-          ))}
+          )}
         </GridList>
       </div>
     </div>

--- a/src/frontend/components/pages/MapDetail.js
+++ b/src/frontend/components/pages/MapDetail.js
@@ -47,6 +47,9 @@ const SpotHorizontalList = React.lazy(() =>
   )
 );
 
+import { ThemeProvider } from '@material-ui/styles';
+import useTheme from '@material-ui/styles/useTheme';
+
 import Helmet from 'react-helmet';
 import Drawer from '@material-ui/core/Drawer';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
@@ -55,6 +58,15 @@ import switchSummary from '../../actions/switchSummary';
 
 const styles = {
   containerLarge: {},
+  containerMd: {
+    position: 'fixed',
+    top: 64,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    display: 'block',
+    width: '100%'
+  },
   containerSmall: {
     position: 'fixed',
     top: 56,
@@ -80,7 +92,14 @@ const styles = {
     right: 0,
     bottom: 124
   },
-  switchSummaryContainer: {
+  switchSummaryContainerLarge: {
+    textAlign: 'center',
+    width: '100%',
+    position: 'absolute',
+    zIndex: 1,
+    top: 78
+  },
+  switchSummaryContainerSmall: {
     textAlign: 'center',
     width: '100%',
     position: 'absolute',
@@ -137,7 +156,7 @@ const MapDetailHelmet = props => {
 };
 
 const MapSummaryDrawer = props => {
-  const large = useMediaQuery('(min-width: 600px)');
+  const lgUp = useMediaQuery('(min-width: 1280px)');
   const mapState = useCallback(
     state => ({
       mapSummaryOpen: state.mapDetail.mapSummaryOpen
@@ -148,17 +167,17 @@ const MapSummaryDrawer = props => {
 
   return (
     <Drawer
-      variant={large ? 'persistent' : 'temporary'}
-      anchor={large ? 'left' : 'right'}
-      open={large ? true : mapSummaryOpen}
+      variant={lgUp ? 'persistent' : 'temporary'}
+      anchor={lgUp ? 'left' : 'right'}
+      open={lgUp ? true : mapSummaryOpen}
       PaperProps={{
-        style: large ? styles.drawerPaperLarge : styles.drawerPaperSmall
+        style: lgUp ? styles.drawerPaperLarge : styles.drawerPaperSmall
       }}
     >
       <React.Suspense fallback={null}>
         <MapSummary
           mapId={props.params.primaryId}
-          dialogMode={large ? false : true}
+          dialogMode={lgUp ? false : true}
         />
       </React.Suspense>
     </Drawer>
@@ -166,11 +185,11 @@ const MapSummaryDrawer = props => {
 };
 
 const MapButtons = React.memo(props => {
-  const large = useMediaQuery('(min-width: 600px)');
+  const lgUp = useMediaQuery('(min-width: 1280px)');
   const currentMap = props.currentMap;
 
   return (
-    <div style={large ? styles.mapButtonsLarge : styles.mapButtonsSmall}>
+    <div style={lgUp ? styles.mapButtonsLarge : styles.mapButtonsSmall}>
       <React.Suspense fallback={null}>
         <CreateResourceButton
           buttonForMap
@@ -185,29 +204,41 @@ const MapButtons = React.memo(props => {
 });
 
 const SwitchSummaryButton = React.memo(() => {
+  const smUp = useMediaQuery('(min-width: 600px)');
   const dispatch = useDispatch();
+  const theme = useTheme();
 
   const handleSummaryButtonClick = useCallback(() => {
     dispatch(switchSummary());
   });
 
   return (
-    <div style={styles.switchSummaryContainer}>
-      <Fab
-        variant="extended"
-        size="small"
-        color="primary"
-        onClick={handleSummaryButtonClick}
+    <ThemeProvider theme={theme}>
+      <div
+        style={
+          smUp
+            ? styles.switchSummaryContainerLarge
+            : styles.switchSummaryContainerSmall
+        }
       >
-        <InfoOutlinedIcon style={styles.infoIcon} />
-        {I18n.t('summary')}
-      </Fab>
-    </div>
+        <Fab
+          variant="extended"
+          size="small"
+          color="primary"
+          onClick={handleSummaryButtonClick}
+        >
+          <InfoOutlinedIcon style={styles.infoIcon} />
+          {I18n.t('summary')}
+        </Fab>
+      </div>
+    </ThemeProvider>
   );
 });
 
 const MapDetail = props => {
-  const large = useMediaQuery('(min-width: 600px)');
+  const smUp = useMediaQuery('(min-width: 600px)');
+  const lgUp = useMediaQuery('(min-width: 1280px)');
+
   const dispatch = useDispatch();
 
   const mapState = useCallback(
@@ -296,7 +327,7 @@ const MapDetail = props => {
   return (
     <div>
       {currentMap && <MapDetailHelmet map={currentMap} />}
-      {large ? (
+      {lgUp ? (
         <div>
           <MapSummaryDrawer {...props} />
           <React.Suspense fallback={null}>
@@ -307,7 +338,7 @@ const MapDetail = props => {
       ) : (
         <div>
           <SwitchSummaryButton />
-          <div style={large ? styles.containerLarge : styles.containerSmall}>
+          <div style={smUp ? styles.containerMd : styles.containerSmall}>
             <React.Suspense fallback={null}>
               <GMap />
             </React.Suspense>
@@ -322,7 +353,7 @@ const MapDetail = props => {
       <React.Suspense fallback={null}>
         <DeleteMapDialog mapId={props.params.primaryId} />
         <InviteTargetDialog mapId={props.params.primaryId} />
-        {!large && <MapSpotDrawer mapId={props.params.primaryId} />}
+        {!lgUp && <MapSpotDrawer mapId={props.params.primaryId} />}
       </React.Suspense>
     </div>
   );

--- a/src/frontend/locales/en.json
+++ b/src/frontend/locales/en.json
@@ -196,5 +196,10 @@
   "sign in success": "Signed in successfully!",
   "copied": "Copied!",
   "recommend": "Recommend",
-  "discover more": "Discover"
+  "discover more": "Discover",
+  "button share": "Share this map",
+  "button like": "Like",
+  "button unlike": "Unlike",
+  "button invite": "Invite friends",
+  "button current location": "Move to current location"
 }

--- a/src/frontend/locales/ja.json
+++ b/src/frontend/locales/ja.json
@@ -196,5 +196,10 @@
   "sign in success": "ログインしました！",
   "copied": "コピーしました！",
   "recommend": "おすすめ",
-  "discover more": "もっと見る"
+  "discover more": "もっと見る",
+  "button share": "マップをシェアする",
+  "button like": "いいね！",
+  "button unlike": "いいね！を取り消す",
+  "button invite": "他のユーザーを招待する",
+  "button current location": "現在地へ移動"
 }

--- a/src/frontend/reducers/spotDetailReducer.js
+++ b/src/frontend/reducers/spotDetailReducer.js
@@ -74,11 +74,13 @@ const reducer = (state = initialState, action) => {
       });
     case CLOSE_SPOT_DIALOG:
       return Object.assign({}, state, {
-        spotDialogOpen: false
+        spotDialogOpen: false,
+        currentSpot: undefined
       });
     case LOCATION_CHANGE:
       return Object.assign({}, state, {
-        spotDialogOpen: false
+        spotDialogOpen: false,
+        currentSpot: undefined
       });
     default:
       return state;


### PR DESCRIPTION
* タブレットサイズの端末ではモバイル版の UI を表示するようにしました。
* マップ画面下部のスポット一覧表示エリアについて、スポット≒レポートが 1 件もない場合はレポート投稿ボタンを表示するようにしました。
* スポットダイアログを開いたあとでレポート投稿ボタンを開くと、スポットが固定されてしまう問題を修正しました。
* レポートのタイル上にカーソルをかざすとスポット名が表示されるようにしました。
* マップツールバーの各種ボタンに Tooltip を表示するようにしました。
* ダイアログを開いたときに GA にアクションが記録されるようにしました。
* 「見つける」ページの最近のレポートのカードのデザインを新しくしました。