### PR TITLE
feat: add a push toggle for published chapters

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -13,6 +13,7 @@ type UpdatePushNotificationParams = {
   liked: boolean;
   coauthor_invited: boolean;
   comment: boolean;
+  published: boolean;
 };
 
 type ActionResult<T = null> = {

--- a/src/components/settings/PushNotificationsCard.tsx
+++ b/src/components/settings/PushNotificationsCard.tsx
@@ -42,6 +42,7 @@ function PushNotificationsCard() {
   const [likedEnabled, setLikedEnabled] = useState(false);
   const [coauthorInvitedEnabled, setCoauthorInvitedEnabled] = useState(false);
   const [commentEnabled, setCommentEnabled] = useState(false);
+  const [publishedEnabled, setPublishedEnabled] = useState(false);
 
   const handleSubscriptionChange = useCallback(
     async (_event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
@@ -71,7 +72,8 @@ function PushNotificationsCard() {
       const result = await updatePushNotification(uid, {
         liked: likedEnabled,
         coauthor_invited: coauthorInvitedEnabled,
-        comment: commentEnabled
+        comment: commentEnabled,
+        published: publishedEnabled
       });
 
       if (result.success) {
@@ -86,13 +88,21 @@ function PushNotificationsCard() {
     } finally {
       setLoading(false);
     }
-  }, [uid, likedEnabled, coauthorInvitedEnabled, commentEnabled, dictionary]);
+  }, [
+    uid,
+    likedEnabled,
+    coauthorInvitedEnabled,
+    commentEnabled,
+    publishedEnabled,
+    dictionary
+  ]);
 
   useEffect(() => {
     if (profile?.push_notification) {
       setLikedEnabled(profile.push_notification.liked);
       setCoauthorInvitedEnabled(profile.push_notification.coauthor_invited);
       setCommentEnabled(profile.push_notification.comment);
+      setPublishedEnabled(profile.push_notification.published);
     }
   }, [profile]);
 
@@ -170,6 +180,19 @@ function PushNotificationsCard() {
                 />
               }
               label={dictionary['push for comment']}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  color="secondary"
+                  checked={publishedEnabled}
+                  onChange={(
+                    _event: ChangeEvent<HTMLInputElement>,
+                    checked: boolean
+                  ) => setPublishedEnabled(checked)}
+                />
+              }
+              label={dictionary['push for published']}
             />
           </FormGroup>
         </FormControl>

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -134,6 +134,7 @@
   "liked review": "liked your report.",
   "liked comment": "liked your comment.",
   "liked chapter": "liked your chapter.",
+  "published chapter": "published a chapter from your map.",
   "link copied": "Link copied.",
   "journal title": "Journal title",
   "journal title required": "Journal title is required.",

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -159,6 +159,7 @@
   "push for liked": "Liked",
   "push for invited": "Invited as a coauthor",
   "push for comment": "New comment on your post",
+  "push for published": "New chapter from your map",
   "push update success": "Push notification updated successfully.",
   "unlink": "Unlink",
   "link": "Link",

--- a/src/dictionaries/ja.json
+++ b/src/dictionaries/ja.json
@@ -159,6 +159,7 @@
   "push for liked": "投稿に「いいね！」されたとき",
   "push for invited": "共著者に招かれたとき",
   "push for comment": "投稿にコメントされたとき",
+  "push for published": "マップからチャプターが公開されたとき",
   "push update success": "プッシュ通知設定を更新しました",
   "unlink": "リンク解除",
   "link": "リンクする",

--- a/src/dictionaries/ja.json
+++ b/src/dictionaries/ja.json
@@ -134,6 +134,7 @@
   "liked review": "さんがあなたのレポートにいいね！しました。",
   "liked comment": "さんがあなたのコメントにいいね！しました。",
   "liked chapter": "さんがあなたのチャプターにいいね！しました。",
+  "published chapter": "さんがあなたのマップからチャプターを公開しました。",
   "link copied": "リンクをコピーしました。",
   "journal title": "手帳のタイトル",
   "journal title required": "手帳のタイトルを入力してください。",

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,7 @@ export type PushNotification = {
   coauthor_invited: boolean;
   liked: boolean;
   comment: boolean;
+  published: boolean;
 };
 
 export type ImageVariants = {


### PR DESCRIPTION
# Summary

Frontend half of the chapter-published notification (#1079): copy for the notification row, and a settings toggle for the `published` push preference. Third step of the sequence yusuke-suzuki/qoodish#567 → yusuke-suzuki/qoodish#566 → this → yusuke-suzuki/qoodish#568.

# Motivation

yusuke-suzuki/qoodish#568 will notify a map's author when a chapter is published from their map, and yusuke-suzuki/qoodish#566 serves the `published` preference that gates its push. Without the copy here the notification row would render the notifier's name followed by nothing, and without the toggle the preference could not be turned off — so both ship before the notification creation switches on.

# Changes

- Copy for the `published chapter` key in both dictionaries, alongside `liked chapter` and `coauthor_invited map`. The notification list and the service worker share the lookup, so the push body inherits it with no worker change.
- `PushNotificationsCard` gains a fourth toggle, and the `PushNotification` type and the update payload carry `published`. The preference is named after the notification key it gates, so the field matches the `key` the service worker already receives; the label text on the card names the chapter, as before.

This releases after the backend serves the key, so the code targets the deployed API contract as it is: `published` is a required field, with no tolerance for its absence.

# Testing

`pnpm biome ci ./src`, `pnpm exec tsc --noEmit`, and `pnpm next build` all pass.

On the Vercel preview once yusuke-suzuki/qoodish#566 is deployed: the settings card shows the new toggle reflecting the server value, saving it round-trips, and the row for a `published` notification created via yusuke-suzuki/qoodish#568 renders the copy and links to the chapter.

# Release procedure

yusuke-suzuki/qoodish#566 is merged; release this only after the backend release that carries it is deployed, so every profile response carries `published`. yusuke-suzuki/qoodish#568 follows this release.

🤖 Generated with [Claude Code](https://claude.ai/code)


## Summary by CodeRabbit

* **New Features**
  * Added a push-notification setting for newly published chapters.
  * Users can enable or disable published-chapter notifications alongside existing notification preferences.
* **Documentation**
  * Added English and Japanese translations for the new notification setting and message.