### PR TITLE
fix: use PR number as Cloud Run traffic tag

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -9,7 +9,6 @@ env:
   PROJECT_ID: qoodish-dev
   SERVICE_NAME: qoodish-web
   ARTIFACT_REGISTRY: asia-northeast1-docker.pkg.dev
-  BRANCH_NAME: ${{ github.head_ref }}
 jobs:
   build-image:
     permissions:
@@ -93,12 +92,6 @@ jobs:
           service_account: github-actions@qoodish-common.iam.gserviceaccount.com
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
-      - name: Normalize branch name for Cloud Run tag
-        id: normalize
-        run: |
-          NORMALIZED_TAG=$(echo "${{ env.BRANCH_NAME }}" | sed 's/[.\_/]/-/g')
-          echo "tag=$NORMALIZED_TAG" >> $GITHUB_OUTPUT
-          echo "Normalized tag: $NORMALIZED_TAG"
       - name: Deploy revision
         env:
           CLOUDSDK_CORE_DISABLE_PROMPTS: 1
@@ -117,7 +110,7 @@ jobs:
             --ingress=all \
             --allow-unauthenticated \
             --execution-environment=gen2 \
-            --tag=${{ steps.normalize.outputs.tag }} \
+            --tag=pr-${{ github.event.number }} \
             --image=$ARTIFACT_REGISTRY/$PROJECT_ID/$SERVICE_NAME/$SERVICE_NAME:$GITHUB_SHA \
             --set-env-vars "NODE_ENV=production" \
             --set-env-vars "API_ENDPOINT=https://api-dev.qoodish.com"


### PR DESCRIPTION
# Summary

Replace the branch-name-based Cloud Run traffic tag with a PR-number-based tag (`pr-{number}`).

# Motivation

The branch name generated by release-please (`release-please--branches--master--components--qoodish`) exceeded Cloud Run's 46-character limit for the combined length of the traffic tag and service name, causing deployments to fail.

# Changes

- Remove the "Normalize branch name" step
- Replace `--tag` value with `pr-${{ github.event.number }}`

🤖 Generated with [Claude Code](https://claude.ai/code)