### PR TITLE
Fix horizontal scroll on spot drawer in iOS

### DIFF
--- a/src/components/organisms/MapSpotDrawer.tsx
+++ b/src/components/organisms/MapSpotDrawer.tsx
@@ -56,9 +56,9 @@ const styles = {
   },
   gridList: {
     flexWrap: 'nowrap',
-    overflowX: 'auto'
     // Promote the list into his own layer on Chrome. This cost memory but helps keeping high FPS.
-    // transform: 'translateZ(0)'
+    transform: 'translateZ(0)',
+    '-webkit-overflow-scrolling': 'unset'
   },
   avatarGridTile: {
     width: 30,


### PR DESCRIPTION
Unset `-webkit-overflow-scrolling`