### PR TITLE
feat: add Email Link auth, remove FB/Twitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ jspm_packages/
 # Typescript v1 declaration files
 typings/
 
+# TypeScript incremental build cache
+*.tsbuildinfo
+
 # Optional npm cache directory
 .npm
 
@@ -77,3 +80,7 @@ credentials.json
 credentials.*.json
 
 .pnpm-store
+
+.claude/settings.local.json
+
+spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,13 @@ This document provides essential context for Claude Code to understand the Qoodi
 - **Data Fetching:** Use SWR hooks for all interactions with the backend. Custom hooks in `src/hooks` are the preferred way to abstract this logic.
 - **State Management:** For global state, React Context is used. For server state, SWR is the source of truth.
 - **Internationalization (i18n):** The app supports English and Japanese. Text displayed to the user should be retrieved via the `useDictionary` hook.
+- **Authentication Flow:** The app uses a unified sign-in/sign-up pattern:
+    - Firebase Authentication handles authentication (Google OAuth, Email Link)
+    - After successful Firebase auth, `AuthProvider` listens via `onAuthStateChanged`
+    - `AuthProvider.signIn(user)` calls backend `POST /users` (Rails API determines if user is new or existing)
+    - Backend response sets `currentUser` in AuthContext
+    - Supported methods: Google OAuth (`signInWithPopup`), Email Link (`sendSignInLinkToEmail`)
+    - Facebook and Twitter authentication have been removed
 
 ## 4. Code Generation & Modification Guidelines
 

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,7 +1,17 @@
+import { getAnalytics, logEvent } from 'firebase/analytics';
 import { getApps, initializeApp } from 'firebase/app';
-import { type User, getAuth, onAuthStateChanged } from 'firebase/auth';
+import {
+  type User,
+  getAuth,
+  isSignInWithEmailLink,
+  onAuthStateChanged,
+  signInWithEmailLink
+} from 'firebase/auth';
+import { useRouter } from 'next/router';
+import { enqueueSnackbar } from 'notistack';
 import { type ReactNode, memo, useCallback, useEffect, useState } from 'react';
 import AuthContext from '../../context/AuthContext';
+import useDictionary from '../../hooks/useDictionary';
 
 type Props = {
   children: ReactNode;
@@ -11,6 +21,9 @@ function AuthProvider({ children }: Props) {
   const [currentUser, setCurrentUser] = useState<User>(null);
   const [loading, setLoading] = useState(true);
   const [signInRequired, setSignInRequired] = useState(false);
+
+  const router = useRouter();
+  const dictionary = useDictionary();
 
   const initFirebase = useCallback(() => {
     initializeApp({
@@ -76,6 +89,40 @@ function AuthProvider({ children }: Props) {
 
     return () => unsubscribe();
   }, [initFirebase, handleAuthStateChanged]);
+
+  useEffect(() => {
+    if (!router.isReady || !getApps().length) return;
+
+    const auth = getAuth();
+    const currentUrl = `${window.location.origin}${router.asPath}`;
+
+    if (!isSignInWithEmailLink(auth, currentUrl)) return;
+
+    let emailForSignIn = window.localStorage.getItem('emailForSignIn');
+
+    if (!emailForSignIn) {
+      emailForSignIn = window.prompt(dictionary['email link email']);
+    }
+
+    if (!emailForSignIn) return;
+
+    signInWithEmailLink(auth, emailForSignIn, currentUrl)
+      .then(() => {
+        window.localStorage.removeItem('emailForSignIn');
+        enqueueSnackbar(dictionary['sign in success'], {
+          variant: 'success'
+        });
+
+        const analytics = getAnalytics();
+        logEvent(analytics, 'login', { provider: 'email_link' });
+      })
+      .catch((err) => {
+        console.error(err);
+        enqueueSnackbar(dictionary['an error occured'], {
+          variant: 'error'
+        });
+      });
+  }, [router.isReady, router.asPath, dictionary]);
 
   return (
     <AuthContext.Provider

--- a/src/components/auth/LoginCard.tsx
+++ b/src/components/auth/LoginCard.tsx
@@ -1,4 +1,12 @@
-import { Box, Stack, Typography, useMediaQuery, useTheme } from '@mui/material';
+import {
+  Box,
+  Card,
+  CardContent,
+  Stack,
+  Typography,
+  useMediaQuery,
+  useTheme
+} from '@mui/material';
 import { useRouter } from 'next/router';
 import { memo, useCallback } from 'react';
 import useDictionary from '../../hooks/useDictionary';
@@ -15,33 +23,27 @@ export default memo(function LoginCard() {
   }, [push]);
 
   return (
-    <Stack spacing={2}>
-      <Typography
-        variant={mdUp ? 'h3' : 'h4'}
-        component="h1"
-        color="white"
-        align="center"
-      >
-        {dictionary['create map together']}
-      </Typography>
+    <Card>
+      <CardContent>
+        <Stack spacing={2}>
+          <Typography
+            align="center"
+            variant={mdUp ? 'h5' : 'h6'}
+            component="div"
+          >
+            {dictionary.login}
+          </Typography>
 
-      <Typography
-        variant={mdUp ? 'subtitle1' : 'subtitle2'}
-        component="p"
-        color="white"
-        align="center"
-      >
-        {dictionary['start new adventure']}
-      </Typography>
-
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'center'
-        }}
-      >
-        <SignInButtons onSignInSuccess={handleSignInSuccess} />
-      </Box>
-    </Stack>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center'
+            }}
+          >
+            <SignInButtons onSignInSuccess={handleSignInSuccess} />
+          </Box>
+        </Stack>
+      </CardContent>
+    </Card>
   );
 });

