### PR TITLE
refactor: migrate large dialogs to useActionState

### DIFF
--- a/src/components/maps/CreateMapDialog.tsx
+++ b/src/components/maps/CreateMapDialog.tsx
@@ -12,7 +12,14 @@ import {
   Typography
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useMemo, useState, useTransition } from 'react';
+import {
+  memo,
+  useActionState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
 import type { AppMap } from '../../../types';
 import { createMap } from '../../actions/maps';
 import useDictionary from '../../hooks/useDictionary';
@@ -36,6 +43,9 @@ type Props = {
   onSaved: (map: AppMap) => void;
 };
 
+type FormState = { error: string | null };
+const initialState: FormState = { error: null };
+
 export default memo(function CreateMapDialog({
   open,
   onClose,
@@ -43,7 +53,6 @@ export default memo(function CreateMapDialog({
 }: Props) {
   const dictionary = useDictionary();
 
-  const [isPending, startTransition] = useTransition();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [thumbnailDataUrl, setThumbnailDataUrl] = useState<string | null>(null);
@@ -74,8 +83,12 @@ export default memo(function CreateMapDialog({
     []
   );
 
-  const handleCreateButtonClick = useCallback(() => {
-    startTransition(async () => {
+  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+    async (_prevState, _formData) => {
+      if (!position) {
+        return { error: dictionary['an error occurred'] };
+      }
+
       try {
         let imageUrl: string | undefined;
 
@@ -105,24 +118,22 @@ export default memo(function CreateMapDialog({
 
           onClose();
           onSaved(result.data);
-        } else {
-          enqueueSnackbar(result.error, { variant: 'error' });
+          return { error: null };
         }
-      } catch (error) {
-        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+
+        return { error: result.error ?? dictionary['an error occurred'] };
+      } catch (_error) {
+        return { error: dictionary['an error occurred'] };
       }
-    });
-  }, [
-    name,
-    description,
-    thumbnailDataUrl,
-    position,
-    isPrivate,
-    isShared,
-    dictionary,
-    onClose,
-    onSaved
-  ]);
+    },
+    initialState
+  );
+
+  useEffect(() => {
+    if (state.error) {
+      enqueueSnackbar(state.error, { variant: 'error' });
+    }
+  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);
@@ -157,67 +168,74 @@ export default memo(function CreateMapDialog({
         transition: { onExited: handleExited }
       }}
     >
-      <DialogTitle>{dictionary['create new map']}</DialogTitle>
-      <DialogContent dividers>
-        <Typography variant="subtitle1" color="text.secondary" gutterBottom>
-          {dictionary.thumbnail}
-        </Typography>
+      <form action={submitAction}>
+        <DialogTitle>{dictionary['create new map']}</DialogTitle>
+        <DialogContent dividers>
+          <Typography variant="subtitle1" color="text.secondary" gutterBottom>
+            {dictionary.thumbnail}
+          </Typography>
 
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          width="fit-content"
-          position="relative"
-          sx={{
-            mb: 2
-          }}
-        >
-          {thumbnailDataUrl ? (
-            <CardMedia
-              sx={{ width: 160, height: 160 }}
-              image={thumbnailDataUrl}
-            />
-          ) : (
-            <Skeleton
-              sx={{ width: 160, height: 160 }}
-              variant="rectangular"
-              animation={false}
-            />
-          )}
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            width="fit-content"
+            position="relative"
+            sx={{
+              mb: 2
+            }}
+          >
+            {thumbnailDataUrl ? (
+              <CardMedia
+                sx={{ width: 160, height: 160 }}
+                image={thumbnailDataUrl}
+              />
+            ) : (
+              <Skeleton
+                sx={{ width: 160, height: 160 }}
+                variant="rectangular"
+                animation={false}
+              />
+            )}
 
-          <Box position="absolute">
-            <AddPhotoButton onChange={handleImagesChange} color="inherit" />
+            <Box position="absolute">
+              <AddPhotoButton onChange={handleImagesChange} color="inherit" />
+            </Box>
           </Box>
-        </Box>
 
-        <MapNameForm onChange={setName} />
-        <MapDescriptionForm onChange={setDescription} />
+          <MapNameForm onChange={setName} />
+          <MapDescriptionForm onChange={setDescription} />
 
-        <Typography variant="subtitle1" color="text.secondary" gutterBottom>
-          {dictionary['center of map']}
-        </Typography>
+          <Typography variant="subtitle1" color="text.secondary" gutterBottom>
+            {dictionary['center of map']}
+          </Typography>
 
-        <PositionForm onChange={setPosition} defaultValue={defaultCenter} />
+          <PositionForm onChange={setPosition} defaultValue={defaultCenter} />
 
-        <Box>
-          <MapOptions onChange={handleMapOptionsChange} />
-        </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} disabled={isPending} color="inherit">
-          {dictionary.cancel}
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleCreateButtonClick}
-          color="secondary"
-          disabled={disabled}
-          loading={isPending}
-        >
-          {dictionary.save}
-        </Button>
-      </DialogActions>
+          <Box>
+            <MapOptions onChange={handleMapOptionsChange} />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            color="inherit"
+          >
+            {dictionary.cancel}
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            color="secondary"
+            disabled={disabled}
+            loading={isPending}
+          >
+            {dictionary.save}
+          </Button>
+        </DialogActions>
+      </form>
     </Dialog>
   );
 });

--- a/src/components/maps/EditMapDialog.tsx
+++ b/src/components/maps/EditMapDialog.tsx
@@ -12,7 +12,14 @@ import {
   Typography
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useMemo, useState, useTransition } from 'react';
+import {
+  memo,
+  useActionState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
 import type { AppMap } from '../../../types';
 import { updateMap } from '../../actions/maps';
 import useDictionary from '../../hooks/useDictionary';
@@ -37,6 +44,9 @@ type Props = {
   currentMap: AppMap | null;
 };
 
+type FormState = { error: string | null };
+const initialState: FormState = { error: null };
+
 export default memo(function EditMapDialog({
   open,
   onClose,
@@ -45,7 +55,6 @@ export default memo(function EditMapDialog({
 }: Props) {
   const dictionary = useDictionary();
 
-  const [isPending, startTransition] = useTransition();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [thumbnailDataUrl, setThumbnailDataUrl] = useState<string | null>(null);
@@ -76,8 +85,12 @@ export default memo(function EditMapDialog({
     []
   );
 
-  const handleEditButtonClick = useCallback(() => {
-    startTransition(async () => {
+  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+    async (_prevState, _formData) => {
+      if (!currentMap || !position) {
+        return { error: dictionary['an error occurred'] };
+      }
+
       try {
         let imageUrl: string | undefined;
 
@@ -92,7 +105,7 @@ export default memo(function EditMapDialog({
           );
         }
 
-        const result = await updateMap(currentMap?.id, {
+        const result = await updateMap(currentMap.id, {
           name,
           description,
           latitude: position.lat,
@@ -109,25 +122,22 @@ export default memo(function EditMapDialog({
 
           onClose();
           onSaved(result.data);
-        } else {
-          enqueueSnackbar(result.error, { variant: 'error' });
+          return { error: null };
         }
-      } catch (error) {
-        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+
+        return { error: result.error ?? dictionary['an error occurred'] };
+      } catch (_error) {
+        return { error: dictionary['an error occurred'] };
       }
-    });
-  }, [
-    name,
-    description,
-    thumbnailDataUrl,
-    position,
-    isPrivate,
-    isShared,
-    currentMap,
-    onClose,
-    onSaved,
-    dictionary
-  ]);
+    },
+    initialState
+  );
+
+  useEffect(() => {
+    if (state.error) {
+      enqueueSnackbar(state.error, { variant: 'error' });
+    }
+  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);
@@ -174,73 +184,80 @@ export default memo(function EditMapDialog({
         transition: { onEnter: setCurrentThumbnail, onExited: handleExited }
       }}
     >
-      <DialogTitle>{dictionary['edit map']}</DialogTitle>
-      <DialogContent dividers>
-        <Typography variant="subtitle1" color="text.secondary" gutterBottom>
-          {dictionary.thumbnail}
-        </Typography>
+      <form action={submitAction}>
+        <DialogTitle>{dictionary['edit map']}</DialogTitle>
+        <DialogContent dividers>
+          <Typography variant="subtitle1" color="text.secondary" gutterBottom>
+            {dictionary.thumbnail}
+          </Typography>
 
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          width="fit-content"
-          position="relative"
-          sx={{
-            mb: 2
-          }}
-        >
-          {thumbnailDataUrl ? (
-            <CardMedia
-              sx={{ width: 160, height: 160 }}
-              image={thumbnailDataUrl}
-            />
-          ) : (
-            <Skeleton
-              sx={{ width: 160, height: 160 }}
-              variant="rectangular"
-              animation={false}
-            />
-          )}
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            width="fit-content"
+            position="relative"
+            sx={{
+              mb: 2
+            }}
+          >
+            {thumbnailDataUrl ? (
+              <CardMedia
+                sx={{ width: 160, height: 160 }}
+                image={thumbnailDataUrl}
+              />
+            ) : (
+              <Skeleton
+                sx={{ width: 160, height: 160 }}
+                variant="rectangular"
+                animation={false}
+              />
+            )}
 
-          <Box position="absolute">
-            <AddPhotoButton onChange={handleImagesChange} color="inherit" />
+            <Box position="absolute">
+              <AddPhotoButton onChange={handleImagesChange} color="inherit" />
+            </Box>
           </Box>
-        </Box>
 
-        <MapNameForm onChange={setName} defaultValue={currentMap?.name} />
-        <MapDescriptionForm
-          onChange={setDescription}
-          defaultValue={currentMap?.description}
-        />
-
-        <Typography variant="subtitle1" color="text.secondary" gutterBottom>
-          {dictionary['center of map']}
-        </Typography>
-
-        <PositionForm onChange={setPosition} defaultValue={defaultCenter} />
-
-        <Box>
-          <MapOptions
-            currentMap={currentMap}
-            onChange={handleMapOptionsChange}
+          <MapNameForm onChange={setName} defaultValue={currentMap?.name} />
+          <MapDescriptionForm
+            onChange={setDescription}
+            defaultValue={currentMap?.description}
           />
-        </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} disabled={isPending} color="inherit">
-          {dictionary.cancel}
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleEditButtonClick}
-          color="secondary"
-          disabled={disabled}
-          loading={isPending}
-        >
-          {dictionary.save}
-        </Button>
-      </DialogActions>
+
+          <Typography variant="subtitle1" color="text.secondary" gutterBottom>
+            {dictionary['center of map']}
+          </Typography>
+
+          <PositionForm onChange={setPosition} defaultValue={defaultCenter} />
+
+          <Box>
+            <MapOptions
+              currentMap={currentMap}
+              onChange={handleMapOptionsChange}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            color="inherit"
+          >
+            {dictionary.cancel}
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            color="secondary"
+            disabled={disabled}
+            loading={isPending}
+          >
+            {dictionary.save}
+          </Button>
+        </DialogActions>
+      </form>
     </Dialog>
   );
 });

--- a/src/components/maps/PositionForm.tsx
+++ b/src/components/maps/PositionForm.tsx
@@ -56,6 +56,7 @@ function PositionForm({ onChange, defaultValue }: Props) {
 
       <Stack direction="row" spacing={1}>
         <Button
+          type="button"
           onClick={() => setEditPosition(false)}
           fullWidth
           variant="outlined"
@@ -65,6 +66,7 @@ function PositionForm({ onChange, defaultValue }: Props) {
           {dictionary.cancel}
         </Button>
         <Button
+          type="button"
           startIcon={<Done />}
           onClick={handleSave}
           fullWidth

--- a/src/components/profiles/EditProfileDialog.tsx
+++ b/src/components/profiles/EditProfileDialog.tsx
@@ -12,7 +12,14 @@ import {
   Typography
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useMemo, useState, useTransition } from 'react';
+import {
+  memo,
+  useActionState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
 import type { Profile } from '../../../types';
 import { updateProfile } from '../../actions/users';
 import useDictionary from '../../hooks/useDictionary';
@@ -35,6 +42,9 @@ type Props = {
   onSaved: () => void;
 };
 
+type FormState = { error: string | null };
+const initialState: FormState = { error: null };
+
 export default memo(function EditProfileDialog({
   currentProfile,
   open,
@@ -43,7 +53,6 @@ export default memo(function EditProfileDialog({
 }: Props) {
   const dictionary = useDictionary();
 
-  const [isPending, startTransition] = useTransition();
   const [name, setName] = useState<string | undefined>(undefined);
   const [biography, setBiography] = useState<string | undefined>(undefined);
   const [thumbnailDataUrl, setThumbnailDataUrl] = useState<string | null>(null);
@@ -58,8 +67,12 @@ export default memo(function EditProfileDialog({
     }
   }, []);
 
-  const handleEditButtonClick = useCallback(() => {
-    startTransition(async () => {
+  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+    async (_prevState, _formData) => {
+      if (!currentProfile) {
+        return { error: dictionary['an error occurred'] };
+      }
+
       try {
         let imagePath: string | undefined;
 
@@ -74,7 +87,7 @@ export default memo(function EditProfileDialog({
           );
         }
 
-        const result = await updateProfile(currentProfile?.id, {
+        const result = await updateProfile(currentProfile.id, {
           name,
           biography,
           image_path: imagePath
@@ -87,22 +100,22 @@ export default memo(function EditProfileDialog({
 
           onClose();
           onSaved();
-        } else {
-          enqueueSnackbar(result.error, { variant: 'error' });
+          return { error: null };
         }
-      } catch (error) {
-        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+
+        return { error: result.error ?? dictionary['an error occurred'] };
+      } catch (_error) {
+        return { error: dictionary['an error occurred'] };
       }
-    });
-  }, [
-    currentProfile,
-    name,
-    biography,
-    thumbnailDataUrl,
-    onClose,
-    onSaved,
-    dictionary
-  ]);
+    },
+    initialState
+  );
+
+  useEffect(() => {
+    if (state.error) {
+      enqueueSnackbar(state.error, { variant: 'error' });
+    }
+  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);
@@ -135,63 +148,70 @@ export default memo(function EditProfileDialog({
         transition: { onEnter: setCurrentThumbnail, onExited: handleExited }
       }}
     >
-      <DialogTitle>{dictionary['edit profile']}</DialogTitle>
-      <DialogContent dividers>
-        <Typography variant="subtitle1" color="text.secondary" gutterBottom>
-          {dictionary.thumbnail}
-        </Typography>
+      <form action={submitAction}>
+        <DialogTitle>{dictionary['edit profile']}</DialogTitle>
+        <DialogContent dividers>
+          <Typography variant="subtitle1" color="text.secondary" gutterBottom>
+            {dictionary.thumbnail}
+          </Typography>
 
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          width="fit-content"
-          position="relative"
-          sx={{
-            mb: 2
-          }}
-        >
-          {thumbnailDataUrl ? (
-            <CardMedia
-              sx={{ width: 160, height: 160 }}
-              image={thumbnailDataUrl}
-            />
-          ) : (
-            <Skeleton
-              sx={{ width: 160, height: 160 }}
-              variant="rectangular"
-              animation={false}
-            />
-          )}
+          <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            width="fit-content"
+            position="relative"
+            sx={{
+              mb: 2
+            }}
+          >
+            {thumbnailDataUrl ? (
+              <CardMedia
+                sx={{ width: 160, height: 160 }}
+                image={thumbnailDataUrl}
+              />
+            ) : (
+              <Skeleton
+                sx={{ width: 160, height: 160 }}
+                variant="rectangular"
+                animation={false}
+              />
+            )}
 
-          <Box position="absolute">
-            <AddPhotoButton onChange={handleImagesChange} color="inherit" />
+            <Box position="absolute">
+              <AddPhotoButton onChange={handleImagesChange} color="inherit" />
+            </Box>
           </Box>
-        </Box>
 
-        <ProfileNameForm
-          onChange={setName}
-          defaultValue={currentProfile?.name}
-        />
-        <BiographyForm
-          onChange={setBiography}
-          defaultValue={currentProfile?.biography}
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} disabled={isPending} color="inherit">
-          {dictionary.cancel}
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleEditButtonClick}
-          color="secondary"
-          disabled={disabled}
-          loading={isPending}
-        >
-          {dictionary.save}
-        </Button>
-      </DialogActions>
+          <ProfileNameForm
+            onChange={setName}
+            defaultValue={currentProfile?.name}
+          />
+          <BiographyForm
+            onChange={setBiography}
+            defaultValue={currentProfile?.biography}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            color="inherit"
+          >
+            {dictionary.cancel}
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            color="secondary"
+            disabled={disabled}
+            loading={isPending}
+          >
+            {dictionary.save}
+          </Button>
+        </DialogActions>
+      </form>
     </Dialog>
   );
 });

--- a/src/components/reviews/CreateReviewDialog.tsx
+++ b/src/components/reviews/CreateReviewDialog.tsx
@@ -9,7 +9,14 @@ import {
   type SlideProps
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useMemo, useState, useTransition } from 'react';
+import {
+  memo,
+  useActionState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
 import type { AppMap } from '../../../types';
 import { createReview } from '../../actions/reviews';
 import useDictionary from '../../hooks/useDictionary';
@@ -38,6 +45,9 @@ type Props = {
   pinnedPosition?: google.maps.LatLng | null;
 };
 
+type FormState = { error: string | null };
+const initialState: FormState = { error: null };
+
 export default memo(function CreateReviewDialog({
   open,
   onClose,
@@ -50,8 +60,6 @@ export default memo(function CreateReviewDialog({
 }: Props) {
   const dictionary = useDictionary();
 
-  const [isPending, startTransition] = useTransition();
-
   const [name, setName] = useState('');
   const [comment, setComment] = useState('');
   const [dataUrls, setDataUrls] = useState<string[]>([]);
@@ -62,6 +70,54 @@ export default memo(function CreateReviewDialog({
   const disabled = useMemo(() => {
     return !(name && comment && map && position);
   }, [name, comment, map, position]);
+
+  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+    async (_prevState, _formData) => {
+      if (!map || !position) {
+        return { error: dictionary['an error occurred'] };
+      }
+
+      try {
+        const photos = [];
+
+        for (const dataUrl of dataUrls) {
+          const fileName = `images/${self.crypto.randomUUID()}.jpg`;
+          const url = await uploadToStorage(dataUrl, fileName, 'data_url');
+
+          photos.push({ url: url });
+        }
+
+        const result = await createReview(map.id, {
+          name,
+          comment,
+          latitude: position.lat,
+          longitude: position.lng,
+          images: photos
+        });
+
+        if (result.success) {
+          enqueueSnackbar(dictionary['create review success'], {
+            variant: 'success'
+          });
+
+          onClose();
+          onSaved();
+          return { error: null };
+        }
+
+        return { error: result.error ?? dictionary['an error occurred'] };
+      } catch (_error) {
+        return { error: dictionary['an error occurred'] };
+      }
+    },
+    initialState
+  );
+
+  useEffect(() => {
+    if (state.error) {
+      enqueueSnackbar(state.error, { variant: 'error' });
+    }
+  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);
@@ -88,42 +144,6 @@ export default memo(function CreateReviewDialog({
     },
     [dataUrls]
   );
-
-  const handleCreateButtonClick = useCallback(() => {
-    startTransition(async () => {
-      try {
-        const photos = [];
-
-        for (const dataUrl of dataUrls) {
-          const fileName = `images/${self.crypto.randomUUID()}.jpg`;
-          const url = await uploadToStorage(dataUrl, fileName, 'data_url');
-
-          photos.push({ url: url });
-        }
-
-        const result = await createReview(map?.id, {
-          name,
-          comment,
-          latitude: position.lat,
-          longitude: position.lng,
-          images: photos
-        });
-
-        if (result.success) {
-          enqueueSnackbar(dictionary['create review success'], {
-            variant: 'success'
-          });
-
-          onClose();
-          onSaved();
-        } else {
-          enqueueSnackbar(result.error, { variant: 'error' });
-        }
-      } catch (error) {
-        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
-      }
-    });
-  }, [map, name, comment, position, dataUrls, onClose, onSaved, dictionary]);
 
   const defaultPositionFromPlace = useMemo(() => {
     if (!place) {
@@ -175,54 +195,64 @@ export default memo(function CreateReviewDialog({
         transition: { onExited: handleExited }
       }}
     >
-      <DialogTitle>{dictionary['create new post']}</DialogTitle>
-      <DialogContent dividers>
-        <Box sx={{ mb: 2 }}>
-          <PositionForm
-            defaultValue={
-              defaultPositionFromPlace ||
-              defaultPositionFromGeolocation ||
-              defaultPositionFromPinnedPosition
-            }
-            onChange={setPosition}
+      <form action={submitAction}>
+        <DialogTitle>{dictionary['create new post']}</DialogTitle>
+        <DialogContent dividers>
+          <Box sx={{ mb: 2 }}>
+            <PositionForm
+              defaultValue={
+                defaultPositionFromPlace ||
+                defaultPositionFromGeolocation ||
+                defaultPositionFromPinnedPosition
+              }
+              onChange={setPosition}
+            />
+          </Box>
+
+          <ReviewNameForm
+            defaultValue={place?.displayName}
+            onChange={setName}
           />
-        </Box>
 
-        <ReviewNameForm defaultValue={place?.displayName} onChange={setName} />
+          <ReviewDescriptionForm onChange={setComment} />
 
-        <ReviewDescriptionForm onChange={setComment} />
-
-        <PhotoPreviewList dataUrls={dataUrls} onDelete={handleImageDelete} />
-      </DialogContent>
-      <DialogActions
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: '1fr auto'
-        }}
-      >
-        <AddPhotoButton onChange={handleImagesChange} multiple />
-
-        <Box
+          <PhotoPreviewList dataUrls={dataUrls} onDelete={handleImageDelete} />
+        </DialogContent>
+        <DialogActions
           sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1
+            display: 'grid',
+            gridTemplateColumns: '1fr auto'
           }}
         >
-          <Button onClick={onClose} disabled={isPending} color="inherit">
-            {dictionary.cancel}
-          </Button>
-          <Button
-            variant="contained"
-            onClick={handleCreateButtonClick}
-            color="secondary"
-            disabled={disabled}
-            loading={isPending}
+          <AddPhotoButton onChange={handleImagesChange} multiple />
+
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1
+            }}
           >
-            {dictionary.save}
-          </Button>
-        </Box>
-      </DialogActions>
+            <Button
+              type="button"
+              onClick={onClose}
+              disabled={isPending}
+              color="inherit"
+            >
+              {dictionary.cancel}
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              color="secondary"
+              disabled={disabled}
+              loading={isPending}
+            >
+              {dictionary.save}
+            </Button>
+          </Box>
+        </DialogActions>
+      </form>
     </Dialog>
   );
 });

--- a/src/components/reviews/EditReviewDialog.tsx
+++ b/src/components/reviews/EditReviewDialog.tsx
@@ -9,7 +9,14 @@ import {
   type SlideProps
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useMemo, useState, useTransition } from 'react';
+import {
+  memo,
+  useActionState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
 import type { Review } from '../../../types';
 import { updateReview } from '../../actions/reviews';
 import useDictionary from '../../hooks/useDictionary';
@@ -34,6 +41,9 @@ type Props = {
   currentReview: Review | null;
 };
 
+type FormState = { error: string | null };
+const initialState: FormState = { error: null };
+
 export default memo(function EditReviewDialog({
   open,
   onClose,
@@ -42,7 +52,6 @@ export default memo(function EditReviewDialog({
 }: Props) {
   const dictionary = useDictionary();
 
-  const [isPending, startTransition] = useTransition();
   const [name, setName] = useState('');
   const [comment, setComment] = useState('');
   const [dataUrls, setDataUrls] = useState<string[]>([]);
@@ -53,6 +62,64 @@ export default memo(function EditReviewDialog({
   const disabled = useMemo(() => {
     return !(name && comment && position);
   }, [name, comment, position]);
+
+  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+    async (_prevState, _formData) => {
+      if (!currentReview || !position) {
+        return { error: dictionary['an error occurred'] };
+      }
+
+      try {
+        const photos = [];
+
+        for (const dataUrl of dataUrls) {
+          const url = new URL(dataUrl);
+
+          if (url.protocol === 'data:') {
+            const fileName = `images/${self.crypto.randomUUID()}.jpg`;
+            const uploaded = await uploadToStorage(
+              dataUrl,
+              fileName,
+              'data_url'
+            );
+
+            photos.push({ url: uploaded });
+          } else {
+            photos.push({ url: dataUrl });
+          }
+        }
+
+        const result = await updateReview(currentReview.id, {
+          name,
+          comment,
+          latitude: position.lat,
+          longitude: position.lng,
+          images: photos
+        });
+
+        if (result.success) {
+          enqueueSnackbar(dictionary['edit review success'], {
+            variant: 'success'
+          });
+
+          onClose();
+          onSaved();
+          return { error: null };
+        }
+
+        return { error: result.error ?? dictionary['an error occurred'] };
+      } catch (_error) {
+        return { error: dictionary['an error occurred'] };
+      }
+    },
+    initialState
+  );
+
+  useEffect(() => {
+    if (state.error) {
+      enqueueSnackbar(state.error, { variant: 'error' });
+    }
+  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);
@@ -75,57 +142,6 @@ export default memo(function EditReviewDialog({
     },
     [dataUrls]
   );
-
-  const handleSaveClick = useCallback(() => {
-    startTransition(async () => {
-      try {
-        const photos = [];
-
-        for (const dataUrl of dataUrls) {
-          const url = new URL(dataUrl);
-
-          if (url.protocol === 'data:') {
-            const fileName = `images/${self.crypto.randomUUID()}.jpg`;
-            const url = await uploadToStorage(dataUrl, fileName, 'data_url');
-
-            photos.push({ url: url });
-          } else {
-            photos.push({ url: dataUrl });
-          }
-        }
-
-        const result = await updateReview(currentReview?.id, {
-          name,
-          comment,
-          latitude: position.lat,
-          longitude: position.lng,
-          images: photos
-        });
-
-        if (result.success) {
-          enqueueSnackbar(dictionary['edit review success'], {
-            variant: 'success'
-          });
-
-          onClose();
-          onSaved();
-        } else {
-          enqueueSnackbar(result.error, { variant: 'error' });
-        }
-      } catch (error) {
-        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
-      }
-    });
-  }, [
-    name,
-    comment,
-    dataUrls,
-    currentReview,
-    position,
-    onClose,
-    onSaved,
-    dictionary
-  ]);
 
   const setCurrentImages = useCallback(async () => {
     if (!currentReview) {
@@ -163,50 +179,63 @@ export default memo(function EditReviewDialog({
         transition: { onEnter: setCurrentImages, onExited: handleExited }
       }}
     >
-      <DialogTitle>{dictionary['edit post']}</DialogTitle>
-      <DialogContent dividers>
-        <Box sx={{ mb: 2 }}>
-          <PositionForm onChange={setPosition} defaultValue={defaultPosition} />
-        </Box>
+      <form action={submitAction}>
+        <DialogTitle>{dictionary['edit post']}</DialogTitle>
+        <DialogContent dividers>
+          <Box sx={{ mb: 2 }}>
+            <PositionForm
+              onChange={setPosition}
+              defaultValue={defaultPosition}
+            />
+          </Box>
 
-        <ReviewNameForm defaultValue={currentReview?.name} onChange={setName} />
+          <ReviewNameForm
+            defaultValue={currentReview?.name}
+            onChange={setName}
+          />
 
-        <ReviewDescriptionForm
-          defaultValue={currentReview?.comment}
-          onChange={setComment}
-        />
+          <ReviewDescriptionForm
+            defaultValue={currentReview?.comment}
+            onChange={setComment}
+          />
 
-        <PhotoPreviewList dataUrls={dataUrls} onDelete={handleImageDelete} />
-      </DialogContent>
-      <DialogActions
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: '1fr auto'
-        }}
-      >
-        <AddPhotoButton onChange={handleImagesChange} multiple />
-
-        <Box
+          <PhotoPreviewList dataUrls={dataUrls} onDelete={handleImageDelete} />
+        </DialogContent>
+        <DialogActions
           sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1
+            display: 'grid',
+            gridTemplateColumns: '1fr auto'
           }}
         >
-          <Button onClick={onClose} disabled={isPending} color="inherit">
-            {dictionary.cancel}
-          </Button>
-          <Button
-            variant="contained"
-            onClick={handleSaveClick}
-            color="secondary"
-            disabled={disabled}
-            loading={isPending}
+          <AddPhotoButton onChange={handleImagesChange} multiple />
+
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1
+            }}
           >
-            {dictionary.save}
-          </Button>
-        </Box>
-      </DialogActions>
+            <Button
+              type="button"
+              onClick={onClose}
+              disabled={isPending}
+              color="inherit"
+            >
+              {dictionary.cancel}
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              color="secondary"
+              disabled={disabled}
+              loading={isPending}
+            >
+              {dictionary.save}
+            </Button>
+          </Box>
+        </DialogActions>
+      </form>
     </Dialog>
   );
 });


### PR DESCRIPTION
# Summary

Migrate the five large Create/Edit dialogs (Review, Map, Profile) and `PositionForm` from `useTransition` + `useCallback` to `useActionState` + `&lt;form action={submitAction}&gt;`. Aligns the form-handling pattern with `IssueDialog`, which adopted it in PR #1053.

# Motivation

PR #1053 introduced the `useActionState` pattern for `IssueDialog` but the larger dialogs were left on the older pattern because they involve image upload and multiple fields. Catching them up now keeps form handling uniform across the codebase, eliminates the seven-to-nine-entry `useCallback` dependency lists that grew with every field, and restores native form semantics (Enter submits).

# Changes

- Wrap dialog bodies in `&lt;form action={submitAction}&gt;` and inline the submit logic
- Replace `useTransition` + `handle*ButtonClick` with `useActionState`-driven action functions; surface `state.error` via `useEffect` snackbar
- Guard each action with an early return when its required props (`map`, `position`, `currentMap`, `currentReview`, `currentProfile`) are missing, so id and coordinate accesses can drop `?.` and match the Server Action signatures
- Set explicit `type="button"` on Cancel buttons and `type="submit"` on Save buttons
- Add `type="button"` to `PositionForm`'s inner Cancel/Save so they no longer fire the parent form once it exists

# Testing

- `pnpm biome ci ./src`
- `pnpm exec tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.ai/code)