### PR TITLE
refactor: inline action error snackbars in dialogs

### DIFF
--- a/src/components/common/IssueDialog.tsx
+++ b/src/components/common/IssueDialog.tsx
@@ -16,7 +16,6 @@ import {
   memo,
   useActionState,
   useCallback,
-  useEffect,
   useId,
   useState
 } from 'react';
@@ -30,12 +29,6 @@ type Props = {
   contentType: string;
 };
 
-type IssueFormState = {
-  error: string | null;
-};
-
-const initialState: IssueFormState = { error: null };
-
 const IssueDialog = ({ open, onClose, contentId, contentType }: Props) => {
   const dictionary = useDictionary();
   const formId = useId();
@@ -44,39 +37,37 @@ const IssueDialog = ({ open, onClose, contentId, contentType }: Props) => {
 
   const [reason, setReason] = useState<string | undefined>(undefined);
 
-  const [state, submitAction, isPending] = useActionState<
-    IssueFormState,
-    FormData
-  >(async (_prevState, formData) => {
-    const submittedReason = formData.get(reasonFieldName)?.toString();
+  const [, submitAction, isPending] = useActionState<null, FormData>(
+    async (_prevState, formData) => {
+      const submittedReason = formData.get(reasonFieldName)?.toString();
 
-    try {
-      const result = await createIssue({
-        content_id: contentId,
-        content_type: contentType,
-        reason_id: Number(submittedReason)
-      });
-
-      if (result.success) {
-        enqueueSnackbar(dictionary['create issue success'], {
-          variant: 'success'
+      try {
+        const result = await createIssue({
+          content_id: contentId,
+          content_type: contentType,
+          reason_id: Number(submittedReason)
         });
 
-        onClose();
-        return { error: null };
+        if (result.success) {
+          enqueueSnackbar(dictionary['create issue success'], {
+            variant: 'success'
+          });
+
+          onClose();
+          return null;
+        }
+
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+        return null;
+      } catch (_error) {
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
-
-      return { error: result.error ?? dictionary['an error occurred'] };
-    } catch (_error) {
-      return { error: dictionary['an error occurred'] };
-    }
-  }, initialState);
-
-  useEffect(() => {
-    if (state.error) {
-      enqueueSnackbar(state.error, { variant: 'error' });
-    }
-  }, [state]);
+    },
+    null
+  );
 
   const handleReasonChange = useCallback(
     (_event: ChangeEvent<HTMLInputElement>, value: string) => {

--- a/src/components/maps/CreateMapDialog.tsx
+++ b/src/components/maps/CreateMapDialog.tsx
@@ -12,14 +12,7 @@ import {
   Typography
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import {
-  memo,
-  useActionState,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState
-} from 'react';
+import { memo, useActionState, useCallback, useMemo, useState } from 'react';
 import type { AppMap } from '../../../types';
 import { createMap } from '../../actions/maps';
 import useDictionary from '../../hooks/useDictionary';
@@ -42,9 +35,6 @@ type Props = {
   onClose: () => void;
   onSaved: (map: AppMap) => void;
 };
-
-type FormState = { error: string | null };
-const initialState: FormState = { error: null };
 
 export default memo(function CreateMapDialog({
   open,
@@ -83,10 +73,11 @@ export default memo(function CreateMapDialog({
     []
   );
 
-  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+  const [, submitAction, isPending] = useActionState<null, FormData>(
     async (_prevState, _formData) => {
       if (!position) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
 
       try {
@@ -118,22 +109,20 @@ export default memo(function CreateMapDialog({
 
           onClose();
           onSaved(result.data);
-          return { error: null };
+          return null;
         }
 
-        return { error: result.error ?? dictionary['an error occurred'] };
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+        return null;
       } catch (_error) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
     },
-    initialState
+    null
   );
-
-  useEffect(() => {
-    if (state.error) {
-      enqueueSnackbar(state.error, { variant: 'error' });
-    }
-  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);

--- a/src/components/maps/DeleteMapDialog.tsx
+++ b/src/components/maps/DeleteMapDialog.tsx
@@ -9,7 +9,7 @@ import {
   FormControlLabel
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useState } from 'react';
+import { memo, useActionState, useState } from 'react';
 import type { AppMap } from '../../../types';
 import { deleteMap } from '../../actions/maps';
 import useDictionary from '../../hooks/useDictionary';
@@ -25,41 +25,38 @@ const DeleteMapDialog = ({ map, open, onClose, onDeleted }: Props) => {
   const dictionary = useDictionary();
 
   const [check, setCheck] = useState(false);
-  const [disabled, setDisabled] = useState(true);
-  const [loading, setLoading] = useState(false);
 
-  const handleCheckChange = useCallback(() => {
-    setCheck(!check);
-    setDisabled(!disabled);
-  }, [check, disabled]);
-
-  const handleExited = useCallback(() => {
-    setCheck(false);
-    setDisabled(true);
-  }, []);
-
-  const handleDeleteButtonClick = useCallback(async () => {
-    setLoading(true);
-
-    try {
-      const result = await deleteMap(map?.id);
-
-      if (result.success) {
-        enqueueSnackbar(dictionary['delete map success'], {
-          variant: 'success'
-        });
-
-        onClose();
-        onDeleted();
-      } else {
-        enqueueSnackbar(result.error, { variant: 'error' });
+  const [, submitAction, isPending] = useActionState<null, FormData>(
+    async (_prevState, _formData) => {
+      if (!map) {
+        enqueueSnackbar(dictionary['delete map failed'], { variant: 'error' });
+        return null;
       }
-    } catch (error) {
-      enqueueSnackbar(dictionary['delete map failed'], { variant: 'error' });
-    } finally {
-      setLoading(false);
-    }
-  }, [map, onClose, onDeleted, dictionary]);
+
+      try {
+        const result = await deleteMap(map.id);
+
+        if (result.success) {
+          enqueueSnackbar(dictionary['delete map success'], {
+            variant: 'success'
+          });
+
+          onClose();
+          onDeleted();
+          return null;
+        }
+
+        enqueueSnackbar(result.error ?? dictionary['delete map failed'], {
+          variant: 'error'
+        });
+        return null;
+      } catch (_error) {
+        enqueueSnackbar(dictionary['delete map failed'], { variant: 'error' });
+        return null;
+      }
+    },
+    null
+  );
 
   return (
     <Dialog
@@ -68,41 +65,48 @@ const DeleteMapDialog = ({ map, open, onClose, onDeleted }: Props) => {
       fullWidth
       slotProps={{
         transition: {
-          onExited: handleExited
+          onExited: () => setCheck(false)
         }
       }}
     >
-      <DialogTitle>{dictionary['sure to delete map']}</DialogTitle>
-      <DialogContent>
-        <DialogContentText gutterBottom>
-          {dictionary['delete map detail']}
-        </DialogContentText>
+      <form action={submitAction}>
+        <DialogTitle>{dictionary['sure to delete map']}</DialogTitle>
+        <DialogContent>
+          <DialogContentText gutterBottom>
+            {dictionary['delete map detail']}
+          </DialogContentText>
 
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={check}
-              onChange={handleCheckChange}
-              color="success"
-            />
-          }
-          label={dictionary['understand this cannot be undone']}
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} color="inherit">
-          {dictionary.cancel}
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleDeleteButtonClick}
-          color="error"
-          disabled={disabled}
-          loading={loading}
-        >
-          {dictionary.delete}
-        </Button>
-      </DialogActions>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={check}
+                onChange={() => setCheck((prev) => !prev)}
+                color="success"
+              />
+            }
+            label={dictionary['understand this cannot be undone']}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            type="button"
+            onClick={onClose}
+            color="inherit"
+            disabled={isPending}
+          >
+            {dictionary.cancel}
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            color="error"
+            disabled={!check}
+            loading={isPending}
+          >
+            {dictionary.delete}
+          </Button>
+        </DialogActions>
+      </form>
     </Dialog>
   );
 };

--- a/src/components/maps/EditMapDialog.tsx
+++ b/src/components/maps/EditMapDialog.tsx
@@ -12,14 +12,7 @@ import {
   Typography
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import {
-  memo,
-  useActionState,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState
-} from 'react';
+import { memo, useActionState, useCallback, useMemo, useState } from 'react';
 import type { AppMap } from '../../../types';
 import { updateMap } from '../../actions/maps';
 import useDictionary from '../../hooks/useDictionary';
@@ -43,9 +36,6 @@ type Props = {
   onSaved: (map: AppMap) => void;
   currentMap: AppMap | null;
 };
-
-type FormState = { error: string | null };
-const initialState: FormState = { error: null };
 
 export default memo(function EditMapDialog({
   open,
@@ -85,10 +75,11 @@ export default memo(function EditMapDialog({
     []
   );
 
-  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+  const [, submitAction, isPending] = useActionState<null, FormData>(
     async (_prevState, _formData) => {
       if (!currentMap || !position) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
 
       try {
@@ -122,22 +113,20 @@ export default memo(function EditMapDialog({
 
           onClose();
           onSaved(result.data);
-          return { error: null };
+          return null;
         }
 
-        return { error: result.error ?? dictionary['an error occurred'] };
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+        return null;
       } catch (_error) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
     },
-    initialState
+    null
   );
-
-  useEffect(() => {
-    if (state.error) {
-      enqueueSnackbar(state.error, { variant: 'error' });
-    }
-  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);

--- a/src/components/profiles/EditProfileDialog.tsx
+++ b/src/components/profiles/EditProfileDialog.tsx
@@ -12,14 +12,7 @@ import {
   Typography
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import {
-  memo,
-  useActionState,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState
-} from 'react';
+import { memo, useActionState, useCallback, useMemo, useState } from 'react';
 import type { Profile } from '../../../types';
 import { updateProfile } from '../../actions/users';
 import useDictionary from '../../hooks/useDictionary';
@@ -41,9 +34,6 @@ type Props = {
   onClose: () => void;
   onSaved: () => void;
 };
-
-type FormState = { error: string | null };
-const initialState: FormState = { error: null };
 
 export default memo(function EditProfileDialog({
   currentProfile,
@@ -67,10 +57,11 @@ export default memo(function EditProfileDialog({
     }
   }, []);
 
-  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+  const [, submitAction, isPending] = useActionState<null, FormData>(
     async (_prevState, _formData) => {
       if (!currentProfile) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
 
       try {
@@ -100,22 +91,20 @@ export default memo(function EditProfileDialog({
 
           onClose();
           onSaved();
-          return { error: null };
+          return null;
         }
 
-        return { error: result.error ?? dictionary['an error occurred'] };
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+        return null;
       } catch (_error) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
     },
-    initialState
+    null
   );
-
-  useEffect(() => {
-    if (state.error) {
-      enqueueSnackbar(state.error, { variant: 'error' });
-    }
-  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);

--- a/src/components/reviews/CreateReviewDialog.tsx
+++ b/src/components/reviews/CreateReviewDialog.tsx
@@ -9,14 +9,7 @@ import {
   type SlideProps
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import {
-  memo,
-  useActionState,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState
-} from 'react';
+import { memo, useActionState, useCallback, useMemo, useState } from 'react';
 import type { AppMap } from '../../../types';
 import { createReview } from '../../actions/reviews';
 import useDictionary from '../../hooks/useDictionary';
@@ -45,9 +38,6 @@ type Props = {
   pinnedPosition?: google.maps.LatLng | null;
 };
 
-type FormState = { error: string | null };
-const initialState: FormState = { error: null };
-
 export default memo(function CreateReviewDialog({
   open,
   onClose,
@@ -71,10 +61,11 @@ export default memo(function CreateReviewDialog({
     return !(name && comment && map && position);
   }, [name, comment, map, position]);
 
-  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+  const [, submitAction, isPending] = useActionState<null, FormData>(
     async (_prevState, _formData) => {
       if (!map || !position) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
 
       try {
@@ -102,22 +93,20 @@ export default memo(function CreateReviewDialog({
 
           onClose();
           onSaved();
-          return { error: null };
+          return null;
         }
 
-        return { error: result.error ?? dictionary['an error occurred'] };
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+        return null;
       } catch (_error) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
     },
-    initialState
+    null
   );
-
-  useEffect(() => {
-    if (state.error) {
-      enqueueSnackbar(state.error, { variant: 'error' });
-    }
-  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);

--- a/src/components/reviews/DeleteCommentDialog.tsx
+++ b/src/components/reviews/DeleteCommentDialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useState } from 'react';
+import { memo, useActionState } from 'react';
 import type { Comment } from '../../../types';
 import { deleteComment } from '../../actions/comments';
 import useDictionary from '../../hooks/useDictionary';
@@ -22,52 +22,61 @@ type Props = {
 const DeleteCommentDialog = ({ comment, open, onClose, onDeleted }: Props) => {
   const dictionary = useDictionary();
 
-  const [loading, setLoading] = useState(false);
-
-  const handleDeleteButtonClick = useCallback(async () => {
-    setLoading(true);
-
-    try {
-      const result = await deleteComment(comment?.review_id, comment?.id);
-
-      if (result.success) {
-        enqueueSnackbar(dictionary['delete comment success'], {
-          variant: 'success'
-        });
-
-        onClose();
-        onDeleted();
-      } else {
-        enqueueSnackbar(result.error, { variant: 'error' });
+  const [, submitAction, isPending] = useActionState<null, FormData>(
+    async (_prevState, _formData) => {
+      if (!comment) {
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
-    } catch (error) {
-      console.error(error);
-      enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
-    } finally {
-      setLoading(false);
-    }
-  }, [comment, onClose, onDeleted, dictionary]);
+
+      try {
+        const result = await deleteComment(comment.review_id, comment.id);
+
+        if (result.success) {
+          enqueueSnackbar(dictionary['delete comment success'], {
+            variant: 'success'
+          });
+
+          onClose();
+          onDeleted();
+          return null;
+        }
+
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+        return null;
+      } catch (_error) {
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
+      }
+    },
+    null
+  );
 
   return (
     <Dialog open={open} onClose={onClose}>
-      <DialogTitle>{dictionary['delete comment']}</DialogTitle>
-      <DialogContent>
-        <DialogContentText>
-          {dictionary['sure to delete comment']}
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} disabled={loading} color="inherit">
-          {dictionary.cancel}
-        </Button>
-        <Button
-          onClick={handleDeleteButtonClick}
-          color="error"
-          loading={loading}
-        >
-          {dictionary.delete}
-        </Button>
-      </DialogActions>
+      <form action={submitAction}>
+        <DialogTitle>{dictionary['delete comment']}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {dictionary['sure to delete comment']}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            color="inherit"
+          >
+            {dictionary.cancel}
+          </Button>
+          <Button type="submit" color="error" loading={isPending}>
+            {dictionary.delete}
+          </Button>
+        </DialogActions>
+      </form>
     </Dialog>
   );
 };

--- a/src/components/reviews/DeleteReviewDialog.tsx
+++ b/src/components/reviews/DeleteReviewDialog.tsx
@@ -9,7 +9,7 @@ import {
   FormControlLabel
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useState } from 'react';
+import { memo, useActionState, useState } from 'react';
 import type { Review } from '../../../types';
 import { deleteReview } from '../../actions/reviews';
 import useDictionary from '../../hooks/useDictionary';
@@ -25,41 +25,42 @@ const DeleteReviewDialog = ({ review, open, onClose, onDeleted }: Props) => {
   const dictionary = useDictionary();
 
   const [check, setCheck] = useState(false);
-  const [disabled, setDisabled] = useState(true);
-  const [loading, setLoading] = useState(false);
 
-  const handleCheckChange = useCallback(() => {
-    setCheck(!check);
-    setDisabled(!disabled);
-  }, [check, disabled]);
-
-  const handleExited = useCallback(() => {
-    setCheck(false);
-    setDisabled(true);
-  }, []);
-
-  const handleDeleteButtonClick = useCallback(async () => {
-    setLoading(true);
-
-    try {
-      const result = await deleteReview(review?.id);
-
-      if (result.success) {
-        enqueueSnackbar(dictionary['delete report success'], {
-          variant: 'success'
+  const [, submitAction, isPending] = useActionState<null, FormData>(
+    async (_prevState, _formData) => {
+      if (!review) {
+        enqueueSnackbar(dictionary['delete report failed'], {
+          variant: 'error'
         });
-
-        onClose();
-        onDeleted();
-      } else {
-        enqueueSnackbar(result.error, { variant: 'error' });
+        return null;
       }
-    } catch (error) {
-      enqueueSnackbar(dictionary['delete report failed'], { variant: 'error' });
-    } finally {
-      setLoading(false);
-    }
-  }, [review, onClose, onDeleted, dictionary]);
+
+      try {
+        const result = await deleteReview(review.id);
+
+        if (result.success) {
+          enqueueSnackbar(dictionary['delete report success'], {
+            variant: 'success'
+          });
+
+          onClose();
+          onDeleted();
+          return null;
+        }
+
+        enqueueSnackbar(result.error ?? dictionary['delete report failed'], {
+          variant: 'error'
+        });
+        return null;
+      } catch (_error) {
+        enqueueSnackbar(dictionary['delete report failed'], {
+          variant: 'error'
+        });
+        return null;
+      }
+    },
+    null
+  );
 
   return (
     <Dialog
@@ -68,41 +69,48 @@ const DeleteReviewDialog = ({ review, open, onClose, onDeleted }: Props) => {
       fullWidth
       slotProps={{
         transition: {
-          onExited: handleExited
+          onExited: () => setCheck(false)
         }
       }}
     >
-      <DialogTitle>{dictionary['sure to delete report']}</DialogTitle>
-      <DialogContent>
-        <DialogContentText gutterBottom>
-          {dictionary['this cannot be undone']}
-        </DialogContentText>
+      <form action={submitAction}>
+        <DialogTitle>{dictionary['sure to delete report']}</DialogTitle>
+        <DialogContent>
+          <DialogContentText gutterBottom>
+            {dictionary['this cannot be undone']}
+          </DialogContentText>
 
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={check}
-              onChange={handleCheckChange}
-              color="success"
-            />
-          }
-          label={dictionary['understand this cannot be undone']}
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} color="inherit" disabled={loading}>
-          {dictionary.cancel}
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleDeleteButtonClick}
-          color="error"
-          disabled={disabled}
-          loading={loading}
-        >
-          {dictionary.delete}
-        </Button>
-      </DialogActions>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={check}
+                onChange={() => setCheck((prev) => !prev)}
+                color="success"
+              />
+            }
+            label={dictionary['understand this cannot be undone']}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            type="button"
+            onClick={onClose}
+            color="inherit"
+            disabled={isPending}
+          >
+            {dictionary.cancel}
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            color="error"
+            disabled={!check}
+            loading={isPending}
+          >
+            {dictionary.delete}
+          </Button>
+        </DialogActions>
+      </form>
     </Dialog>
   );
 };

--- a/src/components/reviews/EditReviewDialog.tsx
+++ b/src/components/reviews/EditReviewDialog.tsx
@@ -9,14 +9,7 @@ import {
   type SlideProps
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import {
-  memo,
-  useActionState,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState
-} from 'react';
+import { memo, useActionState, useCallback, useMemo, useState } from 'react';
 import type { Review } from '../../../types';
 import { updateReview } from '../../actions/reviews';
 import useDictionary from '../../hooks/useDictionary';
@@ -41,9 +34,6 @@ type Props = {
   currentReview: Review | null;
 };
 
-type FormState = { error: string | null };
-const initialState: FormState = { error: null };
-
 export default memo(function EditReviewDialog({
   open,
   onClose,
@@ -63,10 +53,11 @@ export default memo(function EditReviewDialog({
     return !(name && comment && position);
   }, [name, comment, position]);
 
-  const [state, submitAction, isPending] = useActionState<FormState, FormData>(
+  const [, submitAction, isPending] = useActionState<null, FormData>(
     async (_prevState, _formData) => {
       if (!currentReview || !position) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
 
       try {
@@ -104,22 +95,20 @@ export default memo(function EditReviewDialog({
 
           onClose();
           onSaved();
-          return { error: null };
+          return null;
         }
 
-        return { error: result.error ?? dictionary['an error occurred'] };
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+        return null;
       } catch (_error) {
-        return { error: dictionary['an error occurred'] };
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
     },
-    initialState
+    null
   );
-
-  useEffect(() => {
-    if (state.error) {
-      enqueueSnackbar(state.error, { variant: 'error' });
-    }
-  }, [state]);
 
   const handleExited = useCallback(() => {
     setName(undefined);

--- a/src/components/settings/DeleteAccountDialog.tsx
+++ b/src/components/settings/DeleteAccountDialog.tsx
@@ -9,7 +9,7 @@ import {
   FormControlLabel
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useContext, useState } from 'react';
+import { memo, useActionState, useContext, useState } from 'react';
 import { deleteAccount } from '../../actions/users';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
@@ -25,41 +25,38 @@ function DeleteAccountDialog({ open, onClose, onDeleted }: Props) {
   const { uid } = useContext(AuthContext);
 
   const [check, setCheck] = useState(false);
-  const [disabled, setDisabled] = useState(true);
-  const [loading, setLoading] = useState(false);
 
-  const handleCheckChange = useCallback(() => {
-    setCheck(!check);
-    setDisabled(!disabled);
-  }, [check, disabled]);
-
-  const handleExited = useCallback(() => {
-    setCheck(false);
-    setDisabled(true);
-  }, []);
-
-  const handleDeleteButtonClick = useCallback(async () => {
-    setLoading(true);
-
-    try {
-      const result = await deleteAccount(uid);
-
-      if (result.success) {
-        enqueueSnackbar(dictionary['delete account success'], {
-          variant: 'success'
-        });
-
-        onClose();
-        onDeleted();
-      } else {
-        enqueueSnackbar(result.error, { variant: 'error' });
+  const [, submitAction, isPending] = useActionState<null, FormData>(
+    async (_prevState, _formData) => {
+      if (!uid) {
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
       }
-    } catch (error) {
-      enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
-    } finally {
-      setLoading(false);
-    }
-  }, [uid, dictionary, onClose, onDeleted]);
+
+      try {
+        const result = await deleteAccount(uid);
+
+        if (result.success) {
+          enqueueSnackbar(dictionary['delete account success'], {
+            variant: 'success'
+          });
+
+          onClose();
+          onDeleted();
+          return null;
+        }
+
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+        return null;
+      } catch (_error) {
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
+        return null;
+      }
+    },
+    null
+  );
 
   return (
     <Dialog
@@ -68,41 +65,48 @@ function DeleteAccountDialog({ open, onClose, onDeleted }: Props) {
       fullWidth
       slotProps={{
         transition: {
-          onExited: handleExited
+          onExited: () => setCheck(false)
         }
       }}
     >
-      <DialogTitle>{dictionary['sure to delete account']}</DialogTitle>
-      <DialogContent>
-        <DialogContentText gutterBottom>
-          {dictionary['delete account detail']}
-        </DialogContentText>
+      <form action={submitAction}>
+        <DialogTitle>{dictionary['sure to delete account']}</DialogTitle>
+        <DialogContent>
+          <DialogContentText gutterBottom>
+            {dictionary['delete account detail']}
+          </DialogContentText>
 
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={check}
-              onChange={handleCheckChange}
-              color="success"
-            />
-          }
-          label={dictionary['understand this cannot be undone']}
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} color="inherit">
-          {dictionary.cancel}
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleDeleteButtonClick}
-          color="error"
-          disabled={disabled}
-          loading={loading}
-        >
-          {dictionary.delete}
-        </Button>
-      </DialogActions>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={check}
+                onChange={() => setCheck((prev) => !prev)}
+                color="success"
+              />
+            }
+            label={dictionary['understand this cannot be undone']}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            type="button"
+            onClick={onClose}
+            color="inherit"
+            disabled={isPending}
+          >
+            {dictionary.cancel}
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            color="error"
+            disabled={!check}
+            loading={isPending}
+          >
+            {dictionary.delete}
+          </Button>
+        </DialogActions>
+      </form>
     </Dialog>
   );
 }


### PR DESCRIPTION
# Summary

Drop the `useEffect([state])` indirection that PRs #1053-#1054 used to surface action errors and call `enqueueSnackbar` inline within the action itself. The same pattern is now applied across every Server-Action-driven dialog (10 in total), and the four confirmation Delete dialogs are migrated to `useActionState` with this final shape.

# Motivation

The `state.error` / `useEffect` round-trip is a textbook "You Might Not Need an Effect" case: the action already runs in a client component, so it can call `enqueueSnackbar` synchronously. Removing the round-trip lets the dialogs drop `FormState`, `initialState`, and the unused state slot of `useActionState`, leaving the action body as the single source of side-effects.

While touching all dialogs anyway, migrate the Delete-confirmation dialogs (Comment, Review, Map, Account) onto the same `useActionState` + `&lt;form action&gt;` shape they had been left out of in #1054, so every dialog driven by a Server Action looks the same.

# Changes

- Inline `enqueueSnackbar(error, { variant: 'error' })` directly in each action's error/catch branches; remove the `useEffect([state])` block from all 10 dialogs
- Drop `type FormState`, `const initialState`, and the unused state slot — `useActionState<null, FormData>(..., null)` with `[, submitAction, isPending]`
- Migrate `DeleteCommentDialog`, `DeleteReviewDialog`, `DeleteMapDialog`, `DeleteAccountDialog` to `useActionState` + `&lt;form action&gt;`; null-guard required props (`comment`, `review`, `map`, `uid`) at the action head; collapse the redundant `useState(disabled)` into `disabled={!check}`

# Testing

- `pnpm biome ci ./src`
- `pnpm exec tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.ai/code)