### PR TITLE
fix: exclude component name from release tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
# Summary

Release Please was generating tags in `qoodish-v4.0.0` format, which did not match the `v*` trigger pattern in `prod.yaml`, causing production deployments to not run after merging release PRs.

# Motivation

By default, Release Please uses `{component}-v{version}` as the tag format, where the component is taken from `package.json`'s `name` field (`qoodish`). Setting `include-component-in-tag: false` drops the component prefix and restores the `vX.Y.Z` format that the deployment workflow expects.

# Changes

- Add `"include-component-in-tag": false` to `release-please-config.json`

🤖 Generated with [Claude Code](https://claude.ai/code)