### PR TITLE
fix(maps): break re-render loop on place selection

### DIFF
--- a/src/app/[lang]/maps/[mapId]/loading.tsx
+++ b/src/app/[lang]/maps/[mapId]/loading.tsx
@@ -1,7 +1,17 @@
-import { Box, Skeleton, Stack } from '@mui/material';
+import {
+  Box,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Divider,
+  Skeleton
+} from '@mui/material';
 
 const summaryCardWidth = 360;
 const bottomSheetHeight = 105;
+
+const reviewSkeletonKeys = ['a', 'b', 'c'];
 
 export default function Loading() {
   return (
@@ -10,24 +20,63 @@ export default function Loading() {
         sx={{
           display: { xs: 'none', md: 'block' },
           width: summaryCardWidth,
-          height: '100dvh',
-          p: 2
+          height: '100dvh'
         }}
       >
-        <Stack spacing={2}>
-          <Skeleton variant="rectangular" height={160} />
-          <Skeleton variant="text" height={32} width="70%" />
-          <Skeleton variant="text" />
-          <Skeleton variant="text" width="80%" />
-          <Stack direction="row" spacing={1}>
-            <Skeleton variant="rounded" width={100} height={32} />
-            <Skeleton variant="rounded" width={100} height={32} />
-          </Stack>
-          <Skeleton variant="rectangular" height={1} />
-          <Skeleton variant="text" width="40%" />
-          <Skeleton variant="rectangular" height={120} />
-          <Skeleton variant="rectangular" height={120} />
-        </Stack>
+        <Card sx={{ height: '100%', width: '100%', overflowY: 'auto' }}>
+          <Skeleton variant="rectangular" height={180} />
+          <CardContent sx={{ pb: 0 }}>
+            <Skeleton height={70} />
+          </CardContent>
+          <CardHeader
+            avatar={<Skeleton variant="circular" width={40} height={40} />}
+            title={<Skeleton height={20} width="50%" />}
+            subheader={<Skeleton height={20} width="50%" />}
+          />
+          <CardContent sx={{ pt: 0, pb: 0 }}>
+            <Skeleton />
+            <Skeleton />
+          </CardContent>
+          <CardActions sx={{ p: 2 }}>
+            <Skeleton variant="rounded" height={36} width="100%" />
+          </CardActions>
+          <Divider />
+          <CardContent>
+            <Skeleton variant="text" width="30%" sx={{ mb: 1 }} />
+            <Box sx={{ display: 'flex', gap: 0.5 }}>
+              <Skeleton variant="circular" width={40} height={40} />
+              <Skeleton variant="circular" width={40} height={40} />
+              <Skeleton variant="circular" width={40} height={40} />
+            </Box>
+          </CardContent>
+          <Divider />
+          <CardContent>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                mb: 1
+              }}
+            >
+              <Skeleton variant="text" width="30%" />
+              <Skeleton variant="text" width={24} />
+            </Box>
+            {reviewSkeletonKeys.map((key) => (
+              <Box
+                key={key}
+                sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 1 }}
+              >
+                <Skeleton variant="rounded" width={40} height={40} />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Skeleton variant="text" width="60%" />
+                  <Skeleton variant="text" width="80%" />
+                </Box>
+                <Skeleton variant="circular" width={24} height={24} />
+              </Box>
+            ))}
+          </CardContent>
+        </Card>
       </Box>
 
       <Skeleton

--- a/src/components/maps/CustomOverlays.tsx
+++ b/src/components/maps/CustomOverlays.tsx
@@ -98,6 +98,26 @@ function CustomOverlays({ map, reviews, onReviewSaved, onReviewClick }: Props) {
     [onReviewClick]
   );
 
