### PR TITLE
feat: show the chapters written from a map

### DIFF
--- a/src/app/[lang]/(contained)/chapters/[chapterId]/page.tsx
+++ b/src/app/[lang]/(contained)/chapters/[chapterId]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const chapter = await getChapter(chapterId, lang);
 
   const title = chapter
-    ? `${chapter.title || dict['untitled journey']} | Qoodish`
+    ? `${chapter.title || dict['untitled chapter']} | Qoodish`
     : 'Qoodish';
   const description = dict['meta description'];
   const keywords = `${

--- a/src/app/[lang]/maps/[mapId]/(detail)/loading.tsx
+++ b/src/app/[lang]/maps/[mapId]/(detail)/loading.tsx
@@ -13,6 +13,8 @@ const summaryCardWidth = 360;
 
 const reviewSkeletonKeys = ['a', 'b', 'c'];
 
+const tabSkeletonKeys = ['spots', 'chapters'];
+
 export default function Loading() {
   return (
     <Box sx={{ display: { xs: 'block', md: 'flex' } }}>
@@ -50,18 +52,27 @@ export default function Loading() {
             </Box>
           </CardContent>
           <Divider />
-          <CardContent>
-            <Box
-              sx={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                mb: 1
-              }}
-            >
-              <Skeleton variant="text" width="30%" />
-              <Skeleton variant="text" width={24} />
-            </Box>
+          <Box
+            sx={{ display: 'flex', borderBottom: 1, borderColor: 'divider' }}
+          >
+            {tabSkeletonKeys.map((key) => (
+              <Box
+                key={key}
+                sx={{
+                  flex: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 1,
+                  py: 1.5
+                }}
+              >
+                <Skeleton variant="circular" width={20} height={20} />
+                <Skeleton variant="text" width="40%" />
+              </Box>
+            ))}
+          </Box>
+          <Box sx={{ px: 2 }}>
             {reviewSkeletonKeys.map((key) => (
               <Box
                 key={key}
@@ -75,7 +86,7 @@ export default function Loading() {
                 <Skeleton variant="circular" width={24} height={24} />
               </Box>
             ))}
-          </CardContent>
+          </Box>
         </Card>
       </Box>
 

--- a/src/app/[lang]/maps/[mapId]/(detail)/page.tsx
+++ b/src/app/[lang]/maps/[mapId]/(detail)/page.tsx
@@ -6,6 +6,7 @@ import { getServerAuthState } from '../../../../../lib/auth';
 import { getMyJourney, getMyJourneys } from '../../../../../lib/journeys';
 import {
   getMap,
+  getMapChapters,
   getMapCoauthors,
   getMapReviews
 } from '../../../../../lib/maps';
@@ -63,13 +64,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function MapPage({ params }: Props) {
   const { lang, mapId } = await params;
   const { token, uid } = await getServerAuthState();
-  const [map, reviews, coauthors, profile, journeys] = await Promise.all([
-    getMap(mapId, lang, token),
-    getMapReviews(mapId, lang, token),
-    getMapCoauthors(mapId, lang, token),
-    uid ? getProfile(uid, lang, token) : Promise.resolve(null),
-    getMyJourneys(lang, token)
-  ]);
+  const [map, reviews, coauthors, chapters, profile, journeys] =
+    await Promise.all([
+      getMap(mapId, lang, token),
+      getMapReviews(mapId, lang, token),
+      getMapCoauthors(mapId, lang, token),
+      getMapChapters(mapId, lang, token),
+      uid ? getProfile(uid, lang, token) : Promise.resolve(null),
+      getMyJourneys(lang, token)
+    ]);
 
   if (!map) {
     notFound();
@@ -88,6 +91,7 @@ export default async function MapPage({ params }: Props) {
         map={map}
         reviews={reviews}
         coauthors={coauthors}
+        chapters={chapters}
         currentProfile={profile}
         currentJourney={currentJourney}
       />

--- a/src/components/chapters/ChapterEditor.tsx
+++ b/src/components/chapters/ChapterEditor.tsx
@@ -33,6 +33,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import type { AppMap, Chapter, Journal, Journey, Review } from '../../../types';
 import useChapter from '../../hooks/useChapter';
 import useDictionary from '../../hooks/useDictionary';
+import useLocalDateTime from '../../hooks/useLocalDateTime';
 import { isContentEmpty } from '../../utils/chapterContent';
 import {
   createMapFeatures,
@@ -49,6 +50,12 @@ import ConfirmDeleteDialog from './ConfirmDeleteDialog';
 import ConfirmDialog from './ConfirmDialog';
 import MapLinkChip from './MapLinkChip';
 import { $replaceChapterContent } from './replaceChapterContent';
+
+const LONG_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+};
 
 type Props = {
   chapter: Chapter;
@@ -70,6 +77,7 @@ export default function ChapterEditor({
 }: Props) {
   const dictionary = useDictionary();
   const { lang } = useParams<{ lang: string }>();
+  const formatDateTime = useLocalDateTime();
   const router = useRouter();
 
   const readPath = `/${lang}/chapters/${initialChapter.id}`;
@@ -310,11 +318,7 @@ export default function ChapterEditor({
           />
 
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {new Date(chapter.created_at).toLocaleDateString(lang, {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            })}
+            {formatDateTime(chapter.created_at, LONG_DATE_OPTIONS)}
           </Typography>
 
           <Box sx={{ mb: 3 }}>

--- a/src/components/chapters/ChapterReadView.tsx
+++ b/src/components/chapters/ChapterReadView.tsx
@@ -122,7 +122,7 @@ export default function ChapterReadView({
           </Box>
 
           <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
-            {chapter.title || dictionary['untitled journey']}
+            {chapter.title || dictionary['untitled chapter']}
           </Typography>
 
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>

--- a/src/components/chapters/ChapterReadView.tsx
+++ b/src/components/chapters/ChapterReadView.tsx
@@ -19,6 +19,7 @@ import { useCallback, useMemo, useState } from 'react';
 import type { AppMap, Chapter, Journal } from '../../../types';
 import { deleteChapter } from '../../actions/chapters';
 import useDictionary from '../../hooks/useDictionary';
+import useLocalDateTime from '../../hooks/useLocalDateTime';
 import { featureSpots } from '../../utils/mapFeatures';
 import ChapterActions from './ChapterActions';
 import ChapterAuthorCard from './ChapterAuthorCard';
@@ -28,6 +29,12 @@ import ChapterCover from './ChapterCover';
 import ChapterMapCard from './ChapterMapCard';
 import ConfirmDeleteDialog from './ConfirmDeleteDialog';
 import MapLinkChip from './MapLinkChip';
+
+const LONG_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+};
 
 type Props = {
   chapter: Chapter;
@@ -45,6 +52,7 @@ export default function ChapterReadView({
 }: Props) {
   const dictionary = useDictionary();
   const { lang } = useParams<{ lang: string }>();
+  const formatDateTime = useLocalDateTime();
   const router = useRouter();
 
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
@@ -118,11 +126,7 @@ export default function ChapterReadView({
           </Typography>
 
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {new Date(chapter.created_at).toLocaleDateString(lang, {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            })}
+            {formatDateTime(chapter.created_at, LONG_DATE_OPTIONS)}
           </Typography>
 
           <Box sx={{ mb: 3 }}>

--- a/src/components/journeys/JourneyDetailView.tsx
+++ b/src/components/journeys/JourneyDetailView.tsx
@@ -388,7 +388,7 @@ export default function JourneyDetailView({
     setRecording(true);
 
     const { success, data, error } = await createChapter(map.id, {
-      title: dictionary['untitled journey'],
+      title: dictionary['untitled chapter'],
       content: createChapterContent({ ...journey, checkins }),
       map_features: createMapFeatures({ ...journey, checkins }),
       journey_id: journey.id
@@ -710,7 +710,7 @@ export default function JourneyDetailView({
                 <HistoryEdu color="action" />
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Typography variant="subtitle2" noWrap>
-                    {chapter.title || dictionary['untitled journey']}
+                    {chapter.title || dictionary['untitled chapter']}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
                     {chapter.status === 'published'

--- a/src/components/journeys/JourneyDetailView.tsx
+++ b/src/components/journeys/JourneyDetailView.tsx
@@ -66,6 +66,9 @@ import {
 } from '../../actions/journeys';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
+import useLocalDateTime, {
+  LOCAL_DATE_TIME_PLACEHOLDER
+} from '../../hooks/useLocalDateTime';
 import { createChapterContent } from '../../utils/chapterContent';
 import { trailDistanceMeters } from '../../utils/geo';
 import { deletePaused } from '../../utils/journeyPauseStorage';
@@ -80,6 +83,24 @@ import CheckinNoteField from './CheckinNoteField';
 import EndJourneyDialog from './EndJourneyDialog';
 import JourneyMap from './JourneyMap';
 import SpotPickerDialog from './SpotPickerDialog';
+
+const DAY_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+};
+
+const TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  hour: '2-digit',
+  minute: '2-digit'
+};
+
+const DATE_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit'
+};
 
 function toDatetimeLocal(value: string): string {
   const date = new Date(value);
@@ -106,6 +127,7 @@ export default function JourneyDetailView({
 }: Props) {
   const dictionary = useDictionary();
   const { lang } = useParams<{ lang: string }>();
+  const formatLocal = useLocalDateTime();
   const router = useRouter();
   const { uid } = useContext(AuthContext);
 
@@ -398,26 +420,24 @@ export default function JourneyDetailView({
     router.push(`/${lang}/journeys`);
   }, [journey.id, dictionary, router, lang]);
 
-  const formatDay = (value: string) =>
-    new Date(value).toLocaleDateString(lang, {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
+  const formatDay = (value: string) => formatLocal(value, DAY_OPTIONS);
 
-  const formatTime = (value: string) =>
-    new Date(value).toLocaleTimeString(lang, {
-      hour: '2-digit',
-      minute: '2-digit'
-    });
+  const formatTime = (value: string) => formatLocal(value, TIME_OPTIONS);
 
   const formatDateTime = (value: string) =>
-    new Date(value).toLocaleString(lang, {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
+    formatLocal(value, DATE_TIME_OPTIONS);
+
+  const startFormatted = journey.started_at
+    ? formatDateTime(journey.started_at)
+    : null;
+  const finishFormatted = journey.finished_at
+    ? formatDateTime(journey.finished_at)
+    : null;
+  const dateRangeText =
+    startFormatted === LOCAL_DATE_TIME_PLACEHOLDER &&
+    finishFormatted === LOCAL_DATE_TIME_PLACEHOLDER
+      ? LOCAL_DATE_TIME_PLACEHOLDER
+      : [startFormatted, finishFormatted].filter(Boolean).join(' – ');
 
   return (
     <>
@@ -466,12 +486,7 @@ export default function JourneyDetailView({
           </Box>
 
           <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-            {[
-              journey.started_at ? formatDateTime(journey.started_at) : null,
-              journey.finished_at ? formatDateTime(journey.finished_at) : null
-            ]
-              .filter(Boolean)
-              .join(' – ')}
+            {dateRangeText}
           </Typography>
 
           <Stack

--- a/src/components/journeys/JourneyProgressSheet.tsx
+++ b/src/components/journeys/JourneyProgressSheet.tsx
@@ -36,9 +36,15 @@ import type {
   Spot
 } from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
+import useLocalDateTime from '../../hooks/useLocalDateTime';
 import DrawerPuller from '../common/DrawerPuller';
 import CheckinImageStrip from './CheckinImageStrip';
 import CheckinNoteField from './CheckinNoteField';
+
+const TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  hour: '2-digit',
+  minute: '2-digit'
+};
 
 type TimelineItem = {
   key: string;
@@ -221,6 +227,7 @@ function JourneyProgressSheet({
 }: Props) {
   const dictionary = useDictionary();
   const { lang } = useParams<{ lang: string }>();
+  const formatLocal = useLocalDateTime();
 
   const imagesByReview = useMemo(() => {
     return new Map(
@@ -309,11 +316,7 @@ function JourneyProgressSheet({
     [onRemoveMilestone, onRemoveCheckin]
   );
 
-  const formatTime = (value: string) =>
-    new Date(value).toLocaleTimeString(lang, {
-      hour: '2-digit',
-      minute: '2-digit'
-    });
+  const formatTime = (value: string) => formatLocal(value, TIME_OPTIONS);
 
   return (
     <SwipeableDrawer

--- a/src/components/maps/MapChapterList.tsx
+++ b/src/components/maps/MapChapterList.tsx
@@ -1,0 +1,84 @@
+import { HistoryEdu } from '@mui/icons-material';
+import {
+  Avatar,
+  Box,
+  List,
+  ListItemAvatar,
+  ListItemButton,
+  ListItemText
+} from '@mui/material';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { memo } from 'react';
+import type { Chapter } from '../../../types';
+import useDictionary from '../../hooks/useDictionary';
+import AuthorAvatar from '../common/AuthorAvatar';
+import NoContents from '../common/NoContents';
+
+type Props = {
+  chapters: Chapter[];
+};
+
+function MapChapterList({ chapters }: Props) {
+  const dictionary = useDictionary();
+  const { lang } = useParams<{ lang: string }>();
+
+  // The rows carry their own padding, so the panel around this list has none
+  // to give the empty state.
+  if (chapters.length < 1) {
+    return (
+      <Box sx={{ py: 4 }}>
+        <NoContents icon={HistoryEdu} message={dictionary['no chapters yet']} />
+      </Box>
+    );
+  }
+
+  return (
+    <List disablePadding>
+      {chapters.map((chapter) => (
+        <ListItemButton
+          key={chapter.id}
+          divider
+          disableGutters
+          href={`/${lang}/chapters/${chapter.id}`}
+          LinkComponent={Link}
+        >
+          <ListItemAvatar>
+            <Avatar
+              alt={chapter.title}
+              variant="rounded"
+              src={chapter.image?.avatar}
+            >
+              <HistoryEdu />
+            </Avatar>
+          </ListItemAvatar>
+          <ListItemText
+            primary={chapter.title || dictionary['untitled journey']}
+            secondary={new Date(chapter.created_at).toLocaleDateString(lang, {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric'
+            })}
+            slotProps={{
+              primary: {
+                noWrap: true
+              },
+              secondary: {
+                noWrap: true
+              }
+            }}
+          />
+          <AuthorAvatar
+            author={chapter.author}
+            sx={{
+              width: 24,
+              height: 24
+            }}
+          />
+        </ListItemButton>
+      ))}
+    </List>
+  );
+}
+
+export default memo(MapChapterList);

--- a/src/components/maps/MapChapterList.tsx
+++ b/src/components/maps/MapChapterList.tsx
@@ -12,8 +12,15 @@ import { useParams } from 'next/navigation';
 import { memo } from 'react';
 import type { Chapter } from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
+import useLocalDateTime from '../../hooks/useLocalDateTime';
 import AuthorAvatar from '../common/AuthorAvatar';
 import NoContents from '../common/NoContents';
+
+const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+};
 
 type Props = {
   chapters: Chapter[];
@@ -22,6 +29,7 @@ type Props = {
 function MapChapterList({ chapters }: Props) {
   const dictionary = useDictionary();
   const { lang } = useParams<{ lang: string }>();
+  const formatDateTime = useLocalDateTime();
 
   // The rows carry their own padding, so the panel around this list has none
   // to give the empty state.
@@ -54,11 +62,7 @@ function MapChapterList({ chapters }: Props) {
           </ListItemAvatar>
           <ListItemText
             primary={chapter.title || dictionary['untitled journey']}
-            secondary={new Date(chapter.created_at).toLocaleDateString(lang, {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric'
-            })}
+            secondary={formatDateTime(chapter.created_at, DATE_OPTIONS)}
             slotProps={{
               primary: {
                 noWrap: true

--- a/src/components/maps/MapChapterList.tsx
+++ b/src/components/maps/MapChapterList.tsx
@@ -61,7 +61,7 @@ function MapChapterList({ chapters }: Props) {
             </Avatar>
           </ListItemAvatar>
           <ListItemText
-            primary={chapter.title || dictionary['untitled journey']}
+            primary={chapter.title || dictionary['untitled chapter']}
             secondary={formatDateTime(chapter.created_at, DATE_OPTIONS)}
             slotProps={{
               primary: {

--- a/src/components/maps/MapDetailTabs.tsx
+++ b/src/components/maps/MapDetailTabs.tsx
@@ -1,0 +1,57 @@
+import { HistoryEdu, Place } from '@mui/icons-material';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { Box, Tab } from '@mui/material';
+import { type SyntheticEvent, memo, useCallback, useState } from 'react';
+import type { Chapter, Review } from '../../../types';
+import useDictionary from '../../hooks/useDictionary';
+import MapChapterList from './MapChapterList';
+import MapReviewList from './MapReviewList';
+
+type Props = {
+  reviews: Review[];
+  chapters: Chapter[];
+  onReviewClick?: (review: Review) => void;
+};
+
+function MapDetailTabs({ reviews, chapters, onReviewClick }: Props) {
+  const dictionary = useDictionary();
+
+  const [tabValue, setTabValue] = useState('spots');
+
+  const handleTabChange = useCallback(
+    (_event: SyntheticEvent<Element, Event>, newValue: string) => {
+      setTabValue(newValue);
+    },
+    []
+  );
+
+  return (
+    <TabContext value={tabValue}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <TabList onChange={handleTabChange} variant="fullWidth">
+          <Tab
+            icon={<Place />}
+            iconPosition="start"
+            label={dictionary.spots}
+            value="spots"
+          />
+          <Tab
+            icon={<HistoryEdu />}
+            iconPosition="start"
+            label={dictionary.chapters}
+            value="chapters"
+          />
+        </TabList>
+      </Box>
+
+      <TabPanel value="spots" sx={{ px: 2, py: 0 }}>
+        <MapReviewList reviews={reviews} onReviewClick={onReviewClick} />
+      </TabPanel>
+      <TabPanel value="chapters" sx={{ px: 2, py: 0 }}>
+        <MapChapterList chapters={chapters} />
+      </TabPanel>
+    </TabContext>
+  );
+}
+
+export default memo(MapDetailTabs);

--- a/src/components/maps/MapDetailView.tsx
+++ b/src/components/maps/MapDetailView.tsx
@@ -6,6 +6,7 @@ import { enqueueSnackbar } from 'notistack';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type {
   AppMap,
+  Chapter,
   Coauthor,
   Journey,
   Profile,
@@ -34,6 +35,7 @@ type Props = {
   map: AppMap;
   reviews: Review[];
   coauthors: Coauthor[];
+  chapters: Chapter[];
   currentProfile: Profile | null;
   currentJourney: Journey | null;
 };
@@ -42,6 +44,7 @@ export default function MapDetailView({
   map,
   reviews,
   coauthors,
+  chapters,
   currentProfile,
   currentJourney
 }: Props) {
@@ -237,6 +240,7 @@ export default function MapDetailView({
         map={map}
         reviews={reviews}
         coauthors={coauthors}
+        chapters={chapters}
         currentProfile={currentProfile}
         onEditClick={() => setEditDialogOpen(true)}
         onDeleteClick={() => setDeleteDialogOpen(true)}
@@ -277,6 +281,7 @@ export default function MapDetailView({
             map={map}
             reviews={reviews}
             coauthors={coauthors}
+            chapters={chapters}
             currentProfile={currentProfile}
             onEditClick={() => setEditDialogOpen(true)}
             onDeleteClick={() => setDeleteDialogOpen(true)}

--- a/src/components/maps/MapReviewList.tsx
+++ b/src/components/maps/MapReviewList.tsx
@@ -1,6 +1,7 @@
 import { HistoryEdu, Place } from '@mui/icons-material';
 import {
   Avatar,
+  Box,
   List,
   ListItemAvatar,
   ListItemButton,
@@ -36,9 +37,13 @@ function MapReviewList({ reviews, onReviewClick }: Props) {
     [onReviewClick, push, pathname]
   );
 
+  // The rows carry their own padding, so the panel around this list has none
+  // to give the empty state.
   if (reviews.length < 1) {
     return (
-      <NoContents icon={Place} message={dictionary['spots will see here']} />
+      <Box sx={{ py: 4 }}>
+        <NoContents icon={Place} message={dictionary['spots will see here']} />
+      </Box>
     );
   }
 

--- a/src/components/maps/MapSummaryCard.tsx
+++ b/src/components/maps/MapSummaryCard.tsx
@@ -10,13 +10,19 @@ import {
   Typography
 } from '@mui/material';
 import { memo } from 'react';
-import type { AppMap, Coauthor, Profile, Review } from '../../../types';
+import type {
+  AppMap,
+  Chapter,
+  Coauthor,
+  Profile,
+  Review
+} from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
 import BookmarkButton from './BookmarkButton';
 import Coauthors from './Coauthors';
 import MapCardHeader from './MapCardHeader';
+import MapDetailTabs from './MapDetailTabs';
 import MapMenuButton from './MapMenuButton';
-import MapReviewList from './MapReviewList';
 import PrivateMapChip from './PrivateMapChip';
 import RemoveBookmarkButton from './RemoveBookmarkButton';
 
@@ -24,6 +30,7 @@ type Props = {
   map: AppMap | null;
   reviews: Review[];
   coauthors: Coauthor[];
+  chapters: Chapter[];
   currentProfile: Profile | null;
   onEditClick: () => void;
   onDeleteClick: () => void;
@@ -35,6 +42,7 @@ export default memo(function MapSummaryCard({
   map,
   reviews,
   coauthors,
+  chapters,
   currentProfile,
   onEditClick,
   onDeleteClick,
@@ -134,29 +142,7 @@ export default memo(function MapSummaryCard({
         </Box>
       </CardContent>
       <Divider />
-      <CardContent>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center'
-          }}
-        >
-          <Typography variant="h6" component="h2">
-            {dictionary.spots}
-          </Typography>
-
-          <Typography
-            variant="subtitle1"
-            component="div"
-            color="text.secondary"
-          >
-            {reviews.length}
-          </Typography>
-        </Box>
-
-        <MapReviewList reviews={reviews} />
-      </CardContent>
+      <MapDetailTabs reviews={reviews} chapters={chapters} />
     </Card>
   );
 });

--- a/src/components/maps/MobileMapDrawer.tsx
+++ b/src/components/maps/MobileMapDrawer.tsx
@@ -8,14 +8,20 @@ import {
   Typography
 } from '@mui/material';
 import { memo, useCallback, useContext, useEffect, useState } from 'react';
-import type { AppMap, Coauthor, Profile, Review } from '../../../types';
+import type {
+  AppMap,
+  Chapter,
+  Coauthor,
+  Profile,
+  Review
+} from '../../../types';
 import ShellContext from '../../context/ShellContext';
 import useDictionary from '../../hooks/useDictionary';
 import BookmarkButton from './BookmarkButton';
 import Coauthors from './Coauthors';
 import MapCardHeader from './MapCardHeader';
+import MapDetailTabs from './MapDetailTabs';
 import MapMenuButton from './MapMenuButton';
-import MapReviewList from './MapReviewList';
 import MobileMiniMapHeader from './MobileMiniMapHeader';
 import PrivateMapChip from './PrivateMapChip';
 import RemoveBookmarkButton from './RemoveBookmarkButton';
@@ -25,6 +31,7 @@ type Props = {
   map: AppMap | null;
   reviews: Review[];
   coauthors: Coauthor[];
+  chapters: Chapter[];
   currentProfile: Profile | null;
   onEditClick: () => void;
   onDeleteClick: () => void;
@@ -38,6 +45,7 @@ function MobileMapDrawer({
   map,
   reviews,
   coauthors,
+  chapters,
   currentProfile,
   onEditClick,
   onDeleteClick,
@@ -182,32 +190,11 @@ function MobileMapDrawer({
             </Box>
           </CardContent>
           <Divider />
-          <CardContent>
-            <Box
-              sx={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center'
-              }}
-            >
-              <Typography variant="subtitle2" component="h2">
-                {dictionary.spots}
-              </Typography>
-
-              <Typography
-                variant="subtitle1"
-                component="div"
-                color="text.secondary"
-              >
-                {reviews.length}
-              </Typography>
-            </Box>
-
-            <MapReviewList
-              reviews={reviews}
-              onReviewClick={handleReviewClick}
-            />
-          </CardContent>
+          <MapDetailTabs
+            reviews={reviews}
+            chapters={chapters}
+            onReviewClick={handleReviewClick}
+          />
         </Box>
       </SwipeableDrawer>
     </>

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -13,11 +13,12 @@ import { formatDistanceToNow } from 'date-fns';
 import { enUS, ja } from 'date-fns/locale';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { memo, useContext, useEffect, useMemo, useRef } from 'react';
+import { memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { Notification } from '../../../types';
 import { markNotificationAsRead } from '../../actions/notifications';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
+import { LOCAL_DATE_TIME_PLACEHOLDER } from '../../hooks/useLocalDateTime';
 import sleep from '../../utils/sleep';
 import AuthorAvatar from '../common/AuthorAvatar';
 import NoContents from '../common/NoContents';
@@ -37,6 +38,14 @@ const NotificationList = ({
   const dictionary = useDictionary();
 
   const { authenticated } = useContext(AuthContext);
+
+  // Server rendering resolves "now" and the time zone differently from the
+  // browser, so the elapsed time is only rendered once mounted.
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const unreadNotifications = useMemo(
     () => notifications.filter((notification) => !notification.read),
@@ -102,10 +111,12 @@ const NotificationList = ({
             }
             secondary={
               <Typography variant="subtitle1" color="text.secondary">
-                {formatDistanceToNow(new Date(notification.created_at), {
-                  addSuffix: true,
-                  locale: lang === 'ja' ? ja : enUS
-                })}
+                {mounted
+                  ? formatDistanceToNow(new Date(notification.created_at), {
+                      addSuffix: true,
+                      locale: lang === 'ja' ? ja : enUS
+                    })
+                  : LOCAL_DATE_TIME_PLACEHOLDER}
               </Typography>
             }
             disableTypography

--- a/src/components/profiles/UserChapters.tsx
+++ b/src/components/profiles/UserChapters.tsx
@@ -111,7 +111,7 @@ function UserChapters({ chapters: initialChapters }: { chapters: Chapter[] }) {
                     overflow: 'hidden'
                   }}
                 >
-                  {chapter.title || dictionary['untitled journey']}
+                  {chapter.title || dictionary['untitled chapter']}
                 </Typography>
 
                 {chapter.map?.name && (

--- a/src/components/profiles/UserChapters.tsx
+++ b/src/components/profiles/UserChapters.tsx
@@ -22,14 +22,22 @@ import { type MouseEvent, memo, useCallback, useState } from 'react';
 import type { Chapter } from '../../../types';
 import { deleteChapter } from '../../actions/chapters';
 import useDictionary from '../../hooks/useDictionary';
+import useLocalDateTime from '../../hooks/useLocalDateTime';
 import ConfirmDeleteDialog from '../chapters/ConfirmDeleteDialog';
 import NoContents from '../common/NoContents';
 
 const THUMBNAIL_SIZE = { xs: 80, sm: 100 };
 
+const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+};
+
 function UserChapters({ chapters: initialChapters }: { chapters: Chapter[] }) {
   const dictionary = useDictionary();
   const { lang } = useParams<{ lang: string }>();
+  const formatDateTime = useLocalDateTime();
   const router = useRouter();
 
   const [chapters, setChapters] = useState(initialChapters);
@@ -131,11 +139,7 @@ function UserChapters({ chapters: initialChapters }: { chapters: Chapter[] }) {
                   }}
                 >
                   <Typography variant="caption" color="text.secondary">
-                    {new Date(chapter.created_at).toLocaleDateString(lang, {
-                      year: 'numeric',
-                      month: 'short',
-                      day: 'numeric'
-                    })}
+                    {formatDateTime(chapter.created_at, DATE_OPTIONS)}
                   </Typography>
                   {chapter.status === 'draft' && (
                     <Chip label={dictionary.draft} size="small" />

--- a/src/components/profiles/UserJourneys.tsx
+++ b/src/components/profiles/UserJourneys.tsx
@@ -21,14 +21,24 @@ import { type MouseEvent, memo, useCallback, useState } from 'react';
 import type { JourneySummary } from '../../../types';
 import { deleteJourney } from '../../actions/journeys';
 import useDictionary from '../../hooks/useDictionary';
+import useLocalDateTime from '../../hooks/useLocalDateTime';
 import ConfirmDeleteDialog from '../chapters/ConfirmDeleteDialog';
 import NoContents from '../common/NoContents';
+
+const DATE_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit'
+};
 
 function UserJourneys({
   journeys: initialJourneys
 }: { journeys: JourneySummary[] }) {
   const dictionary = useDictionary();
   const { lang } = useParams<{ lang: string }>();
+  const formatLocal = useLocalDateTime();
   const router = useRouter();
 
   const [journeys, setJourneys] = useState(initialJourneys);
@@ -108,13 +118,7 @@ function UserJourneys({
                     <DirectionsWalk fontSize="small" color="action" />
                   </ListItemIcon>
                   <ListItemText
-                    primary={new Date(dateSource).toLocaleString(lang, {
-                      year: 'numeric',
-                      month: 'short',
-                      day: 'numeric',
-                      hour: '2-digit',
-                      minute: '2-digit'
-                    })}
+                    primary={formatLocal(dateSource, DATE_TIME_OPTIONS)}
                     secondary={
                       <>
                         {journey.map?.name && (

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -334,6 +334,7 @@
   "revert to draft success": "Reverted to draft",
   "writing in progress": "Writing",
   "untitled journey": "Untitled journey",
+  "untitled chapter": "Untitled chapter",
   "add milestone": "Add milestone",
   "milestones": "Milestones",
   "milestone added": "Added",

--- a/src/dictionaries/ja.json
+++ b/src/dictionaries/ja.json
@@ -334,6 +334,7 @@
   "revert to draft success": "下書きに戻しました",
   "writing in progress": "執筆中",
   "untitled journey": "無題の旅",
+  "untitled chapter": "無題のチャプター",
   "add milestone": "マイルストーンに追加",
   "milestones": "マイルストーン",
   "milestone added": "追加済み",

--- a/src/hooks/useLocalDateTime.ts
+++ b/src/hooks/useLocalDateTime.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+
+// Rendered on the server before hydration, where the viewer's time zone is
+// unknown. A non-breaking space keeps the line height so the text appears
+// without shifting the layout. Written as an escape because a literal
+// non-breaking space is indistinguishable from a regular one in source.
+export const LOCAL_DATE_TIME_PLACEHOLDER = '\u00A0';
+
+/**
+ * Formats a timestamp in the viewer's locale and time zone.
+ *
+ * Formatting during server rendering would use the server's time zone, which
+ * puts a timestamp near midnight on a different calendar day than the browser
+ * resolves it to. Formatting only after mount keeps the two renders identical.
+ */
+export default function useLocalDateTime() {
+  const { lang } = useParams<{ lang: string }>();
+
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return useCallback(
+    (value: string, options: Intl.DateTimeFormatOptions) =>
+      mounted
+        ? new Intl.DateTimeFormat(lang, options).format(new Date(value))
+        : LOCAL_DATE_TIME_PLACEHOLDER,
+    [mounted, lang]
+  );
+}

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -1,4 +1,4 @@
-import type { AppMap, Coauthor, Review } from '../../types';
+import type { AppMap, Chapter, Coauthor, Review } from '../../types';
 import { apiFetch } from './api';
 
 export async function getMap(
@@ -36,6 +36,20 @@ export async function getMapCoauthors(
 ): Promise<Coauthor[]> {
   const guest = !token;
   const { data } = await apiFetch<Coauthor[]>(`/maps/${mapId}/coauthors`, {
+    lang,
+    guest,
+    next: { revalidate: guest ? 300 : 0 }
+  });
+  return data ?? [];
+}
+
+export async function getMapChapters(
+  mapId: string,
+  lang: string,
+  token?: string
+): Promise<Chapter[]> {
+  const guest = !token;
+  const { data } = await apiFetch<Chapter[]>(`/maps/${mapId}/chapters`, {
     lang,
     guest,
     next: { revalidate: guest ? 300 : 0 }


### PR DESCRIPTION
# Summary

A map now lists the published chapters written from it (#1080), which is the half of the circulation loop in #1071 that a reader can see.

Requires the backend change in yusuke-suzuki/qoodish#563.

# Motivation

A chapter names the map it came from twice — the chip at the top and the card at the foot — but the map pointed back at nothing. Circulation ran one way: a reader arriving at a map could not find the stories that came out of it, and the author could not see what their map led people to write.

# Changes

## Chapters on the map screen

- `getMapChapters` fetches `/maps/:mapId/chapters`, falling back to the guest endpoint for signed-out readers, and the map page passes the result down alongside the reviews and coauthors it already fetches.
- `MapChapterList` renders the rows: cover thumbnail, title, date, and the author's avatar. It mirrors `MapReviewList`, its sibling on the same surface.
- `MapDetailTabs` puts spots and chapters side by side as tabs, shared by the mobile drawer and the desktop summary card so the two surfaces cannot drift. Stacking them would bury the chapters below a spot list the reader has to scroll past on any map with many pins. This answers the open question in #1080 about where they belong on a screen that is a full-bleed map rather than a document — they belong in the sheet that already carries the map's own record, not on a screen of their own.
- Each tab carries the icon the app already associates with its contents — `Place` for spots, `HistoryEdu` for chapters — placed beside the label rather than above it, so the tab bar keeps a single-row height on a sheet that has little of it to spare.
- Coauthors stay above the tabs. It is an avatar row identifying who may edit the map, part of the map's identity rather than a collection to browse.
- An empty list reuses the existing `no chapters yet` copy rather than adding a near-duplicate string. Each list pads its own empty state, since the tab panel has no vertical padding to give it — the rows carry their own.
- The map detail loading skeleton gains a tab bar in place of the heading row it used to show.

## Not in this PR: the chapter published notification

#1079 asks for the map's author to be told when a chapter is published from their map. An earlier revision carried the copy for it, and it is removed along with the backend side.

Push delivery is gated on a preference named after the notification key, and no name works on both sides of that coupling. The notification would have reached the notifications list and stopped there. yusuke-suzuki/qoodish#564 reworks the mechanism and decides which notifications are worth sending at all; #1079 lands with it rather than leaving a key here to unpick later.

## Fixes found in review

Both were flagged on the new list and both were already shipping elsewhere, so each is fixed across every surface that shares it rather than only where the review landed.

- **Timestamps were formatted during render.** Nine call sites reached for `toLocaleDateString` and its siblings, which resolve in the server's time zone while rendering and the viewer's after hydration, so a timestamp near midnight landed on one calendar day in the delivered HTML and another once hydrated. `useLocalDateTime` (`src/hooks/useLocalDateTime.ts`) holds the mount gate in one place and takes `Intl.DateTimeFormat` options, covering the date-only, time-only, and combined forms the screens needed through three different `toLocale*` methods. It returns a non-breaking space before mount, so the line keeps its height and nothing reflows. `NotificationList` resolves "now" through `formatDistanceToNow` and takes the same gate.
- **An untitled chapter read as "Untitled journey".** Five places name a chapter — the map sheet, the profile list, the reader, the journey page's chapter card, and the browser tab — and all used the journey fallback. They now use `untitled chapter`, and the default title given to a chapter recorded from a journey moves with them so a chapter left untitled reads the same either way. The two places that name a journey keep `untitled journey`. Existing chapters keep the title they were saved with.

# Testing

`pnpm biome ci ./src`, `pnpm exec tsc --noEmit`, and `pnpm next build` all pass.

Google Maps cannot load in the sandbox and the flows depend on the live Rails API, so the following need the Vercel preview once yusuke-suzuki/qoodish#563 is deployed: switching between the Spots and Chapters tabs in the mobile drawer and the desktop summary card, selecting a spot from its tab still panning the map and opening the spot drawer, a map with no chapters showing the empty state, a chapter row opening the chapter, the tabs rendering signed out on a public map, and dates resolving to the viewer's time zone without a hydration warning on the chapter, journey, profile, and notification screens.

# Release procedure

Release yusuke-suzuki/qoodish#563 first. Until it is live, `/maps/:mapId/chapters` returns 404 and the Chapters tab renders its empty state, so this change degrades rather than breaks — but the tab stays empty for every map.

🤖 Generated with [Claude Code](https://claude.ai/code)


## Summary by CodeRabbit

* **New Features**
  * Added “spots” and “chapters” tabs to the map detail experience on desktop and mobile, including per-chapter listings.
* **Bug Fixes**
  * Improved map detail loading and empty-state presentation.
  * Delayed “time ago” rendering until after mount to prevent layout/formatting flashes.
* **Localization**
  * Added English/Japanese strings for “untitled chapter” fallbacks.
* **Refactor**
  * Introduced consistent, locale-aware date/time formatting across chapter, journey, and user views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Chapters tab to map details alongside Spots.
  * Display chapters with titles, dates, images, and author avatars.
  * Added empty states for maps without chapters or reviews.
* **Bug Fixes**
  * Improved localized chapter title fallbacks in English and Japanese.
  * Standardized localized date and time display across maps, chapters, journeys, profiles, and notifications.
  * Prevented date-related layout shifts during initial page loading.
* **Style**
  * Updated map loading placeholders to include the new tabs and improved spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->