### PR TITLE
ci: keep one warm Cloud Run instance

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -107,7 +107,9 @@ jobs:
             --project=$PROJECT_ID \
             --cpu=1000m \
             --cpu-boost \
+            --no-cpu-throttling \
             --memory=512Mi \
+            --min-instances=1 \
             --max-instances=2 \
             --port=8080 \
             --service-account=$CLOUD_RUN_SA_NAME \

--- a/src/app/[lang]/(contained)/discover/loading.tsx
+++ b/src/app/[lang]/(contained)/discover/loading.tsx
@@ -1,0 +1,5 @@
+import SkeletonDiscoverPage from '../../../../components/discover/SkeletonDiscoverPage';
+
+export default function Loading() {
+  return <SkeletonDiscoverPage />;
+}

--- a/src/app/[lang]/(contained)/layout.tsx
+++ b/src/app/[lang]/(contained)/layout.tsx
@@ -1,5 +1,5 @@
 import { Box, Container, Grid } from '@mui/material';
-import type { ReactNode } from 'react';
+import { type ReactNode, Suspense } from 'react';
 import BottomNav from '../../../components/layouts/BottomNav';
 import Sidebar from '../../../components/layouts/Sidebar';
 import { getServerAuthState } from '../../../lib/auth';
@@ -10,13 +10,18 @@ type Props = {
   params: Promise<{ lang: string }>;
 };
 
