### PR TITLE
Directory loading index.html without cache

### DIFF
--- a/src/service_workers/sw.js
+++ b/src/service_workers/sw.js
@@ -7,7 +7,9 @@ import * as expiration from 'workbox-expiration';
 
 core.skipWaiting();
 core.clientsClaim();
-precaching.precacheAndRoute(self.__precacheManifest || []);
+precaching.precacheAndRoute(self.__precacheManifest || [], {
+  directoryIndex: null
+});
 googleAnalytics.initialize();
 
 routing.registerRoute(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,8 +23,7 @@ const plugins = [
     icon512: process.env.ICON_512,
     ogpImage: process.env.OGP_IMAGE_URL,
     fbAppId: process.env.FB_APP_ID,
-    gaTrackingId: process.env.GA_TRACKING_ID,
-    filename: 'index.html?[hash]'
+    gaTrackingId: process.env.GA_TRACKING_ID
   }),
   new webpack.EnvironmentPlugin([
     'ENDPOINT',


### PR DESCRIPTION
Express の設定で index.html は動的に返す設定としていたのですが、workbox の挙動により `/` にアクセスしたときだけ index.html のキャッシュにアクセスしてしまっていたので修正しました。

https://developers.google.com/web/tools/workbox/modules/workbox-precaching

```
Directory Index
Requests ending in a / will, by default, be matched against entries with an index.html appended to the end. This means an incoming request for / can automatically be handled with the precached entry /index.html.

You can alter this to something else, or disable it completely, by setting directoryIndex:
```