--- a/src/components/auth/SignInButtons.tsx
+++ b/src/components/auth/SignInButtons.tsx
@@ -1,10 +1,10 @@
-import { Stack } from '@mui/material';
+import { Divider, Stack } from '@mui/material';
 import type { AuthError } from 'firebase/auth';
 import { memo, useState } from 'react';
+import useDictionary from '../../hooks/useDictionary';
 import LinkAccountDialog from './LinkAccountDialog';
-import SignInWithFacebookButton from './SignInWithFacebookButton';
+import SignInWithEmailLinkButton from './SignInWithEmailLinkButton';
 import SignInWithGoogleButton from './SignInWithGoogleButton';
-import SignInWithTwitterButton from './SignInWithTwitterButton';
 
 type Props = {
   onSignInSuccess: () => void;
@@ -15,21 +15,17 @@ function SignInButtons({ onSignInSuccess }: Props) {
     null
   );
 
+  const dictionary = useDictionary();
+
   return (
     <>
-      <Stack spacing={1}>
+      <Stack spacing={2}>
         <SignInWithGoogleButton
           onSignInSuccess={onSignInSuccess}
           onSignInError={setCurrentAuthError}
         />
-        <SignInWithFacebookButton
-          onSignInSuccess={onSignInSuccess}
-          onSignInError={setCurrentAuthError}
-        />
-        <SignInWithTwitterButton
-          onSignInSuccess={onSignInSuccess}
-          onSignInError={setCurrentAuthError}
-        />
+        <Divider>{dictionary.or}</Divider>
+        <SignInWithEmailLinkButton onSignInError={setCurrentAuthError} />
       </Stack>
 
       <LinkAccountDialog

--- a/src/components/auth/SignInWithEmailLinkButton.tsx
+++ b/src/components/auth/SignInWithEmailLinkButton.tsx
@@ -1,0 +1,122 @@
+import { LoadingButton } from '@mui/lab';
+import { Alert, Stack, TextField } from '@mui/material';
+import { getAnalytics, logEvent } from 'firebase/analytics';
+import { type AuthError, getAuth, sendSignInLinkToEmail } from 'firebase/auth';
+import { useRouter } from 'next/router';
+import { type FormEvent, memo, useCallback, useState } from 'react';
+import useDictionary from '../../hooks/useDictionary';
+
+type Props = {
+  onSignInError: (error: AuthError) => void;
+};
+
+function SignInWithEmailLinkButton({ onSignInError }: Props) {
+  const router = useRouter();
+  const dictionary = useDictionary();
+
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getErrorMessage = useCallback(
+    (errorCode: string): string => {
+      switch (errorCode) {
+        case 'auth/invalid-email':
+          return dictionary['email link error invalid email'];
+        case 'auth/too-many-requests':
+          return dictionary['email link error too many requests'];
+        case 'auth/operation-not-allowed':
+          return dictionary['email link error operation not allowed'];
+        case 'auth/expired-action-code':
+          return dictionary['email link error expired'];
+        case 'auth/invalid-action-code':
+          return dictionary['email link error invalid link'];
+        case 'auth/network-request-failed':
+          return dictionary['email link error network request failed'];
+        default:
+          return dictionary['an error occured'];
+      }
+    },
+    [dictionary]
+  );
+
+  const handleSendLink = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      setLoading(true);
+      setError(null);
+
+      const auth = getAuth();
+      auth.languageCode = router.locale;
+
+      const actionCodeSettings = {
+        url: window.location.origin,
+        handleCodeInApp: true,
+        linkDomain: window.location.hostname
+      };
+
+      try {
+        await sendSignInLinkToEmail(auth, email, actionCodeSettings);
+        window.localStorage.setItem('emailForSignIn', email);
+        setSent(true);
+
+        const analytics = getAnalytics();
+        logEvent(analytics, 'email_link_sent');
+      } catch (err) {
+        console.error(err);
+        const errorMessage = getErrorMessage((err as AuthError).code);
+        setError(errorMessage);
+        onSignInError(err as AuthError);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [email, router.locale, onSignInError, getErrorMessage]
+  );
+
+  if (sent) {
+    return (
+      <Stack spacing={2} sx={{ width: '100%' }}>
+        <Alert severity="success">{dictionary['email link sent']}</Alert>
+        <Alert severity="info">
+          {dictionary['email link sent description']}
+        </Alert>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack
+      component="form"
+      onSubmit={handleSendLink}
+      spacing={2}
+      sx={{ width: '100%' }}
+    >
+      {error && <Alert severity="error">{error}</Alert>}
+
+      <TextField
+        label={dictionary['email link email']}
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        fullWidth
+        disabled={loading}
+        variant="outlined"
+      />
+
+      <LoadingButton
+        type="submit"
+        loading={loading}
+        variant="contained"
+        fullWidth
+        disabled={!email}
+      >
+        {dictionary['email link send']}
+      </LoadingButton>
+    </Stack>
+  );
+}
+
+export default memo(SignInWithEmailLinkButton);

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -226,5 +226,16 @@
   "back to map": "Back to the map",
   "user not found": "User Not Found",
   "places": "Places",
-  "select place": "Click to search places"
+  "select place": "Click to search places",
+  "or": "or",
+  "email link email": "Email",
+  "email link send": "Send sign-in link",
+  "email link sent": "Sign-in link has been sent. Please check your email.",
+  "email link sent description": "Click the link in the email to sign in. The link will expire in 60 minutes.",
+  "email link error invalid email": "Invalid email format",
+  "email link error too many requests": "Too many attempts. Please try again later.",
+  "email link error operation not allowed": "Email link authentication is not enabled",
+  "email link error expired": "This sign-in link has expired. Please request a new one.",
+  "email link error invalid link": "This sign-in link is invalid or has already been used.",
+  "email link error network request failed": "Network error. Please check your connection and try again"
 }

--- a/src/dictionaries/ja.json
+++ b/src/dictionaries/ja.json
@@ -226,5 +226,16 @@
   "back to map": "マップに戻る",
   "user not found": "ユーザーが見つかりません",
   "places": "場所",
-  "select place": "クリックして場所を検索"
+  "select place": "クリックして場所を検索",
+  "or": "または",
+  "email link email": "メールアドレス",
+  "email link send": "ログインリンクを送信",
+  "email link sent": "ログインリンクを送信しました。メールをご確認ください。",
+  "email link sent description": "メール内のリンクをクリックしてログインしてください。リンクは 60 分で期限切れになります。",
+  "email link error invalid email": "メールアドレスの形式が正しくありません",
+  "email link error too many requests": "試行回数が多すぎます。しばらくしてから再度お試しください。",
+  "email link error operation not allowed": "メールリンク認証が有効化されていません",
+  "email link error expired": "このログインリンクは期限切れです。新しいリンクをリクエストしてください。",
+  "email link error invalid link": "このログインリンクは無効か、すでに使用されています。",
+  "email link error network request failed": "ネットワークエラーが発生しました。接続を確認して再度お試しください"
 }

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -113,7 +113,40 @@ const LoginPage: NextPageWithLayout = () => {
           }}
         >
           <Container maxWidth="md">