-export default async function ContainedLayout({ children, params }: Props) {
-  const { lang } = await params;
+async function SidebarData({ lang }: { lang: string }) {
   const { token } = await getServerAuthState();
   const [popularMaps, recommendMaps] = await Promise.all([
     getPopularMaps(lang),
     getRecommendMaps(lang, token)
   ]);
+
+  return <Sidebar popularMaps={popularMaps} recommendMaps={recommendMaps} />;
+}
+
+export default async function ContainedLayout({ children, params }: Props) {
+  const { lang } = await params;
 
   return (
     <>
@@ -31,10 +36,9 @@ export default async function ContainedLayout({ children, params }: Props) {
               size={{ md: 4, lg: 4, xl: 4 }}
               sx={{ display: { xs: 'none', md: 'block' } }}
             >
-              <Sidebar
-                popularMaps={popularMaps}
-                recommendMaps={recommendMaps}
-              />
+              <Suspense fallback={<Sidebar />}>
+                <SidebarData lang={lang} />
+              </Suspense>
             </Grid>
           </Grid>
         </Container>

--- a/src/app/[lang]/(contained)/loading.tsx
+++ b/src/app/[lang]/(contained)/loading.tsx
@@ -1,0 +1,39 @@
+import {
+  Box,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Skeleton
+} from '@mui/material';
+
+const PLACEHOLDER_COUNT = 3;
+
+export default function Loading() {
+  return (
+    <Box sx={{ display: 'grid', gap: 3 }}>
+      {Array.from({ length: PLACEHOLDER_COUNT }).map((_, index) => (
+        <Card
+          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+          key={`home-skeleton-${index}`}
+          elevation={0}
+        >
+          <CardHeader
+            avatar={<Skeleton variant="circular" width={40} height={40} />}
+            title={<Skeleton width="40%" />}
+            subheader={<Skeleton width="25%" />}
+          />
+          <CardContent sx={{ pt: 0 }}>
+            <Skeleton variant="text" width="60%" height={32} />
+            <Skeleton variant="text" width="100%" />
+            <Skeleton variant="text" width="90%" />
+          </CardContent>
+          <CardActions>
+            <Skeleton variant="circular" width={32} height={32} />
+            <Skeleton variant="circular" width={32} height={32} />
+          </CardActions>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/src/app/[lang]/(contained)/loading.tsx
+++ b/src/app/[lang]/(contained)/loading.tsx
@@ -1,39 +1,5 @@
-import {
-  Box,
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Skeleton
-} from '@mui/material';
-
-const PLACEHOLDER_COUNT = 3;
+import SkeletonReviewCardList from '../../../components/home/SkeletonReviewCardList';
 
 export default function Loading() {
-  return (
-    <Box sx={{ display: 'grid', gap: 3 }}>
-      {Array.from({ length: PLACEHOLDER_COUNT }).map((_, index) => (
-        <Card
-          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
-          key={`home-skeleton-${index}`}
-          elevation={0}
-        >
-          <CardHeader
-            avatar={<Skeleton variant="circular" width={40} height={40} />}
-            title={<Skeleton width="40%" />}
-            subheader={<Skeleton width="25%" />}
-          />
-          <CardContent sx={{ pt: 0 }}>
-            <Skeleton variant="text" width="60%" height={32} />
-            <Skeleton variant="text" width="100%" />
-            <Skeleton variant="text" width="90%" />
-          </CardContent>
-          <CardActions>
-            <Skeleton variant="circular" width={32} height={32} />
-            <Skeleton variant="circular" width={32} height={32} />
-          </CardActions>
-        </Card>
-      ))}
-    </Box>
-  );
+  return <SkeletonReviewCardList />;
 }

--- a/src/app/[lang]/(contained)/maps/[mapId]/reports/[reviewId]/loading.tsx
+++ b/src/app/[lang]/(contained)/maps/[mapId]/reports/[reviewId]/loading.tsx
@@ -1,0 +1,5 @@
+import SkeletonReviewDetail from '../../../../../../../components/reviews/SkeletonReviewDetail';
+
+export default function Loading() {
+  return <SkeletonReviewDetail />;
+}

--- a/src/app/[lang]/(contained)/notifications/loading.tsx
+++ b/src/app/[lang]/(contained)/notifications/loading.tsx
@@ -1,0 +1,5 @@
+import SkeletonNotificationList from '../../../../components/notifications/SkeletonNotificationList';
+
+export default function Loading() {
+  return <SkeletonNotificationList />;
+}

--- a/src/app/[lang]/(contained)/users/[userId]/loading.tsx
+++ b/src/app/[lang]/(contained)/users/[userId]/loading.tsx
@@ -1,0 +1,5 @@
+import SkeletonUserProfile from '../../../../../components/profiles/SkeletonUserProfile';
+
+export default function Loading() {
+  return <SkeletonUserProfile />;
+}

--- a/src/app/[lang]/Providers.tsx
+++ b/src/app/[lang]/Providers.tsx
@@ -26,6 +26,7 @@ import ProfileContext from '../../context/ProfileContext';
 import ServiceWorkerContext from '../../context/ServiceWorkerContext';
 import useDictionary from '../../hooks/useDictionary';
 import { usePushManager } from '../../hooks/usePushManager';
+import type { ServerAuthState } from '../../lib/auth';
 import AnalyticsTracker from './AnalyticsTracker';
 
 type ProfileHydratorProps = {
@@ -96,8 +97,7 @@ const inputGlobalStyles = <GlobalStyles styles={globalStyles} />;
 type Props = {
   children: ReactNode;
   lang: string;
-  serverAuthenticated: boolean;
-  serverUid?: string;
+  authStatePromise: Promise<ServerAuthState>;
   profilePromise: Promise<Profile | null>;
   notificationsPromise: Promise<Notification[]>;
 };
@@ -105,8 +105,7 @@ type Props = {
 export default function Providers({
   children,
   lang,
-  serverAuthenticated,
-  serverUid,
+  authStatePromise,
   profilePromise,
   notificationsPromise
 }: Props) {
@@ -187,10 +186,7 @@ export default function Providers({
             </Button>
           )}
         >
-          <AuthProvider
-            serverAuthenticated={serverAuthenticated}
-            serverUid={serverUid ?? null}
-          >
+          <AuthProvider authStatePromise={authStatePromise}>
             <ProfileHydrator promise={profilePromise}>
               <NotificationsHydrator promise={notificationsPromise}>
                 <ServiceWorkerContext.Provider value={{ registration }}>

--- a/src/app/[lang]/Providers.tsx
+++ b/src/app/[lang]/Providers.tsx
@@ -28,6 +28,63 @@ import useDictionary from '../../hooks/useDictionary';
 import { usePushManager } from '../../hooks/usePushManager';
 import AnalyticsTracker from './AnalyticsTracker';
 
+type ProfileHydratorProps = {
+  promise: Promise<Profile | null>;
+  children: ReactNode;
+};
+
+function ProfileHydrator({ promise, children }: ProfileHydratorProps) {
+  const [profile, setProfile] = useState<Profile | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    promise.then((value) => {
+      if (!cancelled) {
+        setProfile(value);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [promise]);
+
+  return (
+    <ProfileContext.Provider value={profile}>
+      {children}
+    </ProfileContext.Provider>
+  );
+}
+
+type NotificationsHydratorProps = {
+  promise: Promise<Notification[]>;
+  children: ReactNode;
+};
+
+function NotificationsHydrator({
+  promise,
+  children
+}: NotificationsHydratorProps) {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    promise.then((value) => {
+      if (!cancelled) {
+        setNotifications(value);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [promise]);
+
+  return (
+    <NotificationsContext.Provider value={notifications}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+}
+
 const globalStyles = css`
   .pac-container {
     z-index: 1300 !important;
@@ -41,8 +98,8 @@ type Props = {
   lang: string;
   serverAuthenticated: boolean;
   serverUid?: string;
-  serverProfile?: Profile | null;
-  serverNotifications?: Notification[];
+  profilePromise: Promise<Profile | null>;
+  notificationsPromise: Promise<Notification[]>;
 };
 
 export default function Providers({
@@ -50,8 +107,8 @@ export default function Providers({
   lang,
   serverAuthenticated,
   serverUid,
-  serverProfile,
-  serverNotifications
+  profilePromise,
+  notificationsPromise
 }: Props) {
   const dictionary = useDictionary();
 
@@ -134,14 +191,14 @@ export default function Providers({
             serverAuthenticated={serverAuthenticated}
             serverUid={serverUid ?? null}
           >
-            <ProfileContext.Provider value={serverProfile ?? null}>
-              <NotificationsContext.Provider value={serverNotifications ?? []}>
+            <ProfileHydrator promise={profilePromise}>
+              <NotificationsHydrator promise={notificationsPromise}>
                 <ServiceWorkerContext.Provider value={{ registration }}>
                   <AnalyticsTracker />
                   {children}
                 </ServiceWorkerContext.Provider>
-              </NotificationsContext.Provider>
-            </ProfileContext.Provider>
+              </NotificationsHydrator>
+            </ProfileHydrator>
           </AuthProvider>
         </SnackbarProvider>
       </ThemeProvider>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -50,10 +50,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function RootLayout({ children, params }: Props) {
   const { lang } = await params;
   const { authenticated, uid, token } = await getServerAuthState();
-  const [profile, notifications] = await Promise.all([
-    authenticated && uid ? getProfile(uid, lang, token) : Promise.resolve(null),
-    authenticated ? getNotifications(lang) : Promise.resolve([])
-  ]);
+  const profilePromise =
+    authenticated && uid ? getProfile(uid, lang, token) : Promise.resolve(null);
+  const notificationsPromise = authenticated
+    ? getNotifications(lang)
+    : Promise.resolve([]);
 
   return (
     <html lang={lang}>
@@ -127,8 +128,8 @@ export default async function RootLayout({ children, params }: Props) {
           lang={lang}
           serverAuthenticated={authenticated}
           serverUid={uid}
-          serverProfile={profile}
-          serverNotifications={notifications}
+          profilePromise={profilePromise}
+          notificationsPromise={notificationsPromise}
         >
           <ShellProvider>
             <Box sx={{ display: { xs: 'block', md: 'none' } }}>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -49,12 +49,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function RootLayout({ children, params }: Props) {
   const { lang } = await params;
-  const { authenticated, uid, token } = await getServerAuthState();
-  const profilePromise =
-    authenticated && uid ? getProfile(uid, lang, token) : Promise.resolve(null);
-  const notificationsPromise = authenticated
-    ? getNotifications(lang)
-    : Promise.resolve([]);
+  const authStatePromise = getServerAuthState();
+  const profilePromise = authStatePromise.then(
+    ({ authenticated, uid, token }) =>
+      authenticated && uid ? getProfile(uid, lang, token) : null
+  );
+  const notificationsPromise = authStatePromise.then(({ authenticated }) =>
+    authenticated ? getNotifications(lang) : []
+  );
 
   return (
     <html lang={lang}>
@@ -126,8 +128,7 @@ export default async function RootLayout({ children, params }: Props) {
       <body>
         <Providers
           lang={lang}
-          serverAuthenticated={authenticated}
-          serverUid={uid}
+          authStatePromise={authStatePromise}
           profilePromise={profilePromise}
           notificationsPromise={notificationsPromise}
         >

--- a/src/app/[lang]/maps/[mapId]/loading.tsx
+++ b/src/app/[lang]/maps/[mapId]/loading.tsx
@@ -1,0 +1,5 @@
+import SkeletonMapDetailView from '../../../../components/maps/SkeletonMapDetailView';
+
+export default function Loading() {
+  return <SkeletonMapDetailView />;
+}

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -11,11 +11,11 @@ import {
 } from 'react';
 import AuthContext from '../../context/AuthContext';
 import useEmailLinkHandler from '../../hooks/useEmailLinkHandler';
+import type { ServerAuthState } from '../../lib/auth';
 
 type Props = {
   children: ReactNode;
-  serverAuthenticated: boolean;
-  serverUid: string | null;
+  authStatePromise: Promise<ServerAuthState>;
 };
 
 if (!getApps().length) {
@@ -30,13 +30,14 @@ if (!getApps().length) {
   });
 }
 
-function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
+function AuthProvider({ children, authStatePromise }: Props) {
   const router = useRouter();
-  const [authenticated, setAuthenticated] = useState(serverAuthenticated);
-  const [uid, setUid] = useState<string | null>(serverUid);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [uid, setUid] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [signInRequired, setSignInRequired] = useState(false);
-  const authStateRef = useRef(serverAuthenticated);
+  const authStateRef = useRef(false);
+  const listenerFiredRef = useRef(false);
 
   useEmailLinkHandler({ isLoading: loading });
 
@@ -50,6 +51,8 @@ function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
 
   const handleIdTokenChanged = useCallback(
     async (user: User | null) => {
+      listenerFiredRef.current = true;
+
       if (user) {
         if (user.isAnonymous) {
           await user.delete();
@@ -91,6 +94,21 @@ function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
     },
     [syncSessionCookie, router]
   );
+
+  useEffect(() => {
+    let cancelled = false;
+    authStatePromise.then((state) => {
+      if (cancelled || listenerFiredRef.current) {
+        return;
+      }
+      authStateRef.current = state.authenticated;
+      setAuthenticated(state.authenticated);
+      setUid(state.uid ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [authStatePromise]);
 
   useEffect(() => {
     const auth = getAuth();

--- a/src/components/discover/SkeletonDiscoverPage.tsx
+++ b/src/components/discover/SkeletonDiscoverPage.tsx
@@ -1,0 +1,73 @@
+import {
+  Box,
+  Divider,
+  ImageList,
+  ImageListItem,
+  Skeleton,
+  Stack
+} from '@mui/material';
+import { memo } from 'react';
+
+const REVIEW_TILE_COUNT = 6;
+const MAP_TILE_COUNT = 6;
+
+function SectionHeader() {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+      <Skeleton variant="circular" width={24} height={24} />
+      <Skeleton variant="text" width={120} />
+    </Box>
+  );
+}
+
+type GridSkeletonProps = {
+  count: number;
+  rowHeight: number;
+  keyPrefix: string;
+};
+
+function GridSection({ count, rowHeight, keyPrefix }: GridSkeletonProps) {
+  return (
+    <Box component="section">
+      <SectionHeader />
+      <ImageList cols={3} rowHeight={rowHeight} gap={8} sx={{ m: 0 }}>
+        {Array.from({ length: count }).map((_, index) => (
+          <ImageListItem
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+            key={`${keyPrefix}-${index}`}
+          >
+            <Skeleton variant="rectangular" height="100%" />
+          </ImageListItem>
+        ))}
+      </ImageList>
+    </Box>
+  );
+}
+
+function SkeletonDiscoverPage() {
+  return (
+    <Stack spacing={4} divider={<Divider />}>
+      <Box component="section">
+        <SectionHeader />
+        <Skeleton variant="rectangular" height={240} />
+      </Box>
+      <GridSection
+        count={REVIEW_TILE_COUNT}
+        rowHeight={180}
+        keyPrefix="skeleton-discover-recent-reviews"
+      />
+      <GridSection
+        count={MAP_TILE_COUNT}
+        rowHeight={240}
+        keyPrefix="skeleton-discover-active-maps"
+      />
+      <GridSection
+        count={MAP_TILE_COUNT}
+        rowHeight={240}
+        keyPrefix="skeleton-discover-recent-maps"
+      />
+    </Stack>
+  );
+}
+
+export default memo(SkeletonDiscoverPage);

--- a/src/components/home/SkeletonReviewCardList.tsx
+++ b/src/components/home/SkeletonReviewCardList.tsx
@@ -1,0 +1,44 @@
+import {
+  Box,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Skeleton
+} from '@mui/material';
+import { memo } from 'react';
+
+const PLACEHOLDER_COUNT = 3;
+
+function SkeletonReviewCardList() {
+  return (
+    <Box sx={{ display: 'grid', gap: 3 }}>
+      {Array.from({ length: PLACEHOLDER_COUNT }).map((_, index) => (
+        <Card
+          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+          key={`skeleton-review-card-${index}`}
+          elevation={0}
+        >
+          <CardHeader
+            avatar={<Skeleton variant="circular" width={40} height={40} />}
+            title={<Skeleton width="40%" />}
+            subheader={<Skeleton width="25%" />}
+            action={<Skeleton variant="circular" width={32} height={32} />}
+          />
+          <CardContent sx={{ pt: 0 }}>
+            <Skeleton variant="text" height={32} width="60%" />
+            <Skeleton variant="text" />
+            <Skeleton variant="text" width="80%" />
+          </CardContent>
+          <Skeleton variant="rectangular" height={240} />
+          <CardActions>
+            <Skeleton variant="circular" width={32} height={32} />
+            <Skeleton variant="circular" width={32} height={32} />
+          </CardActions>
+        </Card>
+      ))}
+    </Box>
+  );
+}
+
+export default memo(SkeletonReviewCardList);

--- a/src/components/maps/SkeletonMapDetailView.tsx
+++ b/src/components/maps/SkeletonMapDetailView.tsx
@@ -1,0 +1,72 @@
+import { Box, Skeleton, Stack } from '@mui/material';
+import { memo } from 'react';
+
+const summaryCardWidth = 360;
+const bottomSheetHeight = 105;
+
+function SkeletonMapDetailView() {
+  return (
+    <Box sx={{ display: { xs: 'block', md: 'flex' } }}>
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'block' },
+          width: summaryCardWidth,
+          height: '100dvh',
+          p: 2
+        }}
+      >
+        <Stack spacing={2}>
+          <Skeleton variant="rectangular" height={160} />
+          <Skeleton variant="text" height={32} width="70%" />
+          <Skeleton variant="text" />
+          <Skeleton variant="text" width="80%" />
+          <Stack direction="row" spacing={1}>
+            <Skeleton variant="rounded" width={100} height={32} />
+            <Skeleton variant="rounded" width={100} height={32} />
+          </Stack>
+          <Skeleton variant="rectangular" height={1} />
+          <Skeleton variant="text" width="40%" />
+          <Skeleton variant="rectangular" height={120} />
+          <Skeleton variant="rectangular" height={120} />
+        </Stack>
+      </Box>
+
+      <Skeleton
+        variant="rectangular"
+        sx={{
+          height: {
+            xs: `calc(100dvh - ${bottomSheetHeight}px - 56px)`,
+            sm: `calc(100dvh - ${bottomSheetHeight}px - 64px)`,
+            md: '100dvh'
+          },
+          width: {
+            md: `calc(100dvw - ${summaryCardWidth}px)`
+          },
+          flexGrow: 1
+        }}
+      />
+
+      <Box
+        sx={{
+          display: { xs: 'block', md: 'none' },
+          position: 'fixed',
+          bottom: { xs: 56, sm: 64 },
+          left: 0,
+          right: 0,
+          height: bottomSheetHeight,
+          bgcolor: 'background.paper',
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+          p: 2
+        }}
+      >
+        <Stack spacing={1}>
+          <Skeleton variant="text" width="60%" height={28} />
+          <Skeleton variant="text" width="40%" />
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+
+export default memo(SkeletonMapDetailView);

--- a/src/components/notifications/SkeletonNotificationList.tsx
+++ b/src/components/notifications/SkeletonNotificationList.tsx
@@ -1,0 +1,38 @@
+import {
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Skeleton
+} from '@mui/material';
+import { memo } from 'react';
+
+const PLACEHOLDER_COUNT = 8;
+
+function SkeletonNotificationList() {
+  return (
+    <List>
+      {Array.from({ length: PLACEHOLDER_COUNT }).map((_, index) => (
+        <ListItem
+          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+          key={`skeleton-notification-${index}`}
+          dense
+          secondaryAction={
+            <Skeleton variant="rounded" width={40} height={40} />
+          }
+        >
+          <ListItemAvatar>
+            <Skeleton variant="circular" width={40} height={40} />
+          </ListItemAvatar>
+          <ListItemText
+            disableTypography
+            primary={<Skeleton variant="text" width="80%" />}
+            secondary={<Skeleton variant="text" width="35%" />}
+          />
+        </ListItem>
+      ))}
+    </List>
+  );
+}
+
+export default memo(SkeletonNotificationList);

--- a/src/components/profiles/SkeletonUserProfile.tsx
+++ b/src/components/profiles/SkeletonUserProfile.tsx
@@ -1,0 +1,65 @@
+import {
+  Card,
+  CardContent,
+  Divider,
+  ImageList,
+  ImageListItem,
+  Skeleton,
+  Stack,
+  Tab,
+  Tabs
+} from '@mui/material';
+import { memo } from 'react';
+
+const REVIEW_TILE_COUNT = 6;
+
+function SkeletonUserProfile() {
+  return (
+    <>
+      <Card elevation={0}>
+        <CardContent>
+          <Stack spacing={1} sx={{ placeItems: 'center' }}>
+            <Skeleton variant="circular" width={100} height={100} />
+            <Skeleton variant="text" width="40%" height={36} />
+            <Skeleton variant="text" width="70%" />
+            <Skeleton variant="text" width="50%" />
+
+            <Stack
+              direction="row"
+              divider={<Divider orientation="vertical" flexItem />}
+              spacing={2}
+              sx={{ pt: 1 }}
+            >
+              <Stack alignItems="center" spacing={0.5}>
+                <Skeleton variant="text" width={40} height={28} />
+                <Skeleton variant="text" width={48} />
+              </Stack>
+              <Stack alignItems="center" spacing={0.5}>
+                <Skeleton variant="text" width={40} height={28} />
+                <Skeleton variant="text" width={48} />
+              </Stack>
+            </Stack>
+          </Stack>
+        </CardContent>
+
+        <Tabs value={0} centered>
+          <Tab label={<Skeleton variant="text" width={48} />} />
+          <Tab label={<Skeleton variant="text" width={48} />} />
+        </Tabs>
+      </Card>
+
+      <ImageList cols={3} rowHeight={180} gap={8} sx={{ mt: 2 }}>
+        {Array.from({ length: REVIEW_TILE_COUNT }).map((_, index) => (
+          <ImageListItem
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+            key={`skeleton-profile-review-${index}`}
+          >
+            <Skeleton variant="rectangular" height="100%" />
+          </ImageListItem>
+        ))}
+      </ImageList>
+    </>
+  );
+}
+
+export default memo(SkeletonUserProfile);

--- a/src/components/reviews/SkeletonReviewDetail.tsx
+++ b/src/components/reviews/SkeletonReviewDetail.tsx
@@ -1,0 +1,44 @@
+import {
+  Box,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Skeleton
+} from '@mui/material';
+import { memo } from 'react';
+
+function SkeletonReviewDetail() {
+  return (
+    <>
+      <Card elevation={0}>
+        <CardHeader
+          avatar={<Skeleton variant="circular" width={40} height={40} />}
+          title={<Skeleton width="40%" />}
+          subheader={<Skeleton width="25%" />}
+          action={<Skeleton variant="circular" width={32} height={32} />}
+        />
+        <CardContent sx={{ py: 0 }}>
+          <Skeleton variant="text" height={36} width="60%" />
+          <Skeleton variant="text" />
+          <Skeleton variant="text" />
+          <Skeleton variant="text" width="80%" />
+          <Box sx={{ mt: 2 }}>
+            <Skeleton variant="rectangular" height={320} />
+          </Box>
+        </CardContent>
+        <CardActions>
+          <Skeleton variant="circular" width={32} height={32} />
+          <Skeleton variant="circular" width={32} height={32} />
+          <Skeleton variant="rounded" width={120} height={32} sx={{ ml: 1 }} />
+        </CardActions>
+      </Card>
+
+      <Box sx={{ mt: 2 }}>
+        <Skeleton variant="rounded" width={120} height={32} />
+      </Box>
+    </>
+  );
+}
+
+export default memo(SkeletonReviewDetail);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -13,7 +13,7 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
 };
 
-type ServerAuthState = {
+export type ServerAuthState = {
   authenticated: boolean;
   uid?: string;
   token?: string;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { initializeServerApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { cookies } from 'next/headers';
+import { cache } from 'react';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -18,7 +19,7 @@ type ServerAuthState = {
   token?: string;
 };
 
-export async function getServerAuthState(): Promise<ServerAuthState> {
+export const getServerAuthState = cache(async (): Promise<ServerAuthState> => {
   const cookieStore = await cookies();
   const idToken = cookieStore.get('__session')?.value;
 
@@ -42,4 +43,4 @@ export async function getServerAuthState(): Promise<ServerAuthState> {
   } catch {
     return { authenticated: false };
   }
-}
+});


### PR DESCRIPTION
# Summary

Keep one warm Cloud Run instance for prod so PWA launches no longer wait on a cold container.

# Motivation

Even after the streaming and skeleton work in #1056, the PWA splash screen still hangs for several seconds on launch. The remaining cause is that every standalone start hits a cold Cloud Run container — Node.js boot plus Firebase SDK init add 1–3 s before the server can flush a single HTML byte. With `--min-instances=0` (default) and idle CPU throttling on (default), the second user request after a quiet period also pays for a fresh start.

# Changes

`.github/workflows/prod.yaml`: add two flags to `gcloud beta run deploy`:

- `--min-instances=1`: always keep one warm container ready.
- `--no-cpu-throttling`: keep the warm container fully responsive while idle, so the streaming response and async work behind Suspense boundaries proceed at full CPU.

Dev (`.github/workflows/dev.yaml`) is left untouched — short-lived PR environments don't warrant the always-allocated cost.

# Trade-off

`asia-northeast1` 1 vCPU + 512 MiB always-allocated runs roughly ¥3,000–5,000 / month with `--no-cpu-throttling`. Acceptable for the production PWA UX.

# Testing

After merge and tag deploy:

1. Confirm the Cloud Run console shows `Container instance count >= 1` continuously.
2. Launch the PWA on a real device — splash should give way to the streamed shell + skeletons within the OS-level icon transition window.
3. Verify the response is chunked end-to-end:
   ```
   curl -v -H 'Accept-Encoding: identity' --no-buffer https://qoodish.com/ja
   ```
   `Transfer-Encoding: chunked` should be present and stdout should fill progressively.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015DdKUdR8zFLCZfyHNvX9c4)_