### PR TITLE
refactor(api): split guest and auth url surfaces

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -33,7 +33,6 @@ jobs:
             --out-file=.env.local
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -31,7 +31,6 @@ jobs:
             --out-file=.env.local
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN corepack enable
 WORKDIR /app
 
 FROM base AS deps
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 FROM base AS builder

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "git@github.com:yusuke-suzuki/qoodish-web.git",
   "author": "Yusuke Suzuki",
   "license": "UNLICENSED",
+  "packageManager": "pnpm@11.0.9",
   "scripts": {
     "dev": "next dev -p 5000",
     "build": "next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@biomejs/biome': true
+  '@firebase/util': true
+  protobufjs: true
+  sharp: true
+  unrs-resolver: true

--- a/src/app/[lang]/(contained)/notifications/page.tsx
+++ b/src/app/[lang]/(contained)/notifications/page.tsx
@@ -49,5 +49,5 @@ export default async function NotificationsPage({ params }: Props) {
   const { lang } = await params;
   const notifications = await getNotifications(lang);
 
-  return <NotificationsFeed initialNotifications={notifications} />;
+  return <NotificationsFeed notifications={notifications} />;
 }

--- a/src/app/[lang]/(contained)/users/[userId]/page.tsx
+++ b/src/app/[lang]/(contained)/users/[userId]/page.tsx
@@ -2,7 +2,11 @@ import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
 import UserProfile from '../../../../../components/profiles/UserProfile';
-import { getProfile, getUserReviews } from '../../../../../lib/users';
+import {
+  getProfile,
+  getUserMaps,
+  getUserReviews
+} from '../../../../../lib/users';
 import { getDictionary } from '../../../../../utils/getDictionary';
 
 type Props = {
@@ -57,7 +61,16 @@ export default async function UserPage({ params }: Props) {
     notFound();
   }
 
-  const initialReviews = await getUserReviews(userId, lang);
+  const [initialReviews, maps] = await Promise.all([
+    getUserReviews(userId, lang),
+    getUserMaps(userId, lang, token)
+  ]);
 
-  return <UserProfile profile={profile} initialReviews={initialReviews} />;
+  return (
+    <UserProfile
+      profile={profile}
+      initialReviews={initialReviews}
+      maps={maps}
+    />
+  );
 }

--- a/src/app/api/v1/[...path]/route.ts
+++ b/src/app/api/v1/[...path]/route.ts
@@ -5,32 +5,49 @@ type Params = {
   params: Promise<{ path: string[] }>;
 };
 
-const ALLOWED_GET_PATTERNS = [/^maps$/, /^users\/\d+\/maps$/, /^guest\/maps$/];
+const ALLOWED_GUEST_GET_PATTERNS = [
+  /^guest\/maps$/,
+  /^guest\/users\/\d+\/maps$/
+];
 
-const ALLOWED_POST_PATTERNS = [/^users$/];
+const ALLOWED_AUTH_POST_PATTERNS = [/^users$/];
 
-function isAllowedPath(joinedPath: string, method: string): boolean {
-  const patterns =
-    method === 'POST' ? ALLOWED_POST_PATTERNS : ALLOWED_GET_PATTERNS;
-  return patterns.some((pattern) => pattern.test(joinedPath));
+type PathClass = 'guest' | 'auth' | 'unknown';
+
+function classifyPath(joinedPath: string, method: string): PathClass {
+  if (
+    method === 'GET' &&
+    ALLOWED_GUEST_GET_PATTERNS.some((pattern) => pattern.test(joinedPath))
+  ) {
+    return 'guest';
+  }
+  if (
+    method === 'POST' &&
+    ALLOWED_AUTH_POST_PATTERNS.some((pattern) => pattern.test(joinedPath))
+  ) {
+    return 'auth';
+  }
+  return 'unknown';
 }
 
 async function proxyRequest(request: NextRequest, { params }: Params) {
   const { path } = await params;
   const joinedPath = path.join('/');
+  const classification = classifyPath(joinedPath, request.method);
 
-  if (!isAllowedPath(joinedPath, request.method)) {
+  if (classification === 'unknown') {
     return NextResponse.json({ detail: 'Not found' }, { status: 404 });
   }
 
   const cookieStore = await cookies();
   const token = cookieStore.get('__session')?.value;
 
+  if (classification === 'auth' && !token) {
+    return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 });
+  }
+
   const url = new URL(request.url);
-  const isGuestPath = joinedPath.startsWith('guest/');
-  const apiPath =
-    isGuestPath || token ? `/${joinedPath}` : `/guest/${joinedPath}`;
-  const apiUrl = `${process.env.API_ENDPOINT}${apiPath}${url.search}`;
+  const apiUrl = `${process.env.API_ENDPOINT}/${joinedPath}${url.search}`;
 
   const headers: Record<string, string> = {
     Accept: 'application/json',
@@ -38,7 +55,7 @@ async function proxyRequest(request: NextRequest, { params }: Params) {
       request.headers.get('accept-language')?.split(',')[0] ?? 'en'
   };
 
-  if (token) {
+  if (classification === 'auth' && token) {
     headers.Authorization = `Bearer ${token}`;
   }
 
@@ -63,7 +80,7 @@ async function proxyRequest(request: NextRequest, { params }: Params) {
       }
     });
   } catch (error) {
-    console.error(`Proxy error for ${apiPath}:`, error);
+    console.error(`Proxy error for /${joinedPath}:`, error);
     return NextResponse.json(
       { detail: 'Internal proxy error' },
       { status: 502 }

--- a/src/components/notifications/NotificationsFeed.tsx
+++ b/src/components/notifications/NotificationsFeed.tsx
@@ -7,10 +7,10 @@ import type { Notification } from '../../../types';
 import NotificationList from './NotificationList';
 
 type Props = {
-  initialNotifications: Notification[];
+  notifications: Notification[];
 };
 
-export default function NotificationsFeed({ initialNotifications }: Props) {
+export default function NotificationsFeed({ notifications }: Props) {
   const router = useRouter();
 
   const handleReadNotifications = useCallback(() => {
@@ -20,7 +20,7 @@ export default function NotificationsFeed({ initialNotifications }: Props) {
   return (
     <List>
       <NotificationList
-        notifications={initialNotifications}
+        notifications={notifications}
         onReadNotifications={handleReadNotifications}
       />
     </List>

--- a/src/components/profiles/UserMaps.tsx
+++ b/src/components/profiles/UserMaps.tsx
@@ -1,40 +1,18 @@
 import { Map as MapIcon } from '@mui/icons-material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo } from 'react';
 import type { AppMap } from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
 import NoContents from '../common/NoContents';
 import MapGridList from '../maps/MapGridList';
 
 type Props = {
-  userId: number;
+  maps: AppMap[];
 };
 
-export default memo(function UserMaps({ userId }: Props) {
-  const [maps, setMaps] = useState<AppMap[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
+export default memo(function UserMaps({ maps }: Props) {
   const dictionary = useDictionary();
 
-  const loadMaps = useCallback(async () => {
-    setIsLoading(true);
-
-    try {
-      const res = await fetch(`/api/v1/users/${userId}/maps`);
-
-      if (res.ok) {
-        const data: AppMap[] = await res.json();
-        setMaps(data);
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [userId]);
-
-  useEffect(() => {
-    loadMaps();
-  }, [loadMaps]);
-
-  if (!isLoading && maps.length < 1) {
+  if (maps.length < 1) {
     return (
       <NoContents icon={MapIcon} message={dictionary['maps will see here']} />
     );

--- a/src/components/profiles/UserProfile.tsx
+++ b/src/components/profiles/UserProfile.tsx
@@ -19,7 +19,7 @@ import {
   useContext,
   useState
 } from 'react';
-import type { Profile, Review } from '../../../types';
+import type { AppMap, Profile, Review } from '../../../types';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
 import ProfileAvatar from '../common/ProfileAvatar';
@@ -30,9 +30,10 @@ import UserReviews from './UserReviews';
 type Props = {
   profile: Profile;
   initialReviews: Review[];
+  maps: AppMap[];
 };
 
-function UserProfile({ profile, initialReviews }: Props) {
+function UserProfile({ profile, initialReviews, maps }: Props) {
   const { uid } = useContext(AuthContext);
   const router = useRouter();
 
@@ -135,7 +136,7 @@ function UserProfile({ profile, initialReviews }: Props) {
           <UserReviews userId={profile.id} initialReviews={initialReviews} />
         </TabPanel>
         <TabPanel value="2" sx={{ px: 0 }}>
-          <UserMaps userId={profile.id} />
+          <UserMaps maps={maps} />
         </TabPanel>
       </TabContext>
 


### PR DESCRIPTION
# Summary

Remove the auto-fallback in the `/api/v1/[...path]` route handler (which switched the Rails path based on token presence) and split the URL surface into guest GET (`/api/v1/guest/...`) and authenticated POST (`/api/v1/users`). Move the only authenticated GET caller (`UserMaps`) off the route handler by switching it to SSR. Drop the `initial` prop prefix in places where it is not actually a `useState` seed. Upgrade pnpm to 11.0.9 via `packageManager`, migrate the build allow list to `pnpm-workspace.yaml`, and remove the redundant `version` input from `pnpm/action-setup` so the Docker build no longer halts at `ERR_PNPM_IGNORED_BUILDS`.

# Background

Follow-up to #1059 / #1060 / #1061, preparing the ground for caching `/api/v1/...` responses in the service worker. While the auto-fallback was in place, the same URL `/api/v1/maps` could return either an authenticated or an anonymous response depending on the cookie. Layering `StaleWhileRevalidate` on top would let an authenticated response leak to an anonymous viewer.

The first idea was to point `UserMaps.tsx`'s client fetch at `/api/v1/guest/users/:id/maps`. That does not work: on the Rails side, `/users/:id/maps` (auth) and `/guest/users/:id/maps` (guest) differ in that `private = true` maps are excluded from the data set itself in the guest path, so a viewer looking at their own profile would no longer see their own private maps. The chosen approach is to fetch on the server through `getUserMaps(userId, lang, token)`, mirroring the existing `UserReviews` SSR pattern.

# Changes

## URL surface split and SSR migration

- `src/app/api/v1/[...path]/route.ts`:
  - Rename `ALLOWED_GET_PATTERNS` / `ALLOWED_POST_PATTERNS` to `ALLOWED_GUEST_GET_PATTERNS` / `ALLOWED_AUTH_POST_PATTERNS`.
  - Add `classifyPath`, returning `guest` / `auth` / `unknown`. Reply 404 for `unknown` and 401 for `auth` without a token.
  - Drop the `isGuestPath` variable and the auto-fallback (`isGuestPath || token ? /${path} : /guest/${path}`); the path forwarded to Rails is always `/${joinedPath}`.
- `src/components/profiles/UserMaps.tsx`: drop `useState` / `useEffect` / the client `fetch`; the component now forwards the prop straight to `<MapGridList>`.
- `src/components/profiles/UserProfile.tsx`: add `maps: AppMap[]` to `Props` and pass it to `<UserMaps>`.
- `src/app/[lang]/(contained)/users/[userId]/page.tsx`: call `getUserMaps(userId, lang, token)` in parallel with `getUserReviews` and pass `maps` down.

## `initial` prefix cleanup

In this repository, the `initial` prefix marks a value used as the seed of `useState` and later replaced via `setState` — `UserReviews.initialReviews` (seeds `useState`, appended to in `loadMore`) and `Timeline.initialReviews` (same shape). When a component forwards a prop straight to a child without going through `useState`, the prefix misleadingly implies a client-side update that never happens.

Drop the prefix in the two components where this applies:

- `src/components/profiles/UserMaps.tsx`: `initialMaps` → `maps` (introduced in this PR by the SSR migration above).
- `src/components/notifications/NotificationsFeed.tsx`: `initialNotifications` → `notifications` (pre-existing; no `useState`, refreshes via `router.refresh()`).

`UserReviews.initialReviews` and `Timeline.initialReviews` keep the prefix because they are genuine state seeds.

## pnpm 11 upgrade and build allow list (independent commit)

The Docker build halts at `pnpm install --frozen-lockfile` with `ERR_PNPM_IGNORED_BUILDS`. pnpm treats a dependency's lifecycle script as an unreviewed supply-chain risk and refuses the install unless the project explicitly opts each package in. Five dependencies in this tree ship such scripts:

- `sharp` — fetches the native image binding required at runtime.
- `unrs-resolver` — installs a native resolver used by Next.js.
- `@biomejs/biome` — pulls the platform-specific Biome binary.
- `@firebase/util` / `protobufjs` — postinstall steps from the Firebase SDK chain.

pnpm 11 removed `package.json`'s `pnpm.onlyBuiltDependencies` in favor of `pnpm-workspace.yaml`'s `allowBuilds` map, and corepack now ships pnpm 11 as its default. This commit migrates to the new layout:

- `package.json`: set `"packageManager": "pnpm@11.0.9"` and remove the legacy `pnpm.onlyBuiltDependencies` block.
- `pnpm-workspace.yaml` (new): `allowBuilds` map with the five packages above set to `true`. Generated content matches `pnpm approve-builds --all`.
- `Dockerfile`: include `pnpm-workspace.yaml` in the `COPY` that brings the manifest into the `deps` stage. Without it the container's `pnpm install` cannot see the allow list and ignored builds become fatal inside the build.
- `.github/workflows/dev.yaml` and `.github/workflows/prod.yaml`: drop the `version: 10` input from `pnpm/action-setup@v4`. With `packageManager` present, the action reads the resolved version from `package.json`; declaring both produces a "Multiple versions of pnpm specified" error.

This change is in its own commit (`build:`) so it can be reviewed independently of the route handler refactor.

# Private map behavior

`getUserMaps` selects the Rails path through `apiFetch`'s `guest = !token`, so the SSR migration preserves the existing behavior:

| Scenario | Token | Rails path | Data set |
| --- | --- | --- | --- |
| Own profile (signed in) | yes | `/users/:id/maps` (auth) | Includes the viewer's own private maps |
| Other profile (signed in) | yes | `/users/:id/maps` (auth) | Other users' private maps excluded by Rails |
| Other profile (signed out) | no | `/guest/users/:id/maps` | Public only |

# Verification

- [x] `corepack pnpm biome ci ./src` (pnpm 11.0.9).
- [x] `corepack pnpm exec tsc --noEmit` (pnpm 11.0.9).
- [x] `corepack pnpm install --frozen-lockfile` with `CI=true` in a fresh store containing `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml`: completes on pnpm 11.0.9 with all five postinstall scripts running and no `ERR_PNPM_IGNORED_BUILDS`. Omitting `pnpm-workspace.yaml` reproduces the original failure, confirming the file is required at install time.
- [ ] CI `build-image` step succeeds.
- [ ] On the viewer's own profile (signed in), the "maps" tab shows the viewer's own private maps and the Network panel shows no client fetch to `/api/v1/users/:id/maps`.
- [ ] On another user's profile (signed in or signed out), only public maps are listed.
- [ ] `GET /api/v1/guest/maps?popular=true` → 200.
- [ ] `GET /api/v1/maps?popular=true` → 401 (auto-fallback removed).
- [ ] `GET /api/v1/users/:id/maps` → 404 (no auth GET pattern).
- [ ] `POST /api/v1/users` with cookie → 2xx (sign-in flow).
- [ ] The search bar continues to hit `/api/v1/guest/maps?input=...`.
- [ ] On `/notifications`, notifications render and reading them triggers `router.refresh()`.

# Out of scope

- Adding `runtimeCaching` (`StaleWhileRevalidate`) for `/api/v1/guest/maps` in `src/worker/index.ts`, with a matcher restricted to explicit guest URLs.
- Adding new endpoints (such as `/reviews`) to `ALLOWED_*_PATTERNS`.
- Revisiting how `UserReviews` is given the token.
- Adding `error.tsx`.

🤖 Generated with [Claude Code](https://claude.ai/code)