### PR TITLE
feat: hide AppBar on drawer open and scroll

### DIFF
--- a/src/components/layouts/MobileAppBar.tsx
+++ b/src/components/layouts/MobileAppBar.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { Search } from '@mui/icons-material';
-import { AppBar, Box, IconButton, Toolbar } from '@mui/material';
+import {
+  AppBar,
+  Box,
+  IconButton,
+  Slide,
+  Toolbar,
+  useScrollTrigger
+} from '@mui/material';
 import { memo, useContext, useState } from 'react';
 import AuthContext from '../../context/AuthContext';
 import ProfileContext from '../../context/ProfileContext';
@@ -12,39 +19,47 @@ import MobileDrawer from './MobileDrawer';
 
 export default memo(function MobileAppBar() {
   const { uid } = useContext(AuthContext);
-  const { openSearch, openCreateMap } = useContext(ShellContext);
+  const { openSearch, openCreateMap, appBarHidden } = useContext(ShellContext);
   const profile = useContext(ProfileContext);
 
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  const scrollTrigger = useScrollTrigger();
+
   return (
     <>
-      <AppBar position="fixed">
-        <Toolbar
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: '1fr auto 1fr'
-          }}
-        >
-          <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
-            <IconButton
-              size="small"
-              edge="start"
-              onClick={() => setDrawerOpen(true)}
-            >
-              <ProfileAvatar profile={profile} size={32} />
-            </IconButton>
-          </Box>
+      <Slide
+        appear={false}
+        direction="down"
+        in={!appBarHidden && !scrollTrigger}
+      >
+        <AppBar position="fixed">
+          <Toolbar
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: '1fr auto 1fr'
+            }}
+          >
+            <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
+              <IconButton
+                size="small"
+                edge="start"
+                onClick={() => setDrawerOpen(true)}
+              >
+                <ProfileAvatar profile={profile} size={32} />
+              </IconButton>
+            </Box>
 
-          <Logo color="inherit" />
+            <Logo color="inherit" />
 
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <IconButton onClick={openSearch} edge="end" color="inherit">
-              <Search />
-            </IconButton>
-          </Box>
-        </Toolbar>
-      </AppBar>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <IconButton onClick={openSearch} edge="end" color="inherit">
+                <Search />
+              </IconButton>
+            </Box>
+          </Toolbar>
+        </AppBar>
+      </Slide>
 
       <MobileDrawer
         open={drawerOpen}

--- a/src/components/layouts/ShellProvider.tsx
+++ b/src/components/layouts/ShellProvider.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { type ReactNode, useCallback, useContext, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState
+} from 'react';
 import type { AppMap } from '../../../types';
 import AuthContext from '../../context/AuthContext';
 import ShellContext from '../../context/ShellContext';
@@ -18,6 +24,7 @@ export default function ShellProvider({ children }: Props) {
   const { authenticated, setSignInRequired } = useContext(AuthContext);
   const [searchOpen, setSearchOpen] = useState(false);
   const [createMapOpen, setCreateMapOpen] = useState(false);
+  const [appBarHidden, setAppBarHidden] = useState(false);
 
   const openSearch = useCallback(() => setSearchOpen(true), []);
   const openCreateMap = useCallback(() => {
@@ -36,8 +43,13 @@ export default function ShellProvider({ children }: Props) {
     [push]
   );
 
+  const contextValue = useMemo(
+    () => ({ openSearch, openCreateMap, appBarHidden, setAppBarHidden }),
+    [openSearch, openCreateMap, appBarHidden]
+  );
+
   return (
-    <ShellContext.Provider value={{ openSearch, openCreateMap }}>
+    <ShellContext.Provider value={contextValue}>
       {children}
       <SearchDialog open={searchOpen} onClose={() => setSearchOpen(false)} />
       <CreateMapDialog

--- a/src/components/maps/MobileMapDrawer.tsx
+++ b/src/components/maps/MobileMapDrawer.tsx
@@ -7,8 +7,9 @@ import {
   SwipeableDrawer,
   Typography
 } from '@mui/material';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useContext, useState } from 'react';
 import type { AppMap, Follower, Profile, Review } from '../../../types';
+import ShellContext from '../../context/ShellContext';
 import useDictionary from '../../hooks/useDictionary';
 import FollowButton from './FollowButton';
 import Followers from './Followers';
@@ -47,7 +48,18 @@ function MobileMapDrawer({
 }: Props) {
   const [open, setOpen] = useState(false);
 
+  const { setAppBarHidden } = useContext(ShellContext);
   const dictionary = useDictionary();
+
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+    setAppBarHidden(true);
+  }, [setAppBarHidden]);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    setAppBarHidden(false);
+  }, [setAppBarHidden]);
 
   const handleReviewClick = useCallback(
     (review: Review) => {
@@ -64,8 +76,8 @@ function MobileMapDrawer({
         hideBackdrop
         disableSwipeToOpen={false}
         open={reviewDrawerOpen ? false : open}
-        onOpen={() => setOpen(true)}
-        onClose={() => setOpen(false)}
+        onOpen={handleOpen}
+        onClose={handleClose}
         swipeAreaWidth={drawerBleeding}
         sx={{
           zIndex: (theme) => theme.zIndex.appBar - 1,

--- a/src/context/ShellContext.tsx
+++ b/src/context/ShellContext.tsx
@@ -5,11 +5,15 @@ import { createContext } from 'react';
 type ShellContextType = {
   openSearch: () => void;
   openCreateMap: () => void;
+  appBarHidden: boolean;
+  setAppBarHidden: (hidden: boolean) => void;
 };
 
 const ShellContext = createContext<ShellContextType>({
   openSearch: () => {},
-  openCreateMap: () => {}
+  openCreateMap: () => {},
+  appBarHidden: false,
+  setAppBarHidden: () => {}
 });
 
 export default ShellContext;


### PR DESCRIPTION
# Summary

The fixed AppBar overlapped the top of `MobileMapDrawer` when the drawer was open, covering part of the 105px peeking section. This PR hides the AppBar when the drawer opens and restores it when the drawer closes. `useScrollTrigger()` is also wired up so the AppBar hides on window scroll for all other mobile pages.

# Motivation

`MobileMapDrawer` uses a bottom sheet with `drawerBleeding = 105px`. When open, the AppBar (56px tall) sat on top of that section. Hiding the AppBar on drawer open eliminates the overlap and follows the standard mobile pattern. Hide-on-scroll for the rest of the app is a natural complement.

# Changes

- `ShellContext`: add `appBarHidden` / `setAppBarHidden` to carry the drawer-open signal across the component tree
- `ShellProvider`: provide `appBarHidden` state and memoize the context value with `useMemo` to avoid unnecessary consumer re-renders
- `MobileMapDrawer`: call `setAppBarHidden(true)` on `onOpen` and `setAppBarHidden(false)` on `onClose`
- `MobileAppBar`: wrap `AppBar` in MUI `Slide`; hide when `appBarHidden || useScrollTrigger()` (window scroll covers all non-map pages)

🤖 Generated with [Claude Code](https://claude.ai/code)