### PR TITLE
style: unify settings card header variant

### DIFF
--- a/src/components/settings/AccountEmailCard.tsx
+++ b/src/components/settings/AccountEmailCard.tsx
@@ -21,7 +21,7 @@ function AccountEmailCard() {
     <>
       <Card elevation={0}>
         <CardContent>
-          <Typography variant="h6" component="h2" gutterBottom>
+          <Typography variant="h5" component="h2" gutterBottom>
             {dictionary['account email']}
           </Typography>
           <Typography component="p" color="text.secondary" gutterBottom>


### PR DESCRIPTION
# Summary

Unify the Typography variant used for card headers across the settings page.
`AccountEmailCard` was using `h6` while all other settings cards used `h5`.

# Motivation

The inconsistent variant caused the account email card header to render
smaller than the other three settings cards (`ProvidersCard`,
`PushNotificationsCard`, `DeleteAccountCard`), breaking visual consistency
on the settings page.

# Changes

- Change `AccountEmailCard` header Typography from `variant="h6"` to `variant="h5"`

🤖 Generated with [Claude Code](https://claude.ai/code)