### PR TITLE
fix: make bottom review item tappable in drawer

### DIFF
--- a/src/components/maps/MobileMapDrawer.tsx
+++ b/src/components/maps/MobileMapDrawer.tsx
@@ -66,6 +66,9 @@ function MobileMapDrawer({
         onClose={() => setOpen(false)}
         swipeAreaWidth={drawerBleeding}
         sx={{ zIndex: (theme) => theme.zIndex.appBar - 1 }}
+        SwipeAreaProps={{
+          sx: { zIndex: (theme) => theme.zIndex.appBar - 2 }
+        }}
         ModalProps={{
           keepMounted: true
         }}
@@ -73,7 +76,9 @@ function MobileMapDrawer({
           paper: {
             sx: {
               height: `calc(100% - ${drawerBleeding}px)`,
-              overflow: 'visible'
+              overflow: 'visible',
+              display: 'flex',
+              flexDirection: 'column'
             }
           }
         }}
@@ -97,7 +102,7 @@ function MobileMapDrawer({
           />
         </Box>
         <Divider />
-        <Box sx={{ overflowY: 'auto' }}>
+        <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0 }}>
           <MapCardHeader
             map={map}
             action={


### PR DESCRIPTION
# Summary

Fix the bottom item in the map detail ReviewList not responding to taps on mobile.

# Motivation

MUI's `SwipeableDrawer` renders a `SwipeArea` element with `position: fixed; bottom: 0; height: 105px` and `z-index: theme.zIndex.drawer - 1` (1199). The drawer's custom z-index is `theme.zIndex.appBar - 1` (1099). Because the SwipeArea sits above the drawer in the stacking order, it intercepts all touch events in the bottom 105px of the viewport, making the last review item untappable.

# Changes

- Lower SwipeArea's z-index below the drawer via `SwipeAreaProps` so touches reach the list content
- Make the drawer paper a flex column container and constrain the scrollable `Box` with `flex: 1` / `minHeight: 0` to ensure proper scroll behavior

🤖 Generated with [Claude Code](https://claude.ai/code)