### PR TITLE
docs: add code guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ This document provides essential context for Claude Code to understand the Qoodi
 - **Directory Structure:**
     - `src/pages`: Next.js pages for routing.
     - `src/components`: Reusable React components, organized by feature/domain.
+    - `src/components/common`: Shared components referenced by multiple features. Place components here when they are used across two or more feature directories.
     - `src/hooks`: Custom hooks encapsulating business logic and data fetching (e.g., `useMap`, `useReview`).
     - `src/context`: React context providers (e.g., `AuthContext`, `GoogleMapsContext`).
     - `src/utils`: Utility functions.
@@ -45,4 +46,6 @@ This document provides essential context for Claude Code to understand the Qoodi
 - When creating components, use MUI components (`<Button>`, `<Card>`, `<Typography>`, etc.) as the base.
 - Ensure all new code is strongly typed with TypeScript.
 - For user-facing text, always use the i18n dictionaries and the `useDictionary` hook. Do not hardcode strings in English or Japanese.
+- **Responsive Layout:** Design mobile-first. Every layout must function on small screens — buttons must not overflow their containers, and text must not be truncated in a way that makes it ambiguous or unintelligible. Use MUI's responsive utilities (`sx` breakpoints, `useMediaQuery`) to adapt layouts across screen sizes.
+- **Web Standards:** Prefer web standards (HTML/CSS/JavaScript built-ins and Web APIs documented on MDN) over third-party library equivalents. Question whether a dependency is needed before reaching for one; browser-native solutions (Intersection Observer, ResizeObserver, CSS animations, etc.) are preferred when they fully cover the use case.
 - **IMPORTANT:** Before pushing code, always run `pnpm biome ci ./src` to verify code quality and formatting. All checks must pass.


### PR DESCRIPTION
# Summary

Add three coding guidelines to `CLAUDE.md` to clarify expected practices for component organization, responsive design, and technology choices.

# Motivation

These guidelines capture conventions that were previously implicit, making them explicit so that code generation stays consistent with the project's standards.

# Changes

- Add `src/components/common` as the designated directory for components shared across two or more feature directories
- Add a mobile-first responsive layout requirement: buttons must not overflow their containers, and text must not be truncated in a way that makes it ambiguous or unintelligible on small screens
- Add a web standards preference: use HTML/CSS/JavaScript built-ins and Web APIs (MDN) over third-party library equivalents where they fully cover the use case

🤖 Generated with [Claude Code](https://claude.ai/code)