-            <LoginCard />
+            <Grid container spacing={2}>
+              <Grid
+                item
+                xs={12}
+                sm={7}
+                md={8}
+                lg={8}
+                alignContent={smUp ? 'center' : 'flex-end'}
+              >
+                <Stack spacing={2}>
+                  <Typography
+                    variant={mdUp ? 'h3' : 'h4'}
+                    component="h1"
+                    color="white"
+                    align="center"
+                  >
+                    {dictionary['create map together']}
+                  </Typography>
+
+                  <Typography
+                    variant={mdUp ? 'subtitle1' : 'subtitle2'}
+                    component="p"
+                    color="white"
+                    align="center"
+                  >
+                    {dictionary['start new adventure']}
+                  </Typography>
+                </Stack>
+              </Grid>
+
+              <Grid item xs={12} sm={5} md={4} lg={4}>
+                <LoginCard />
+              </Grid>
+            </Grid>
           </Container>
         </Box>
       </Box>


### PR DESCRIPTION
This pull request implements a major update to the authentication flow, replacing Facebook and Twitter sign-in with a passwordless email link sign-in using Firebase Authentication, and improves the login UI and internationalization support. The changes also refactor the login page layout for better user experience.

**Authentication Flow Overhaul**

* Adds support for passwordless sign-in via email links using Firebase Authentication; Facebook and Twitter sign-in are removed. After Firebase authentication, the backend determines if the user is new or existing, and sets the current user in the app context. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R34-R40) [[2]](diffhunk://#diff-b6d7ac0d737794978ee5b185ac20272e2d0257a28ca8b08b06e377905a034f12R1-R14) [[3]](diffhunk://#diff-e32bc89606b8e6c1d01fcafc05711bcdb0c3c1f1b5fda3b59c85bf88ad0f5e6dR1-R122)
* Implements email link sign-in: users can request a sign-in link to their email, and the app handles the link when clicked, including error handling, analytics logging, and user feedback. [[1]](diffhunk://#diff-b6d7ac0d737794978ee5b185ac20272e2d0257a28ca8b08b06e377905a034f12R93-R126) [[2]](diffhunk://#diff-e32bc89606b8e6c1d01fcafc05711bcdb0c3c1f1b5fda3b59c85bf88ad0f5e6dR1-R122)

**UI and UX Improvements**

* Refactors the login page layout to display the login form and introductory text side-by-side, improving visual hierarchy and clarity.
* Updates `LoginCard` to use Material UI `Card` components and adjusts typography for consistency with the redesigned login page. [[1]](diffhunk://#diff-4061254a370081d67684c194151df4c120d983b97a305c778246fd67487b2a5eL1-R9) [[2]](diffhunk://#diff-4061254a370081d67684c194151df4c120d983b97a305c778246fd67487b2a5eR26-R34) [[3]](diffhunk://#diff-4061254a370081d67684c194151df4c120d983b97a305c778246fd67487b2a5eR46-R47)
* Updates sign-in buttons: removes Facebook and Twitter options, adds a divider and the new email link sign-in button. [[1]](diffhunk://#diff-5159d8c5b5997601bb03f55e37d19d891568fc2cdfc534c4833f28138614d070L1-L7) [[2]](diffhunk://#diff-5159d8c5b5997601bb03f55e37d19d891568fc2cdfc534c4833f28138614d070R18-R28)

**Internationalization**

* Adds new dictionary entries for all email link authentication messages and errors in both English and Japanese, ensuring all user-facing text is localized. [[1]](diffhunk://#diff-cf8c01eff8cb7173dfa28cfd3bf467a058671d1e29bd9657dc6947ee7247b096L229-R240) [[2]](diffhunk://#diff-43ed36c69438fdcc6547f41e0c779cb3ab7d225ba272e01abe3c4b404878c0ddL229-R240)