### PR TITLE
fix: replace useMediaQuery with CSS responsive display in Layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,7 +9,6 @@ import {
   Paper,
   Stack,
   Typography,
-  useMediaQuery,
   useTheme
 } from '@mui/material';
 import Link from 'next/link';
@@ -44,9 +43,6 @@ type Props = {
 
 function Layout({ children, fullWidth, hideBottomNav, showBackButton }: Props) {
   const theme = useTheme();
-  const smUp = useMediaQuery(theme.breakpoints.up('sm'));
-  const mdUp = useMediaQuery(theme.breakpoints.up('md'));
-  const mdDown = useMediaQuery(theme.breakpoints.down('md'));
 
   const dictionary = useDictionary();
 
@@ -108,64 +104,46 @@ function Layout({ children, fullWidth, hideBottomNav, showBackButton }: Props) {
         onSaved={handleCreatedMap}
       />
 
-      {mdDown && (
-        <>
-          <MobileAppBar
-            showBackButton={showBackButton}
-            onSearchOpen={() => setSearchOpen(true)}
-            onCreateMapClick={handleCreateMapClick}
-          />
+      <Box sx={{ display: { xs: 'block', md: 'none' } }}>
+        <MobileAppBar
+          showBackButton={showBackButton}
+          onSearchOpen={() => setSearchOpen(true)}
+          onCreateMapClick={handleCreateMapClick}
+        />
 
+        {currentUser && !hideBottomNav && (
           <Box
             sx={{
               position: 'fixed',
-              top: smUp ? theme.spacing(8) : theme.spacing(7),
-              zIndex: 1101,
-              width: '100%',
-              display: loading ? 'block' : 'none',
-              alignItems: 'center'
+              bottom: 0,
+              left: 0,
+              right: 0,
+              zIndex: 1
             }}
           >
-            <LinearProgress color="secondary" />
+            <BottomNav onCreateMapClick={handleCreateMapClick} />
           </Box>
+        )}
+      </Box>
 
-          {currentUser && !hideBottomNav && (
-            <Box
-              sx={{
-                position: 'fixed',
-                bottom: 0,
-                left: 0,
-                right: 0,
-                zIndex: 1
-              }}
-            >
-              <BottomNav onCreateMapClick={handleCreateMapClick} />
-            </Box>
-          )}
-        </>
-      )}
+      <Box sx={{ display: { xs: 'none', md: 'block' } }}>
+        <MiniDrawer
+          onSearchOpen={() => setSearchOpen(true)}
+          onCreateMapClick={handleCreateMapClick}
+        />
+      </Box>
 
-      {mdUp && (
-        <>
-          <MiniDrawer
-            onSearchOpen={() => setSearchOpen(true)}
-            onCreateMapClick={handleCreateMapClick}
-          />
-
-          <Box
-            sx={{
-              position: 'fixed',
-              top: 0,
-              zIndex: 1201,
-              width: '100%',
-              display: loading ? 'block' : 'none',
-              alignItems: 'center'
-            }}
-          >
-            <LinearProgress color="secondary" />
-          </Box>
-        </>
-      )}
+      <Box
+        sx={{
+          position: 'fixed',
+          top: { xs: theme.spacing(7), sm: theme.spacing(8), md: 0 },
+          zIndex: { xs: 1101, md: 1201 },
+          width: '100%',
+          display: loading ? 'block' : 'none'
+        }}
+      >
+        <LinearProgress color="secondary" />
+      </Box>
 
       <Box
         sx={{
@@ -202,8 +180,11 @@ function Layout({ children, fullWidth, hideBottomNav, showBackButton }: Props) {
               {children}
             </Grid>
 
-            {mdUp && !fullWidth && (
-              <Grid size={{ md: 4, lg: 4, xl: 4 }}>
+            {!fullWidth && (
+              <Grid
+                size={{ md: 4, lg: 4, xl: 4 }}
+                sx={{ display: { xs: 'none', md: 'block' } }}
+              >
                 <Stack spacing={2}>
                   <RecommendMaps />
 


### PR DESCRIPTION
# Summary

Fixes FOUC (Flash of Unstyled Content) on page reload caused by `useMediaQuery` returning `false` during SSR.
Replaces JS-based conditional rendering with CSS media queries generated by MUI's `sx` prop, so both nav variants are included in the SSR HTML from the start.

# Motivation

`useMediaQuery` requires the browser viewport, which is unavailable on the server, so all breakpoint checks return `false` during SSR.
As a result, neither `MobileAppBar` nor `MiniDrawer` was included in the server-rendered HTML, and both appeared only after hydration — causing a visible layout shift.

Passing `ssrMatchMedia` with UA-based device detection is not a real fix: it can only guess the device type, not the actual viewport width, so hydration mismatches remain for edge cases.
The correct approach is to delegate show/hide logic to CSS media queries, which are evaluated by the browser against the actual viewport before any JavaScript runs.

MUI's `sx` prop with responsive values emits CSS `@media` rules via Emotion.
Because `documentGetInitialProps` in `_document.tsx` injects these styles into the SSR HTML, the browser receives the correct layout immediately — no JS execution required.

# Changes

- Remove `useMediaQuery` import and all three breakpoint variables (`smUp`, `mdUp`, `mdDown`)
- Wrap `MobileAppBar` block in `Box sx={{ display: { xs: 'block', md: 'none' } }}` so it is always in the SSR output
- Wrap `MiniDrawer` block in `Box sx={{ display: { xs: 'none', md: 'block' } }}` so it is always in the SSR output
- Replace `mdUp && !fullWidth` sidebar condition with `!fullWidth` and add `sx={{ display: { xs: 'none', md: 'block' } }}` to the Grid
- Consolidate the two `LinearProgress` instances into a single component with responsive `top` and `zIndex` values, removing the ineffective `alignItems: 'center'`

Closes #1022

🤖 Generated with [Claude Code](https://claude.ai/code)