### PR TITLE
perf(pwa): stream layout fetches via suspense

### DIFF
--- a/src/app/[lang]/AccountProviders.tsx
+++ b/src/app/[lang]/AccountProviders.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { type ReactNode, use } from 'react';
+import type { Notification, Profile } from '../../../types';
+import NotificationsContext from '../../context/NotificationsContext';
+import ProfileContext from '../../context/ProfileContext';
+
+type Props = {
+  profilePromise: Promise<Profile | null>;
+  notificationsPromise: Promise<Notification[]>;
+  children: ReactNode;
+};
+
+export default function AccountProviders({
+  profilePromise,
+  notificationsPromise,
+  children
+}: Props) {
+  const profile = use(profilePromise);
+  const notifications = use(notificationsPromise);
+
+  return (
+    <ProfileContext.Provider value={profile}>
+      <NotificationsContext.Provider value={notifications}>
+        {children}
+      </NotificationsContext.Provider>
+    </ProfileContext.Provider>
+  );
+}

--- a/src/app/[lang]/Providers.tsx
+++ b/src/app/[lang]/Providers.tsx
@@ -2,7 +2,9 @@
 
 import { css } from '@emotion/react';
 import {
+  Box,
   Button,
+  CircularProgress,
   CssBaseline,
   GlobalStyles,
   ThemeProvider,
@@ -14,6 +16,7 @@ import { enUS, jaJP } from '@mui/material/locale';
 import { SnackbarProvider, closeSnackbar } from 'notistack';
 import {
   type ReactNode,
+  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -21,11 +24,10 @@ import {
 } from 'react';
 import type { Notification, Profile } from '../../../types';
 import AuthProvider from '../../components/auth/AuthProvider';
-import NotificationsContext from '../../context/NotificationsContext';
-import ProfileContext from '../../context/ProfileContext';
 import ServiceWorkerContext from '../../context/ServiceWorkerContext';
 import useDictionary from '../../hooks/useDictionary';
 import { usePushManager } from '../../hooks/usePushManager';
+import AccountProviders from './AccountProviders';
 import AnalyticsTracker from './AnalyticsTracker';
 
 const globalStyles = css`
@@ -41,8 +43,8 @@ type Props = {
   lang: string;
   serverAuthenticated: boolean;
   serverUid?: string;
-  profile: Profile | null;
-  notifications: Notification[];
+  profilePromise: Promise<Profile | null>;
+  notificationsPromise: Promise<Notification[]>;
 };
 
 export default function Providers({
@@ -50,8 +52,8 @@ export default function Providers({
   lang,
   serverAuthenticated,
   serverUid,
-  profile,
-  notifications
+  profilePromise,
+  notificationsPromise
 }: Props) {
   const dictionary = useDictionary();
 
@@ -59,6 +61,8 @@ export default function Providers({
     useState<ServiceWorkerRegistration>(null);
 
   usePushManager(registration);
+
+  const serviceWorkerValue = useMemo(() => ({ registration }), [registration]);
 
   const theme = useMemo(() => {
     const locale = lang === 'ja' ? jaJP : enUS;
@@ -134,14 +138,32 @@ export default function Providers({
             serverAuthenticated={serverAuthenticated}
             serverUid={serverUid ?? null}
           >
-            <ProfileContext.Provider value={profile}>
-              <NotificationsContext.Provider value={notifications}>
-                <ServiceWorkerContext.Provider value={{ registration }}>
+            <Suspense
+              fallback={
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '100vw',
+                    height: '100vh',
+                    bgcolor: 'background.default'
+                  }}
+                >
+                  <CircularProgress />
+                </Box>
+              }
+            >
+              <AccountProviders
+                profilePromise={profilePromise}
+                notificationsPromise={notificationsPromise}
+              >
+                <ServiceWorkerContext.Provider value={serviceWorkerValue}>
                   <AnalyticsTracker />
                   {children}
                 </ServiceWorkerContext.Provider>
-              </NotificationsContext.Provider>
-            </ProfileContext.Provider>
+              </AccountProviders>
+            </Suspense>
           </AuthProvider>
         </SnackbarProvider>
       </ThemeProvider>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import type { Notification, Profile } from '../../../types';
 import MiniDrawer from '../../components/layouts/MiniDrawer';
 import MobileAppBar from '../../components/layouts/MobileAppBar';
 import ShellProvider from '../../components/layouts/ShellProvider';
@@ -50,10 +51,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function RootLayout({ children, params }: Props) {
   const { lang } = await params;
   const { authenticated, uid, token } = await getServerAuthState();
-  const [profile, notifications] = await Promise.all([
-    authenticated && uid ? getProfile(uid, lang, token) : null,
-    authenticated ? getNotifications(lang) : []
-  ]);
+  const profilePromise =
+    authenticated && uid
+      ? getProfile(uid, lang, token)
+      : Promise.resolve<Profile | null>(null);
+  const notificationsPromise = authenticated
+    ? getNotifications(lang)
+    : Promise.resolve<Notification[]>([]);
 
   return (
     <html lang={lang}>
@@ -127,8 +131,8 @@ export default async function RootLayout({ children, params }: Props) {
           lang={lang}
           serverAuthenticated={authenticated}
           serverUid={uid}
-          profile={profile}
-          notifications={notifications}
+          profilePromise={profilePromise}
+          notificationsPromise={notificationsPromise}
         >
           <ShellProvider>
             <Box sx={{ display: { xs: 'block', md: 'none' } }}>


### PR DESCRIPTION
# Summary

Hand `getProfile` and `getNotifications` to the layout's client `Providers` as promises and resolve them inside a `<Suspense>` boundary using the React 19 `use()` API, so the HTML body can flush after the cheap auth-cookie read instead of waiting for both Rails API round trips.

# Motivation

The third Out of scope follow-up from #1059 (`feat(pwa): cache navigations during cold starts`) and #1060 (`fix(pwa): clear nav cache on auth transitions`). The locale layout (`src/app/[lang]/layout.tsx`) awaited a `Promise.all([getProfile, getNotifications])` against the Rails API before flushing any HTML, so during a Cloud Run cold start the PWA splash stayed on screen until both round trips finished. Pulling those fetches out of the await path and resolving them inside a Suspense boundary lets the HTML shell stream out as soon as `getServerAuthState()` resolves, which is the point Chrome can dismiss the splash.

# Changes

- `src/app/[lang]/layout.tsx`: keep `await getServerAuthState()` (cookie read, cheap) and replace the `Promise.all` await with two locally-typed promises that are passed straight into `<Providers>` as `profilePromise` / `notificationsPromise`.
- `src/app/[lang]/Providers.tsx`: switch the props from resolved values to promises, wrap the existing context tree in a `<Suspense>` boundary with a fullscreen `<CircularProgress>` fallback, delegate the `ProfileContext` / `NotificationsContext` providers to a new client component, and memoize the `ServiceWorkerContext` value so its only consumer (`PushNotificationsCard`) is no longer rerendered by unrelated state changes in `Providers`.
- `src/app/[lang]/AccountProviders.tsx` (new): a `'use client'` component that calls `use()` on each promise and renders `<ProfileContext.Provider>` / `<NotificationsContext.Provider>` with the resolved values.

# Design notes

`getServerAuthState()` stays awaited. It is a cookie read plus an in-memory Firebase init — no Rails call — and `AuthProvider` consumes the resulting `serverAuthenticated` / `serverUid` as `useState` initial values, which need to be present synchronously at mount. Promoting it to a streamed promise would force `AuthProvider` to be redesigned around `use()` for a few-millisecond saving.

The Suspense boundary wraps the entire `Providers` subtree (everything below `AuthProvider`, including page `{children}`). `ProfileContext` is consumed not only by the layout shell (`MiniDrawer` / `MobileAppBar` / `BottomNav` / `AccountMenuButton` / `MobileDrawer`) but also by page-level components in `reviews/`, `maps/`, and `settings/`, so a narrower boundary would force every consumer to suspend independently without buying any earlier paint for them. The shell-flush goal is unaffected by the boundary width — what flushes early is the HTML *above* the boundary (`<html>`, `<head>`, the `<body>` opening), and that already covers everything Chrome needs to register a contentful paint and dismiss the splash.

The fallback is a fullscreen MUI `<CircularProgress>` over `background.default`. A skeleton that mirrors the `MiniDrawer` / `MobileAppBar` outline would reduce CLS, but the boundary is wide enough that a skeleton would have to redraw the entire layout — the maintenance cost outweighs the CLS gain at this step. If CLS becomes measurable in production, a shell skeleton is a self-contained follow-up.

`AccountProviders` is named for the domain it serves (the user account — profile and notifications), not the React 19 streaming mechanism it happens to use. The `Account` prefix is already established in this project (`AccountMenuButton`, `AccountEmailCard`, the `Account` menu items in the drawers). The outer `Providers.tsx` (theme / MUI / Snackbar / `AuthProvider`) and the inner `AccountProviders.tsx` (profile + notifications) share the `Providers` suffix but operate at clearly different scopes.

`ServiceWorkerContext` is fed by an object literal `{ registration }` whose outer reference would otherwise be re-allocated on every render of `Providers`, forcing the only consumer (`PushNotificationsCard`) to re-render even when `registration` itself was unchanged. Wrapping the value in `useMemo` follows the same pattern already used for the `ShellContext` value in `src/components/layouts/ShellProvider.tsx`.

# Out of scope

- Enabling PPR (`experimental.ppr`). Suspense streaming and PPR are complementary but independent.
- Refactoring `AuthProvider` to take an auth promise. The synchronous `serverAuthenticated` / `serverUid` props remain sufficient.
- Wrapping `getProfile` / `getNotifications` in `try/catch` and returning empty fallbacks. Failure handling at the lib layer is a separate concern.
- A finer-grained boundary that wraps only the notifications badge in `MiniDrawer`.
- Streaming `(contained)/layout.tsx`'s `getPopularMaps` / `getRecommendMaps`. Different layout, different PR.
- Changes to the sign-in flow (`/api/v1/users` POST in `AuthProvider.handleIdTokenChanged`).
- Adding an `error.tsx`. The current behaviour on `getProfile` / `getNotifications` rejection is unchanged — both before and after this PR, a rejection bubbles to the framework's default error UI.
- A skeleton fallback that mirrors the `MiniDrawer` / `MobileAppBar` shape.

# Testing

- `pnpm biome ci ./src` — passes.
- `pnpm exec tsc --noEmit` — passes.
- `pnpm build` — passes.
- Manual verification:
  - In Chrome DevTools → Network with Slow 3G throttling, the `localhost` document response shows a first chunk arriving immediately after `getServerAuthState()` resolves; profile and notifications arrive in later chunks once the Rails API responds.
  - With the throttling profile that delays `/users/{uid}` and `/notifications` by ~3 s, the Performance tab shows the body's first byte arriving well before either Rails request completes, and the Suspense fallback `<CircularProgress>` is rendered until the resolutions land.
  - Signed-out path (cookie cleared): `Promise.resolve(null)` and `Promise.resolve([])` make the boundary resolve synchronously, so the fallback is effectively unobservable.
  - Service Worker `pages` cache (NetworkFirst, introduced in #1059) continues to serve cached HTML on offline reload — verify by going offline after the first successful load and confirming the same shell still appears.

🤖 Generated with [Claude Code](https://claude.ai/code)
