### PR TITLE
fix: correct Emotion SSR cache setup to prevent icon FOUC

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import type { EmotionCache } from '@emotion/cache';
 import { getAnalytics, logEvent } from 'firebase/analytics';
 import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
@@ -47,8 +48,9 @@ type AppPropsWithLayout = AppProps & {
 
 export default function CustomApp({
   Component,
-  pageProps
-}: AppPropsWithLayout) {
+  pageProps,
+  emotionCache
+}: AppPropsWithLayout & { emotionCache?: EmotionCache }) {
   const [registration, setRegistration] =
     useState<ServiceWorkerRegistration>(null);
 
@@ -132,7 +134,7 @@ export default function CustomApp({
   const getLayout = Component.getLayout ?? ((page) => page);
 
   return (
-    <AppCacheProvider>
+    <AppCacheProvider emotionCache={emotionCache}>
       <ThemeProvider theme={theme}>
         <CssBaseline />
         {inputGlobalStyles}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -100,7 +100,6 @@ export default class CustomDocument extends Document<
             <meta name="googlebot" content="noindex" />
           )}
 
-          <meta name="emotion-insertion-point" content="" />
           <DocumentHeadTags {...this.props} />
         </Head>
         <body>


### PR DESCRIPTION
## Summary

- Remove duplicate `emotion-insertion-point` meta tag from `_document.tsx`. `DocumentHeadTags` already adds this tag, so the manually added one caused the client-side cache to use the wrong insertion point, breaking style ordering between SSR and client styles.
- Accept the per-request `emotionCache` prop (passed by `documentGetInitialProps` via `enhanceApp`) in `_app.tsx` and forward it to `AppCacheProvider`. Previously, `AppCacheProvider` always fell back to `defaultEmotionCache`, which does not have `compat = true` set. Without that flag, Emotion skips serializing styles into the SSR HTML string, so MUI icons rendered at the SVG default size (~300px) until client JS injected the CSS.

## Test plan

- [ ] Hard-reload a page and confirm icons no longer expand briefly before settling to their correct size
- [ ] Verify layout renders correctly on both mobile and desktop breakpoints

🤖 Generated with [Claude Code](https://claude.ai/code)