### PR TITLE
feat(pwa): cache navigations during cold starts

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const withSerwist = withSerwistInit({
   swSrc: 'src/worker/index.ts',
   swDest: 'public/sw.js',
   reloadOnOnline: true,
+  cacheOnNavigation: true,
   disable: process.env.NODE_ENV === 'development'
 });
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -2,6 +2,7 @@ import type { PrecacheEntry, RuntimeCaching } from 'serwist';
 import {
   CacheFirst,
   ExpirationPlugin,
+  NetworkFirst,
   Serwist,
   StaleWhileRevalidate
 } from 'serwist';
@@ -51,8 +52,22 @@ interface PushEventPayload {
   data: NotificationData;
 }
 
-// Define runtime caching
 const runtimeCaching: RuntimeCaching[] = [
+  {
+    // Return cached HTML during Cloud Run cold starts so the PWA splash dismisses without waiting on the network.
+    matcher: ({ request, url }) =>
+      request.mode === 'navigate' && url.origin === self.location.origin,
+    handler: new NetworkFirst({
+      cacheName: 'pages',
+      networkTimeoutSeconds: 3,
+      plugins: [
+        new ExpirationPlugin({
+          maxEntries: 32,
+          maxAgeSeconds: 24 * 60 * 60
+        })
+      ]
+    })
+  },
   {
     matcher: /^https:\/\/fonts\.googleapis\.com\/.*/,
     handler: new StaleWhileRevalidate({
@@ -133,7 +148,7 @@ const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
   skipWaiting: true,
   clientsClaim: true,
-  navigationPreload: false,
+  navigationPreload: true,
   runtimeCaching
 });
 


### PR DESCRIPTION
# Summary

Reduce the time the PWA splash screen stays visible after launch by caching navigations in the service worker and enabling navigation preload.

# Motivation

When the installed PWA was launched after a period of inactivity, the splash screen could remain on screen for ten seconds or more before any UI rendered. Both the web frontend and the Rails API run on Cloud Run, and stacking their cold starts on top of the SSR data fetch in `src/app/[lang]/layout.tsx` regularly exceeded Chrome's splash timeout. Killing and relaunching the app worked around the symptom because the instances were warm by then, but the cached HTML that prior visits should have produced was not actually being used: `src/worker/index.ts` registered runtime caches only for Google Fonts and Cloud Storage images, so navigation requests went to the network on every launch and lost the benefit of being a PWA.

# Changes

- `src/worker/index.ts`: add a `NetworkFirst` handler with a 3 second `networkTimeoutSeconds` for same-origin navigation requests so a cached HTML response is returned immediately when the network is slow. Enable `navigationPreload`.
- `next.config.js`: enable `cacheOnNavigation` so client-side route transitions also populate the navigation cache.

# Design notes

`start_url` in `public/app.webmanifest` is left at `/?utm_source=homescreen` rather than a locale-prefixed path. Hard-coding `/en` would skip one middleware hop on launch but override the `Accept-Language` detection in `src/middleware.ts`, forcing Japanese users to the English UI. The single redirect saved on launch is not worth that locale regression.

# Out of scope

- Caching `/api/v1/...` responses in the service worker. The route handler in `src/app/api/v1/[...path]/route.ts` currently mixes guest and authenticated paths under the same URL (`^maps$`, `^users\/\d+\/maps$`), so partial caching would risk leaking authenticated responses to guests. Splitting the URL surface into guest-only paths and then layering `StaleWhileRevalidate` on top is left to a follow-up.
- Streaming the auth/profile/notifications fetch in `src/app/[lang]/layout.tsx` via React Suspense to improve the cold-start TTFB for first-time visits.
- Invalidating the navigation cache on sign-out. The `pages` cache is per-browser-profile so cross-user leakage is impossible, but a recently-signed-out user could briefly see the previously cached signed-in HTML if the network does not respond within the 3 second `NetworkFirst` window. Calling `caches.delete('pages')` from the sign-out flow is left as a follow-up.
- Shipping a branded offline fallback page. The browser's default offline indicator is used when both the network fails and the navigation cache misses; a custom page added in an earlier iteration could not be exercised end-to-end during manual testing and was dropped to avoid shipping unverified content.

# Testing

- `pnpm biome ci ./src` — passes.
- `pnpm exec tsc --noEmit` — passes.
- `pnpm build` — succeeds.
- Manual verification on a deployed environment: with Cloud Run scaled to zero, launching the installed PWA dismisses the splash screen within a few seconds because the previously cached HTML is served by `NetworkFirst` while the cold start happens in the background.

🤖 Generated with [Claude Code](https://claude.ai/code)