+  const handleCreateReviewOpen = useCallback(() => {
+    setCreateReviewDialogOpen(true);
+  }, []);
+
+  const handleCreateReviewClose = useCallback(() => {
+    setCreateReviewDialogOpen(false);
+  }, []);
+
+  const handlePlaceClose = useCallback(() => {
+    setCurrentPlace(null);
+  }, []);
+
+  const handlePinnedPositionClose = useCallback(() => {
+    setPinnedPosition(null);
+  }, []);
+
+  const handlePopoverClose = useCallback(() => {
+    setPopoverAnchorEl(null);
+  }, []);
+
   const handleMapClick = useCallback(
     async (event: google.maps.MapMouseEvent | google.maps.IconMouseEvent) => {
       if ('placeId' in event) {
@@ -201,7 +221,7 @@ function CustomOverlays({ map, reviews, onReviewSaved, onReviewClick }: Props) {
           anchorEl={popoverAnchorEl}
           popoverId={reviewPopoverId}
           popoverOpen={popoverOpen}
-          onPopoverClose={() => setPopoverAnchorEl(null)}
+          onPopoverClose={handlePopoverClose}
           onSaved={onReviewSaved}
           onDeleted={handleReviewDeleted}
         />
@@ -210,22 +230,22 @@ function CustomOverlays({ map, reviews, onReviewSaved, onReviewClick }: Props) {
       <PlaceInfoWindow
         place={currentPlace}
         disableCreateReview={!map || !map.postable}
-        onCreateReviewClick={() => setCreateReviewDialogOpen(true)}
-        onClose={() => setCurrentPlace(null)}
+        onCreateReviewClick={handleCreateReviewOpen}
+        onClose={handlePlaceClose}
       />
 
       <PositionInfoWindow
         position={pinnedPosition}
         disableCreateReview={!map || !map.postable}
-        onCreateReviewClick={() => setCreateReviewDialogOpen(true)}
-        onClose={() => setPinnedPosition(null)}
+        onCreateReviewClick={handleCreateReviewOpen}
+        onClose={handlePinnedPositionClose}
       />
 
       <CustomMapControls onPlaceChange={setCurrentPlace} />
 
       <CreateReviewDialog
         open={createReviewDialogOpen}
-        onClose={() => setCreateReviewDialogOpen(false)}
+        onClose={handleCreateReviewClose}
         map={map}
         place={currentPlace}
         currentPosition={currentPosition}

--- a/src/components/maps/GoogleMaps.tsx
+++ b/src/components/maps/GoogleMaps.tsx
@@ -101,18 +101,21 @@ function GoogleMaps({
     }
   }, [googleMap, zoom]);
 
+  const contextValue = useMemo(
+    () => ({
+      googleMap,
+      loader,
+      currentPosition,
+      setCurrentPosition
+    }),
+    [googleMap, loader, currentPosition]
+  );
+
   return (
     <Box>
       <Box ref={mapRef} sx={sx} />
 
-      <GoogleMapsContext.Provider
-        value={{
-          googleMap: googleMap,
-          loader: loader,
-          currentPosition: currentPosition,
-          setCurrentPosition: setCurrentPosition
-        }}
-      >
+      <GoogleMapsContext.Provider value={contextValue}>
         {children}
       </GoogleMapsContext.Provider>
     </Box>

--- a/src/components/maps/InfoWindow.tsx
+++ b/src/components/maps/InfoWindow.tsx
@@ -25,7 +25,8 @@ function InfoWindow({ children, position, open, onClose }: Props) {
     const { InfoWindow } = await loader.importLibrary('maps');
 
     const window = new InfoWindow({
-      content: container
+      content: container,
+      disableAutoPan: true
     });
 
     setInfoWindow(window);
@@ -50,7 +51,11 @@ function InfoWindow({ children, position, open, onClose }: Props) {
       return;
     }
 
-    infoWindow.addListener('closeclick', onClose);
+    const listener = infoWindow.addListener('closeclick', onClose);
+
+    return () => {
+      listener.remove();
+    };
   }, [infoWindow, onClose]);
 
   useEffect(() => {

--- a/src/components/maps/MobileMapDrawer.tsx
+++ b/src/components/maps/MobileMapDrawer.tsx
@@ -17,6 +17,7 @@ import MapCardHeader from './MapCardHeader';
 import MapMenuButton from './MapMenuButton';
 import MapReviewList from './MapReviewList';
 import MobileMiniMapHeader from './MobileMiniMapHeader';
+import PrivateMapChip from './PrivateMapChip';
 import UnfollowButton from './UnfollowButton';
 
 const drawerBleeding = 105;
@@ -114,15 +115,15 @@ function MobileMapDrawer({
             height: drawerBleeding
           }}
         >
-          <MobileMiniMapHeader
-            map={map}
-            reviews={reviews}
-            draggable
-            sx={{ pt: 0 }}
-          />
+          <MobileMiniMapHeader map={map} reviews={reviews} draggable />
         </Box>
         <Divider />
         <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0 }}>
+          {map?.private && (
+            <Box sx={{ px: 2, pt: 2 }}>
+              <PrivateMapChip />
+            </Box>
+          )}
           <MapCardHeader
             map={map}
             action={

--- a/src/components/maps/MobileMiniMapHeader.tsx
+++ b/src/components/maps/MobileMiniMapHeader.tsx
@@ -1,9 +1,8 @@
-import { DragHandle } from '@mui/icons-material';
+import { DragHandle, Lock } from '@mui/icons-material';
 import { Avatar, Box, CardHeader, Skeleton, type SxProps } from '@mui/material';
 import { type ReactNode, memo } from 'react';
 import type { AppMap, Review } from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
-import PrivateMapChip from './PrivateMapChip';
 
 type Props = {
   map: AppMap | null;
@@ -40,30 +39,39 @@ function MobileMiniMapHeader({ map, reviews, draggable, action, sx }: Props) {
         title={map ? map.name : <Skeleton width="100%" />}
         subheader={
           map ? (
-            <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-              {reviews.length} {dictionary['spots count']}
-              {map.private && <PrivateMapChip />}
-            </Box>
+            `${reviews.length} ${dictionary['spots count']}`
           ) : (
             <Skeleton width="50%" />
           )
         }
-        action={action || null}
+        action={
+          action ??
+          (map?.private ? (
+            <Lock
+              fontSize="small"
+              color="action"
+              titleAccess={dictionary.private}
+            />
+          ) : null)
+        }
         slotProps={{
+          root: {
+            sx: { pt: 0 }
+          },
+          content: {
+            sx: { minWidth: 0 }
+          },
           title: {
             variant: 'subtitle1',
             component: 'h1',
             fontWeight: 600,
-            noWrap: true,
-            width: 'calc(100dvw - 112px)'
+            noWrap: true
           },
-
           subheader: {
             variant: 'body2',
             component: 'div',
             noWrap: true,
-            color: 'text.secondary',
-            width: 'calc(100dvw - 112px)'
+            color: 'text.secondary'
           }
         }}
       />


### PR DESCRIPTION
# Summary

Three independent bug fixes on the map detail screen: the place
InfoWindow opened on autocomplete selection triggered a re-render
loop, the PrivateMapChip was clipped on the right edge of the
mobile bottom-sheet header, and the desktop loading skeleton no
longer matched what `MapSummaryCard` renders once data arrives.

# Motivation

Selecting a place from the autocomplete panned the map (via the
InfoWindow's auto-pan), which emitted an `idle` event that
re-rendered `CustomOverlays` with fresh inline callback identities,
breaking the memoization of its children and triggering another
render. The loop only stopped when the user dismissed the
InfoWindow.

Separately, the private-map indicator chip sat inline next to the
spot count in the mini header's `subheader` row. On narrow
viewports any width the chip needed had to come out of the title
and subheader column, so the chip's right edge was always clipped.

The detail-page loading skeleton had drifted from
`MapSummaryCard`'s structure: image height, divider count, and
per-section composition (owner header, followers row, spots list)
all differed, so the skeleton no longer matched the loaded layout
and a visible content shift appeared when the data arrived.

# Changes

- `InfoWindow`: set `disableAutoPan: true` so opening the window
  no longer pans the map, and capture the `closeclick` listener so
  the effect cleanup can remove it.
- `GoogleMaps`: memoize the context value via `useMemo` so
  consumers do not re-render on every parent render.
- `CustomOverlays`: hoist inline callbacks passed to
  `PlaceInfoWindow`, `PositionInfoWindow`, `ReviewPopover`, and
  `CreateReviewDialog` behind `useCallback` so the memoized
  children stay stable across renders.
- `MobileMiniMapHeader`: move `PrivateMapChip` out of the
  subheader row. The `action` slot now carries only a `Lock` icon
  (with `titleAccess` for screen readers). Drop the
  `width: calc(100dvw - 112px)` from the title and subheader slots
  and rely on `minWidth: 0` on the content slot plus `noWrap` for
  ellipsis. Apply `pt: 0` to the root slot directly via
  `slotProps` so the header owns its top padding.
- `MobileMapDrawer`: render the full labeled `PrivateMapChip` at
  the top of the drawer's scrollable content, above
  `MapCardHeader`, so the "Members only" / "フォロワー限定" label
  stays visible when the drawer expands. Drop the now-redundant
  caller-side `sx={{ pt: 0 }}` on `MobileMiniMapHeader`.
- `loading.tsx` (map detail): rebuild the desktop summary skeleton
  to mirror `MapSummaryCard` block by block — image, title,
  `MapCardHeader`, description, follow action, `Divider`,
  followers row, `Divider`, spots heading + list — so the
  pre-load geometry matches the loaded layout.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0129vtEQ99LRCep4xz44sari)_