### PR TITLE
Fib back button behavior

### DIFF
--- a/src/components/molecules/BackButton.js
+++ b/src/components/molecules/BackButton.js
@@ -26,7 +26,7 @@ const BackButton = () => {
       return;
     }
 
-    if (historyCount > 1) {
+    if (historyCount > 2) {
       history.goBack();
     } else {
       history.push('/');


### PR DESCRIPTION
rize-router を更新したことで、初回ロード時に 2 回 history がカウントされるようになった。
これに伴い、戻るボタンの挙動を修正する必要があった。