### PR TITLE
fix: lower map drawer z-index below AppBar

### DIFF
--- a/src/components/maps/MobileMapDrawer.tsx
+++ b/src/components/maps/MobileMapDrawer.tsx
@@ -65,6 +65,7 @@ function MobileMapDrawer({
         onOpen={() => setOpen(true)}
         onClose={() => setOpen(false)}
         swipeAreaWidth={drawerBleeding}
+        sx={{ zIndex: (theme) => theme.zIndex.appBar - 1 }}
         ModalProps={{
           keepMounted: true
         }}

--- a/src/components/maps/ReviewDrawer.tsx
+++ b/src/components/maps/ReviewDrawer.tsx
@@ -72,6 +72,7 @@ function ReviewDrawer({
         onOpen={onOpen}
         onClose={onClose}
         disableSwipeToOpen
+        sx={{ zIndex: (theme) => theme.zIndex.appBar - 1 }}
         ModalProps={{
           slotProps: {
             backdrop: {


### PR DESCRIPTION
# Summary

Sets the z-index of `MobileMapDrawer` and `ReviewDrawer` to `appBar - 1` (1099) so that the AppBar and the navigation drawer always render above them.

# Motivation

All three `SwipeableDrawer` components — the navigation `MobileDrawer`, `MobileMapDrawer`, and `ReviewDrawer` — shared the MUI default z-index of 1200. Because the map page mounts its drawers after the layout, they ended up in front of the navigation drawer when it was opened, and the 105 px bleed area of `MobileMapDrawer` remained visible on top of the navigation panel.

# Changes

- `MobileMapDrawer`: add `sx={{ zIndex: (theme) => theme.zIndex.appBar - 1 }}`
- `ReviewDrawer`: add `sx={{ zIndex: (theme) => theme.zIndex.appBar - 1 }}`

🤖 Generated with [Claude Code](https://claude.ai/code)