### PR TITLE
fix: include locale in Firebase email action URLs

### DIFF
--- a/src/components/auth/SignInWithEmailLinkButton.tsx
+++ b/src/components/auth/SignInWithEmailLinkButton.tsx
@@ -21,6 +21,9 @@ function SignInWithEmailLinkButton() {
   const [sent, setSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const basePath =
+    router.locale === router.defaultLocale ? '' : `/${router.locale}`;
+
   const getErrorMessage = useCallback(
     (errorCode: string): string => {
       switch (errorCode) {
@@ -53,7 +56,7 @@ function SignInWithEmailLinkButton() {
       auth.languageCode = router.locale;
 
       const actionCodeSettings = {
-        url: window.location.origin,
+        url: `${window.location.origin}${basePath}`,
         handleCodeInApp: true,
         linkDomain: window.location.hostname
       };
@@ -73,7 +76,7 @@ function SignInWithEmailLinkButton() {
         setLoading(false);
       }
     },
-    [email, router.locale, getErrorMessage]
+    [email, router.locale, basePath, getErrorMessage]
   );
 
   if (sent) {

--- a/src/components/settings/ChangeEmailDialog.tsx
+++ b/src/components/settings/ChangeEmailDialog.tsx
@@ -73,6 +73,9 @@ function ChangeEmailDialog({ open, onClose }: Props) {
     [dictionary]
   );
 
+  const basePath =
+    router.locale === router.defaultLocale ? '' : `/${router.locale}`;
+
   const attemptEmailUpdate = useCallback(async () => {
     if (!currentUser) return;
 
@@ -80,11 +83,11 @@ function ChangeEmailDialog({ open, onClose }: Props) {
     auth.languageCode = router.locale;
 
     await verifyBeforeUpdateEmail(currentUser, email, {
-      url: `${window.location.origin}/login`,
+      url: `${window.location.origin}${basePath}/login`,
       handleCodeInApp: false
     });
     setSent(true);
-  }, [currentUser, email, router.locale]);
+  }, [currentUser, email, router.locale, basePath]);
 
   const handleSend = useCallback(async () => {
     setLoading(true);
@@ -145,7 +148,7 @@ function ChangeEmailDialog({ open, onClose }: Props) {
       window.localStorage.setItem('reauthForEmailChange', 'true');
 
       await sendSignInLinkToEmail(auth, currentUser.email, {
-        url: `${window.location.origin}/settings`,
+        url: `${window.location.origin}${basePath}/settings`,
         handleCodeInApp: true
       });
       setReauthStep('emailLinkSent');
@@ -158,7 +161,7 @@ function ChangeEmailDialog({ open, onClose }: Props) {
     } finally {
       setLoading(false);
     }
-  }, [currentUser, email, router.locale, getErrorMessage]);
+  }, [currentUser, email, router.locale, basePath, getErrorMessage]);
 
   const handleExited = useCallback(() => {
     setEmail('');

--- a/src/components/settings/LinkEmailDialog.tsx
+++ b/src/components/settings/LinkEmailDialog.tsx
@@ -28,6 +28,9 @@ function LinkEmailDialog({ open, onClose }: Props) {
   const [sent, setSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const basePath =
+    router.locale === router.defaultLocale ? '' : `/${router.locale}`;
+
   const handleEmailChange = useCallback((value: string, isValid: boolean) => {
     setEmail(value);
     setEmailValid(isValid);
@@ -59,7 +62,7 @@ function LinkEmailDialog({ open, onClose }: Props) {
     auth.languageCode = router.locale;
 
     const actionCodeSettings = {
-      url: `${window.location.origin}/settings`,
+      url: `${window.location.origin}${basePath}/settings`,
       handleCodeInApp: true,
       linkDomain: window.location.hostname
     };
@@ -75,7 +78,7 @@ function LinkEmailDialog({ open, onClose }: Props) {
     } finally {
       setLoading(false);
     }
-  }, [email, router.locale, getErrorMessage]);
+  }, [email, router.locale, basePath, getErrorMessage]);
 
   const handleExited = useCallback(() => {
     setEmail('');

--- a/src/hooks/useEmailLinkHandler.ts
+++ b/src/hooks/useEmailLinkHandler.ts
@@ -62,6 +62,7 @@ async function linkEmailProvider(
 async function reauthAndChangeEmail(
   currentUser: User,
   currentUrl: string,
+  basePath: string,
   dictionary: Dictionary
 ) {
   const emailForReauth = window.localStorage.getItem('emailForReauth');
@@ -80,7 +81,7 @@ async function reauthAndChangeEmail(
     );
     await reauthenticateWithCredential(currentUser, credential);
     await verifyBeforeUpdateEmail(currentUser, pendingEmailChange, {
-      url: `${window.location.origin}/login`,
+      url: `${window.location.origin}${basePath}/login`,
       handleCodeInApp: false
     });
     enqueueSnackbar(dictionary['change email sent'], { variant: 'success' });
@@ -125,6 +126,9 @@ export default function useEmailLinkHandler({
   const dictionary = useDictionary();
   const handledRef = useRef(false);
 
+  const basePath =
+    router.locale === router.defaultLocale ? '' : `/${router.locale}`;
+
   useEffect(() => {
     if (!router.isReady || !getApps().length) return;
     if (handledRef.current) return;
@@ -137,7 +141,7 @@ export default function useEmailLinkHandler({
     if (window.localStorage.getItem('reauthForEmailChange') === 'true') {
       if (currentUser) {
         handledRef.current = true;
-        reauthAndChangeEmail(currentUser, currentUrl, dictionary);
+        reauthAndChangeEmail(currentUser, currentUrl, basePath, dictionary);
       }
     } else if (window.localStorage.getItem('linkProvider') === 'true') {
       if (currentUser) {
@@ -154,5 +158,12 @@ export default function useEmailLinkHandler({
       handledRef.current = true;
       completeEmailSignIn(auth, currentUrl, dictionary);
     }
-  }, [currentUser, setCurrentUser, router.isReady, router.asPath, dictionary]);
+  }, [
+    currentUser,
+    setCurrentUser,
+    router.isReady,
+    router.asPath,
+    basePath,
+    dictionary
+  ]);
 }


### PR DESCRIPTION
# Summary

Firebase email link authentication URLs (`actionCodeSettings.url`) were missing the locale prefix, causing users on Japanese pages (`/ja/*`) to be redirected to English pages after clicking email links.

# Motivation

Users browsing the app in Japanese (`/ja/...`) expect to remain on Japanese pages after completing email-based authentication flows. The `actionCodeSettings.url` passed to Firebase was built from `window.location.origin` alone, omitting the `/ja` prefix that Next.js i18n routing requires.

# Changes

- Derive `basePath` from `router.locale` / `router.defaultLocale` and prepend it to all Firebase action URLs
- Fixed across four files covering sign-in, email linking, email change, and reauthentication flows

🤖 Generated with [Claude Code](https://claude.ai/code)