### PR TITLE
fix: sync provider list immediately after link/unlink

### DIFF
--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,13 +1,11 @@
 import { getApps, initializeApp } from 'firebase/app';
-import { type User, getAuth, onAuthStateChanged } from 'firebase/auth';
 import {
-  type ReactNode,
-  memo,
-  useCallback,
-  useEffect,
-  useReducer,
-  useState
-} from 'react';
+  type User,
+  type UserInfo,
+  getAuth,
+  onAuthStateChanged
+} from 'firebase/auth';
+import { type ReactNode, memo, useCallback, useEffect, useState } from 'react';
 import AuthContext from '../../context/AuthContext';
 import useEmailLinkHandler from '../../hooks/useEmailLinkHandler';
 
@@ -17,10 +15,15 @@ type Props = {
 
 function AuthProvider({ children }: Props) {
   const [currentUser, setCurrentUser] = useState<User>(null);
+  const [providerData, setProviderData] = useState<UserInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [signInRequired, setSignInRequired] = useState(false);
 
-  useEmailLinkHandler({ currentUser, setCurrentUser });
+  useEffect(() => {
+    setProviderData([...(currentUser?.providerData ?? [])]);
+  }, [currentUser]);
+
+  useEmailLinkHandler({ currentUser, setProviderData });
 
   const initFirebase = useCallback(() => {
     initializeApp({
@@ -92,6 +95,8 @@ function AuthProvider({ children }: Props) {
       value={{
         currentUser: currentUser,
         setCurrentUser: setCurrentUser,
+        providerData: providerData,
+        setProviderData: setProviderData,
         isLoading: loading,
         signInRequired: signInRequired,
         setSignInRequired: setSignInRequired

--- a/src/components/settings/ChangeEmailDialog.tsx
+++ b/src/components/settings/ChangeEmailDialog.tsx
@@ -31,7 +31,7 @@ type ReauthStep = 'idle' | 'google' | 'emailLink' | 'emailLinkSent';
 function ChangeEmailDialog({ open, onClose }: Props) {
   const dictionary = useDictionary();
   const router = useRouter();
-  const { currentUser } = useContext(AuthContext);
+  const { currentUser, providerData } = useContext(AuthContext);
 
   const [email, setEmail] = useState('');
   const [emailValid, setEmailValid] = useState(true);
@@ -42,10 +42,8 @@ function ChangeEmailDialog({ open, onClose }: Props) {
 
   const hasGoogleProvider = useMemo(
     () =>
-      currentUser?.providerData.some(
-        (p) => p.providerId === GoogleAuthProvider.PROVIDER_ID
-      ) ?? false,
-    [currentUser]
+      providerData.some((p) => p.providerId === GoogleAuthProvider.PROVIDER_ID),
+    [providerData]
   );
 
   const handleEmailChange = useCallback((value: string, isValid: boolean) => {

--- a/src/components/settings/ProvidersCard.tsx
+++ b/src/components/settings/ProvidersCard.tsx
@@ -21,14 +21,7 @@ import {
 } from 'firebase/auth';
 import { useRouter } from 'next/router';
 import { enqueueSnackbar } from 'notistack';
-import {
-  memo,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState
-} from 'react';
+import { memo, useCallback, useContext, useMemo, useState } from 'react';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
 import LinkEmailDialog from './LinkEmailDialog';
@@ -37,7 +30,8 @@ import UnlinkProviderDialog from './UnlinkProviderDialog';
 function ProvidersCard() {
   const dictionary = useDictionary();
   const router = useRouter();
-  const { currentUser, setCurrentUser } = useContext(AuthContext);
+  const { currentUser, providerData, setProviderData } =
+    useContext(AuthContext);
 
   const [loading, setLoading] = useState(false);
   const [unlinkDialogOpen, setUnlinkDialogOpen] = useState(false);
@@ -45,13 +39,6 @@ function ProvidersCard() {
     string | null
   >(null);
   const [linkEmailDialogOpen, setLinkEmailDialogOpen] = useState(false);
-  const [providerData, setProviderData] = useState(
-    currentUser?.providerData ?? []
-  );
-
-  useEffect(() => {
-    setProviderData(currentUser?.providerData ?? []);
-  }, [currentUser]);
 
   const googleProvider = useMemo(
     () =>
@@ -110,7 +97,7 @@ function ProvidersCard() {
     } finally {
       setLoading(false);
     }
-  }, [currentUser, router.locale, dictionary]);
+  }, [currentUser, router.locale, dictionary, setProviderData]);
 
   const handleOpenUnlinkDialog = useCallback((providerId: string) => {
     setUnlinkTargetProviderId(providerId);
@@ -123,8 +110,7 @@ function ProvidersCard() {
     try {
       await unlink(currentUser, unlinkTargetProviderId);
       await currentUser.reload();
-      const auth = getAuth();
-      setCurrentUser(auth.currentUser);
+      setProviderData([...currentUser.providerData]);
 
       enqueueSnackbar(dictionary['unlink provider success'], {
         variant: 'success'
@@ -138,7 +124,7 @@ function ProvidersCard() {
       console.error(error);
       enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
     }
-  }, [currentUser, unlinkTargetProviderId, dictionary, setCurrentUser]);
+  }, [currentUser, unlinkTargetProviderId, dictionary, setProviderData]);
 
   return (
     <>

--- a/src/context/AuthContext.ts
+++ b/src/context/AuthContext.ts
@@ -1,9 +1,11 @@
-import type { User } from 'firebase/auth';
+import type { User, UserInfo } from 'firebase/auth';
 import { createContext } from 'react';
 
 type ContextProps = {
   currentUser: User | null;
   setCurrentUser: (user: User | null) => void;
+  providerData: UserInfo[];
+  setProviderData: (data: UserInfo[]) => void;
   isLoading: boolean;
   signInRequired: boolean;
   setSignInRequired: (value: boolean) => void;
@@ -12,6 +14,8 @@ type ContextProps = {
 const AuthContext = createContext<ContextProps>({
   currentUser: null,
   setCurrentUser: () => {},
+  providerData: [],
+  setProviderData: () => {},
   isLoading: true,
   signInRequired: false,
   setSignInRequired: () => {}

--- a/src/hooks/useEmailLinkHandler.ts
+++ b/src/hooks/useEmailLinkHandler.ts
@@ -4,6 +4,7 @@ import {
   type Auth,
   EmailAuthProvider,
   type User,
+  type UserInfo,
   getAuth,
   isSignInWithEmailLink,
   linkWithCredential,
@@ -20,14 +21,13 @@ type Dictionary = { [key: string]: string };
 
 type Args = {
   currentUser: User | null;
-  setCurrentUser: (user: User | null) => void;
+  setProviderData: (data: UserInfo[]) => void;
 };
 
 async function linkEmailProvider(
   currentUser: User,
-  auth: Auth,
   currentUrl: string,
-  setCurrentUser: (user: User | null) => void,
+  setProviderData: (data: UserInfo[]) => void,
   dictionary: Dictionary
 ) {
   const emailForLink = window.localStorage.getItem('emailForLink');
@@ -40,7 +40,7 @@ async function linkEmailProvider(
     );
     await linkWithCredential(currentUser, credential);
     await currentUser.reload();
-    setCurrentUser(auth.currentUser);
+    setProviderData([...currentUser.providerData]);
 
     window.localStorage.removeItem('emailForLink');
     window.localStorage.removeItem('linkProvider');
@@ -120,7 +120,7 @@ async function completeEmailSignIn(
 
 export default function useEmailLinkHandler({
   currentUser,
-  setCurrentUser
+  setProviderData
 }: Args) {
   const router = useRouter();
   const dictionary = useDictionary();
@@ -146,13 +146,7 @@ export default function useEmailLinkHandler({
     } else if (window.localStorage.getItem('linkProvider') === 'true') {
       if (currentUser) {
         handledRef.current = true;
-        linkEmailProvider(
-          currentUser,
-          auth,
-          currentUrl,
-          setCurrentUser,
-          dictionary
-        );
+        linkEmailProvider(currentUser, currentUrl, setProviderData, dictionary);
       }
     } else {
       handledRef.current = true;
@@ -160,7 +154,7 @@ export default function useEmailLinkHandler({
     }
   }, [
     currentUser,
-    setCurrentUser,
+    setProviderData,
     router.isReady,
     router.asPath,
     basePath,


### PR DESCRIPTION
# Summary

Fix the settings page so the provider list updates immediately after linking or unlinking an authentication provider, without requiring a page reload.

# Motivation

Components read `providerData` from the mutable `currentUser.providerData`, whose object reference does not change after `reload()`, so React skipped re-renders and the provider list stayed stale until a full page reload.

# Changes

- Lift `providerData` into AuthContext as independent state (`useState<UserInfo[]>`)
- AuthProvider syncs it via `useEffect` when `currentUser` changes (sign-in/sign-out)
- Link/unlink handlers set `providerData` directly with a spread copy to guarantee a new reference
- `ChangeEmailDialog` and `ProvidersCard` consume `providerData` from context instead of `currentUser.providerData`

🤖 Generated with [Claude Code](https://claude.ai/code)