### PR TITLE
Specify width & height for Rendertron

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ app.get('*', async (req, res) => {
     const response = await fetch(
       `${process.env.RENDERTRON_ENDPOINT}/render/${generateUrl(
         req
-      )}?mobile=true`
+      )}?mobile=true&width=365&height=812`
     );
     const body = await response.text();
 


### PR DESCRIPTION
Rendertron によるダイナミックレンダリング時に viewport のサイズを指定していなかったため、モバイルフレンドリーテストで PC 版の画面がレンダリングされ、文字が小さすぎる旨のアラートがデていたので viewport を指定するようにしました。
iPhone X のサイズを指定 (365 * 812)。