### PR TITLE
chore: persist Claude Code memory across rebuilds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,5 +15,15 @@
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {}
+  },
+  "remoteUser": "node",
+  "mounts": [
+    "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
+    "source=claude-code-config-${devcontainerId},target=${containerUserHome}/.claude,type=volume"
+  ],
+  "containerEnv": {
+    "NODE_OPTIONS": "--max-old-space-size=4096",
+    "CLAUDE_CONFIG_DIR": "${containerUserHome}/.claude",
+    "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
   }
 }


### PR DESCRIPTION
This pull request updates the `.devcontainer/devcontainer.json` configuration to improve the development environment for Node.js users. The changes focus on setting up persistent storage for command history and Claude configuration, specifying the default user, and optimizing environment variables for better performance and usability.

Development environment enhancements:

* Sets `remoteUser` to `node` to ensure the container runs as the Node.js user by default.
* Adds volume mounts to persist shell command history and Claude configuration across container restarts.

Environment variable configuration:

* Sets `NODE_OPTIONS` to increase the maximum old space size to 4096 MB for better Node.js performance.
* Sets `CLAUDE_CONFIG_DIR` to point to the Claude configuration directory inside the container.
* Disables `POWERLEVEL9K` git status prompt to reduce shell prompt overhead.