### PR TITLE
fix: reset mobile AppBar visibility on navigation

### DIFF
--- a/src/components/layouts/MobileAppBar.tsx
+++ b/src/components/layouts/MobileAppBar.tsx
@@ -9,16 +9,15 @@ import {
   Toolbar,
   useScrollTrigger
 } from '@mui/material';
+import { usePathname } from 'next/navigation';
 import { memo, useContext, useState } from 'react';
-import AuthContext from '../../context/AuthContext';
 import ProfileContext from '../../context/ProfileContext';
 import ShellContext from '../../context/ShellContext';
 import ProfileAvatar from '../common/ProfileAvatar';
 import Logo from './Logo';
 import MobileDrawer from './MobileDrawer';
 
-export default memo(function MobileAppBar() {
-  const { uid } = useContext(AuthContext);
+function MobileAppBarContent() {
   const { openSearch, openCreateMap, appBarHidden } = useContext(ShellContext);
   const profile = useContext(ProfileContext);
 
@@ -69,4 +68,14 @@ export default memo(function MobileAppBar() {
       />
     </>
   );
+}
+
+export default memo(function MobileAppBar() {
+  const pathname = usePathname();
+
+  // MobileAppBar lives in the persistent root layout, so useScrollTrigger keeps
+  // its trigger value across client navigations and never recomputes without a
+  // scroll event. Remount on path change so the scroll state reflects the new
+  // page (scrolled to top) instead of staying hidden.
+  return <MobileAppBarContent key={pathname} />;
 });

--- a/src/components/maps/MobileMapDrawer.tsx
+++ b/src/components/maps/MobileMapDrawer.tsx
@@ -7,7 +7,7 @@ import {
   SwipeableDrawer,
   Typography
 } from '@mui/material';
-import { memo, useCallback, useContext, useState } from 'react';
+import { memo, useCallback, useContext, useEffect, useState } from 'react';
 import type { AppMap, Follower, Profile, Review } from '../../../types';
 import ShellContext from '../../context/ShellContext';
 import useDictionary from '../../hooks/useDictionary';
@@ -54,12 +54,21 @@ function MobileMapDrawer({
 
   const handleOpen = useCallback(() => {
     setOpen(true);
-    setAppBarHidden(true);
-  }, [setAppBarHidden]);
+  }, []);
 
   const handleClose = useCallback(() => {
     setOpen(false);
-    setAppBarHidden(false);
+  }, []);
+
+  // The review drawer overrides this drawer's open prop, so while it is open
+  // this drawer is visually closed even when `open` is still true. Keep the
+  // AppBar visible in that case.
+  useEffect(() => {
+    setAppBarHidden(open && !reviewDrawerOpen);
+  }, [open, reviewDrawerOpen, setAppBarHidden]);
+
+  useEffect(() => {
+    return () => setAppBarHidden(false);
   }, [setAppBarHidden]);
 
   const handleReviewClick = useCallback(


### PR DESCRIPTION
# Summary

Two fixes for the mobile AppBar staying hidden when it should be visible: after navigating to another screen while hidden by scroll, and on the spot (review) detail opened from the map summary.

# Motivation

`MobileAppBar` is rendered in the persistent root layout (`[lang]/layout.tsx`), so its `useScrollTrigger` instance is never unmounted across client navigations. `useScrollTrigger` only recomputes on scroll events, so a `true` (hidden) value from scrolling down on one page carried over to the next, where no scroll event fired to reset it.

Separately, `MobileMapDrawer` toggled the shared `appBarHidden` state imperatively in its open and close handlers. Selecting a spot opens `ReviewDrawer`, which overrides the summary drawer's `open` prop without firing its close handler, so `appBarHidden` stayed `true` and the AppBar remained hidden on the spot detail screen.

# Changes

- Extract the scroll-aware AppBar content into `MobileAppBarContent` and remount it via `key={pathname}` (`usePathname`), so `useScrollTrigger` re-initializes from the new page's scroll position on each navigation.
- Drop the unused `uid` read from `AuthContext`.
- Derive `appBarHidden` in `MobileMapDrawer` from the drawer's actual visibility (`open && !reviewDrawerOpen`) instead of toggling it in handlers, and reset it on unmount so leaving the map screen restores the AppBar.

# Test plan

- [x] `pnpm biome ci ./src` passes
- [x] `pnpm exec tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.ai/code)