### PR TITLE
chore: migrate from Gemini Code Assist to Claude Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "google.geminicodeassist",
-        "GitHub.copilot",
-        "GitHub.copilot-chat",
+        "anthropic.claude-code",
         "redhat.vscode-yaml",
         "biomejs.biome",
         "hoovercj.vscode-power-mode"
@@ -14,6 +12,7 @@
     }
   },
   "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {}
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Gemini Code Assist Context for Qoodish-Web
+# Claude Code Context for Qoodish-Web
 
-This document provides essential context for Gemini Code Assist to understand the Qoodish-Web project. Please use this information to generate code that is consistent with the existing architecture, conventions, and dependencies.
+This document provides essential context for Claude Code to understand the Qoodish-Web project. Please use this information to generate code that is consistent with the existing architecture, conventions, and dependencies.
 
 ## 1. Project Overview
 
@@ -54,4 +54,4 @@ When generating commit messages, please follow these rules:
 - Ensure each line in the body does not exceed 72 characters by inserting line breaks where necessary, including within sentences.
 - Separate distinct paragraphs with a blank line.
 - Use the body to explain what and why vs. how.
-- Reference pull requests.
+- Reference pull requests if needed.


### PR DESCRIPTION
This pull request updates the development environment to use Anthropic Claude Code instead of Google Gemini Code Assist, and renames the project context documentation accordingly. It also updates relevant documentation and configuration to reflect this change.

Development environment updates:
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L7-R15): Replaces Gemini and GitHub Copilot VSCode extensions with the Anthropic Claude Code extension, and adds the Claude Code devcontainer feature.

Documentation updates:
* `GEMINI.md` renamed to `CLAUDE.md`: Updates all references from "Gemini Code Assist" to "Claude Code" to match the new tool.
* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L57-R57): Clarifies the guideline for referencing pull requests in commit messages.