### PR TITLE
fix(pwa): clear nav cache on auth transitions

### DIFF
--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -48,6 +48,12 @@ function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
     });
   }, []);
 
+  const clearNavigationCache = useCallback(async () => {
+    if (typeof caches !== 'undefined') {
+      await caches.delete('pages');
+    }
+  }, []);
+
   const handleIdTokenChanged = useCallback(
     async (user: User | null) => {
       if (user) {
@@ -60,6 +66,7 @@ function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
 
           if (authStateRef.current) {
             authStateRef.current = false;
+            await clearNavigationCache();
             router.refresh();
           }
         } else {
@@ -69,6 +76,7 @@ function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
           if (!authStateRef.current) {
             await fetch('/api/v1/users', { method: 'POST' });
             authStateRef.current = true;
+            await clearNavigationCache();
             router.refresh();
           }
 
@@ -85,11 +93,12 @@ function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
 
         if (authStateRef.current) {
           authStateRef.current = false;
+          await clearNavigationCache();
           router.refresh();
         }
       }
     },
-    [syncSessionCookie, router]
+    [syncSessionCookie, clearNavigationCache, router]
   );
 
   useEffect(() => {


### PR DESCRIPTION
# Summary

Drop the navigation cache (`pages`) introduced by #1059 whenever `AuthProvider` detects an auth-state transition (anonymous user delete, sign in, sign out), so the timeout window in `NetworkFirst` cannot resurface HTML that was cached for a different auth state.

# Motivation

The navigation cache stores SSR-rendered HTML keyed by URL, and the locale layout (`src/app/[lang]/layout.tsx`) inlines the signed-in user's profile and notifications into that HTML. The same URL therefore produces different bodies before and after each auth transition. With the 3 second `networkTimeoutSeconds` configured on `NetworkFirst`, the fallback path can serve a body that no longer matches the current session — a recently signed-out user could see the cached signed-in HTML, and a freshly signed-in user could see the cached guest HTML. Cache Storage is partitioned per browser profile so cross-user leakage is impossible; the failure mode is intra-profile only.

PR #1059 listed sign-out invalidation as an Out of scope follow-up; this PR closes that and the symmetric sign-in case.

# Changes

- `src/components/auth/AuthProvider.tsx`:
  - Add a `clearNavigationCache` `useCallback` that wraps `caches.delete('pages')` with a `typeof caches !== 'undefined'` guard. The guard keeps the call safe under SSR module evaluation and on browsers without the Cache Storage API.
  - Call it from all three auth-state transitions in `handleIdTokenChanged`: the anonymous-user delete branch, the sign-in transition (`if (!authStateRef.current)` inside the non-anonymous branch), and the ordinary sign-out branch. Each call sits between flipping `authStateRef.current` and `router.refresh()`, so the refreshed RSC cannot pick up a stale cache as a fallback.

# Design notes

The cache name `'pages'` is the same string set on the `NetworkFirst` handler in `src/worker/index.ts`. Three call sites would otherwise repeat the guarded delete, so the operation is consolidated into a single `useCallback` inside `AuthProvider`. Pulling the cache name across the worker / React boundary into a shared module is intentionally avoided — a cross-context import would add packaging weight without a corresponding readability gain at this scale.

The `caches.delete` result (a `boolean` indicating whether anything was removed) is intentionally ignored: a false return means there was nothing to clear, which is the desired post-condition either way. No `try/catch` is added; a Cache Storage failure is rare and recovering inside the auth flow would not produce a better outcome than letting React handle the rejected promise.

The anonymous-user delete branch does not call `syncSessionCookie(null)` while the ordinary sign-out branch does, but that asymmetry predates this PR and is independent of cache invalidation. If it is reproducible in practice it deserves its own change.

# Out of scope

These remain as separate follow-ups, in the same vein as #1059's Out of scope section:

- Caching `/api/v1/...` responses in the service worker, which depends on splitting the route handler's URL surface (`src/app/api/v1/[...path]/route.ts`) into guest-only and authenticated paths.
- Streaming the auth/profile/notifications fetch in `src/app/[lang]/layout.tsx` via React Suspense to improve cold-start TTFB for first-time visits.

# Testing

- `pnpm biome ci ./src` — passes.
- `pnpm exec tsc --noEmit` — passes.
- Manual verification in Chrome DevTools → Application → Cache Storage, observing the `pages` cache:
  - Browse a few routes signed out: cache accumulates guest HTML entries.
  - Sign in: cache becomes empty, then re-fills with signed-in HTML as routes are visited.
  - Sign out: cache becomes empty again. Switch to DevTools → Network → Offline and reload — the previously cached signed-in HTML must no longer be served.

🤖 Generated with [Claude Code](https://claude.ai/code)
