### PR TITLE
fix: prevent stale mapId on map navigation

### DIFF
--- a/src/components/maps/CustomOverlays.tsx
+++ b/src/components/maps/CustomOverlays.tsx
@@ -53,7 +53,7 @@ function CustomOverlays({ map, reviews, onReviewSaved, onReviewClick }: Props) {
   const { currentUser } = useContext(AuthContext);
   const { profile } = useProfile(currentUser ? currentUser.uid : null);
 
-  const { replace, query } = useRouter();
+  const { replace } = useRouter();
 
   const theme = useTheme();
   const mdUp = useMediaQuery(theme.breakpoints.up('md'));
@@ -146,14 +146,14 @@ function CustomOverlays({ map, reviews, onReviewSaved, onReviewClick }: Props) {
     };
   }, [googleMap, handleIdle, handleMapClick, handleMapRightClick]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: query and replace are intentionally omitted to prevent infinite loops.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: replace is intentionally omitted to prevent infinite loops.
   useEffect(() => {
     if (!googleMap || !map) return;
 
     replace(
       {
         query: {
-          ...query,
+          mapId: map.id,
           lat: map.latitude,
           lng: map.longitude,
           zoom: 17
@@ -165,14 +165,14 @@ function CustomOverlays({ map, reviews, onReviewSaved, onReviewClick }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [googleMap, map]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: query and replace are intentionally omitted to prevent infinite loops.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: replace is intentionally omitted to prevent infinite loops.
   useEffect(() => {
-    if (!googleMap || !currentPlace) return;
+    if (!googleMap || !map || !currentPlace) return;
 
     replace(
       {
         query: {
-          ...query,
+          mapId: map.id,
           lat: currentPlace.location.lat(),
           lng: currentPlace.location.lng(),
           zoom: 17
@@ -182,7 +182,7 @@ function CustomOverlays({ map, reviews, onReviewSaved, onReviewClick }: Props) {
       { shallow: true }
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [googleMap, currentPlace]);
+  }, [googleMap, map, currentPlace]);
 
   const popoverOpen = Boolean(popoverAnchorEl);
 

--- a/src/components/maps/MapReviewList.tsx
+++ b/src/components/maps/MapReviewList.tsx
@@ -22,9 +22,8 @@ type Props = {
 
 function MapReviewList({ reviews, isLoading, onReviewClick }: Props) {
   const dictionary = useDictionary();
-  const { push, query } = useRouter();
+  const { push } = useRouter();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: query and push are intentionally omitted to prevent infinite loops.
   const handleClick = useCallback(
     (review: Review) => {
       if (onReviewClick) {
@@ -33,7 +32,7 @@ function MapReviewList({ reviews, isLoading, onReviewClick }: Props) {
       push(
         {
           query: {
-            ...query,
+            mapId: review.map.id,
             lat: review.latitude,
             lng: review.longitude,
             zoom: 17
@@ -45,8 +44,7 @@ function MapReviewList({ reviews, isLoading, onReviewClick }: Props) {
         }
       );
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [onReviewClick]
+    [onReviewClick, push]
   );
 
   if (!isLoading && reviews.length < 1) {


### PR DESCRIPTION
## Summary

When navigating from map A to map B via search, `router.query` captured in `useEffect` and `useCallback` closures retained the old `mapId` from map A. Calling `replace/push` with `{ ...query }` spread then navigated the user back to map A instead of staying on map B.

The root cause is that `query` was intentionally excluded from dependency arrays in `CustomOverlays.tsx` and `MapReviewList.tsx` to prevent infinite loops — but this left stale `mapId` values in the closures across map transitions.

The fix replaces the `...query` spread with explicit values sourced from props and arguments that are already in the dependency arrays:

- `CustomOverlays`: both `useEffect` blocks now use `map.id` directly, which is derived from the `map` prop already tracked as a dependency
- `MapReviewList`: `handleClick` now uses `review.map.id`, which arrives as a function argument and always reflects the current map

## Test plan

- [ ] Open map A
- [ ] Navigate to map B via the search dialog
- [ ] Click a spot marker or a review in the review list
- [ ] Confirm the URL remains `/maps/<B>?lat=...` and the user stays on map B

🤖 Generated with [Claude Code](https://claude.ai/code)