### PR TITLE
refactor: migrate own-resource calls to /me API

### DIFF
--- a/src/actions/coauthors.ts
+++ b/src/actions/coauthors.ts
@@ -57,7 +57,7 @@ export async function acceptCoauthorshipInvitation(
   invitationId: number
 ): Promise<ActionResult> {
   const { error } = await apiFetch(
-    `/coauthorship_invitations/${invitationId}/accept`,
+    `/me/coauthorship_invitations/${invitationId}/accept`,
     {
       method: 'POST'
     }
@@ -74,7 +74,7 @@ export async function declineCoauthorshipInvitation(
   invitationId: number
 ): Promise<ActionResult> {
   const { error } = await apiFetch(
-    `/coauthorship_invitations/${invitationId}/decline`,
+    `/me/coauthorship_invitations/${invitationId}/decline`,
     {
       method: 'POST'
     }

--- a/src/actions/devices.ts
+++ b/src/actions/devices.ts
@@ -10,7 +10,7 @@ type ActionResult = {
 export async function registerDevice(
   registrationToken: string
 ): Promise<ActionResult> {
-  const { error } = await apiFetch(`/devices/${registrationToken}`, {
+  const { error } = await apiFetch(`/me/devices/${registrationToken}`, {
     method: 'PUT'
   });
 

--- a/src/actions/journals.ts
+++ b/src/actions/journals.ts
@@ -15,10 +15,9 @@ type UpdateJournalParams = {
 };
 
 export async function updateJournal(
-  journalId: number,
   params: UpdateJournalParams
 ): Promise<ActionResult<Journal>> {
-  const { data, error } = await apiFetch<Journal>(`/journals/${journalId}`, {
+  const { data, error } = await apiFetch<Journal>('/me/journal', {
     method: 'PUT',
     body: JSON.stringify(params)
   });

--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -10,7 +10,7 @@ type ActionResult = {
 export async function markNotificationAsRead(
   notificationId: number
 ): Promise<ActionResult> {
-  const { error } = await apiFetch(`/notifications/${notificationId}`, {
+  const { error } = await apiFetch(`/me/notifications/${notificationId}`, {
     method: 'PUT',
     body: JSON.stringify({ read: true })
   });

--- a/src/actions/reviews.ts
+++ b/src/actions/reviews.ts
@@ -3,7 +3,7 @@
 import type { Review } from '../../types';
 import { apiFetch } from '../lib/api';
 import { getTimelineReviews } from '../lib/reviews';
-import { getUserReviews } from '../lib/users';
+import { getMyReviews, getUserReviews } from '../lib/users';
 
 export async function fetchMoreTimelineReviews(
   nextTimestamp: string
@@ -16,6 +16,12 @@ export async function fetchMoreUserReviews(
   nextTimestamp: string
 ): Promise<Review[]> {
   return getUserReviews(String(userId), undefined, nextTimestamp);
+}
+
+export async function fetchMoreMyReviews(
+  nextTimestamp: string
+): Promise<Review[]> {
+  return getMyReviews(undefined, nextTimestamp);
 }
 
 type CreateReviewParams = {
@@ -54,7 +60,7 @@ export async function updateReview(
   reviewId: number,
   params: UpdateReviewParams
 ): Promise<ActionResult<Review>> {
-  const { data, error } = await apiFetch<Review>(`/reviews/${reviewId}`, {
+  const { data, error } = await apiFetch<Review>(`/me/reviews/${reviewId}`, {
     method: 'PUT',
     body: JSON.stringify(params)
   });
@@ -67,7 +73,7 @@ export async function updateReview(
 }
 
 export async function deleteReview(reviewId: number): Promise<ActionResult> {
-  const { error } = await apiFetch(`/reviews/${reviewId}`, {
+  const { error } = await apiFetch(`/me/reviews/${reviewId}`, {
     method: 'DELETE'
   });
 

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -9,11 +9,13 @@ type UpdateProfileParams = {
   image_ids?: number[];
 };
 
-type UpdatePushNotificationParams = {
-  liked: boolean;
-  coauthor_invited: boolean;
-  comment: boolean;
-  published: boolean;
+type UpdatePreferencesParams = {
+  web_push: {
+    liked: boolean;
+    coauthor_invited: boolean;
+    comment: boolean;
+    published: boolean;
+  };
 };
 
 type ActionResult<T = null> = {
@@ -23,10 +25,9 @@ type ActionResult<T = null> = {
 };
 
 export async function updateProfile(
-  userId: number,
   params: UpdateProfileParams
 ): Promise<ActionResult<Profile>> {
-  const { data, error } = await apiFetch<Profile>(`/users/${userId}`, {
+  const { data, error } = await apiFetch<Profile>('/me/profile', {
     method: 'PUT',
     body: JSON.stringify(params)
   });
@@ -38,8 +39,8 @@ export async function updateProfile(
   return { success: true, data };
 }
 
-export async function deleteAccount(uid: string): Promise<ActionResult> {
-  const { error } = await apiFetch(`/users/${uid}`, {
+export async function deleteAccount(): Promise<ActionResult> {
+  const { error } = await apiFetch('/me/account', {
     method: 'DELETE'
   });
 
@@ -50,11 +51,10 @@ export async function deleteAccount(uid: string): Promise<ActionResult> {
   return { success: true };
 }
 
-export async function updatePushNotification(
-  uid: string,
-  params: UpdatePushNotificationParams
+export async function updatePreferences(
+  params: UpdatePreferencesParams
 ): Promise<ActionResult> {
-  const { error } = await apiFetch(`/users/${uid}/push_notification`, {
+  const { error } = await apiFetch('/me/preferences', {
     method: 'PUT',
     body: JSON.stringify(params)
   });

--- a/src/app/[lang]/(contained)/users/[userId]/page.tsx
+++ b/src/app/[lang]/(contained)/users/[userId]/page.tsx
@@ -4,6 +4,9 @@ import UserProfile from '../../../../../components/profiles/UserProfile';
 import { getServerAuthState } from '../../../../../lib/auth';
 import { getMyChapters, getUserChapters } from '../../../../../lib/chapters';
 import {
+  getMyJournal,
+  getMyMaps,
+  getMyReviews,
   getProfile,
   getUserJournal,
   getUserMaps,
@@ -65,9 +68,11 @@ export default async function UserPage({ params }: Props) {
   const isOwnProfile = Boolean(uid && profile.uid === uid);
 
   const [initialReviews, maps, journal, chapters] = await Promise.all([
-    getUserReviews(userId, lang),
-    getUserMaps(userId, lang, token),
-    getUserJournal(userId, lang, token),
+    isOwnProfile ? getMyReviews(lang) : getUserReviews(userId, lang),
+    isOwnProfile ? getMyMaps(lang, token) : getUserMaps(userId, lang, token),
+    isOwnProfile
+      ? getMyJournal(lang, token)
+      : getUserJournal(userId, lang, token),
     isOwnProfile
       ? getMyChapters(lang, token)
       : getUserChapters(userId, lang, token)

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -7,7 +7,7 @@ import MiniDrawer from '../../components/layouts/MiniDrawer';
 import MobileAppBar from '../../components/layouts/MobileAppBar';
 import ShellProvider from '../../components/layouts/ShellProvider';
 import { getServerAuthState } from '../../lib/auth';
-import { getNotifications, getProfile } from '../../lib/users';
+import { getMyProfile, getNotifications } from '../../lib/users';
 import { getDictionary } from '../../utils/getDictionary';
 import Providers from './Providers';
 
@@ -116,10 +116,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function RootLayout({ children, params }: Props) {
   const { lang } = await params;
   const { authenticated, uid, token } = await getServerAuthState();
-  const profilePromise =
-    authenticated && uid
-      ? getProfile(uid, lang, token)
-      : Promise.resolve<Profile | null>(null);
+  const profilePromise = authenticated
+    ? getMyProfile(lang, token)
+    : Promise.resolve<Profile | null>(null);
   const notificationsPromise = authenticated
     ? getNotifications(lang)
     : Promise.resolve<Notification[]>([]);

--- a/src/app/[lang]/maps/[mapId]/(detail)/page.tsx
+++ b/src/app/[lang]/maps/[mapId]/(detail)/page.tsx
@@ -10,7 +10,7 @@ import {
   getMapCoauthors,
   getMapReviews
 } from '../../../../../lib/maps';
-import { getProfile } from '../../../../../lib/users';
+import { getMyProfile } from '../../../../../lib/users';
 import { getDictionary } from '../../../../../utils/getDictionary';
 
 type Props = {
@@ -63,14 +63,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function MapPage({ params }: Props) {
   const { lang, mapId } = await params;
-  const { token, uid } = await getServerAuthState();
+  const { token } = await getServerAuthState();
   const [map, reviews, coauthors, chapters, profile, journeys] =
     await Promise.all([
       getMap(mapId, lang, token),
       getMapReviews(mapId, lang, token),
       getMapCoauthors(mapId, lang, token),
       getMapChapters(mapId, lang, token),
-      uid ? getProfile(uid, lang, token) : Promise.resolve(null),
+      getMyProfile(lang, token),
       getMyJourneys(lang, token)
     ]);
 

--- a/src/components/profiles/EditProfileDialog.tsx
+++ b/src/components/profiles/EditProfileDialog.tsx
@@ -102,7 +102,7 @@ export default memo(function EditProfileDialog({
 
       startTransition(async () => {
         try {
-          const result = await updateProfile(currentProfile.id, {
+          const result = await updateProfile({
             name,
             biography,
             image_ids:
@@ -121,7 +121,7 @@ export default memo(function EditProfileDialog({
           // The profile is already persisted at this point, so a failing
           // journal update reports itself but must not withhold the refresh.
           if (journal) {
-            const journalResult = await updateJournal(journal.id, {
+            const journalResult = await updateJournal({
               title: journalTitle
             });
 

--- a/src/components/profiles/UserProfile.tsx
+++ b/src/components/profiles/UserProfile.tsx
@@ -142,7 +142,11 @@ function UserProfile({
         </Card>
 
         <TabPanel value="1" sx={{ px: 0 }}>
-          <UserReviews userId={profile.id} initialReviews={initialReviews} />
+          <UserReviews
+            userId={profile.id}
+            initialReviews={initialReviews}
+            isOwnProfile={isOwnProfile}
+          />
         </TabPanel>
         <TabPanel value="2" sx={{ px: 0 }}>
           <UserMaps maps={maps} />

--- a/src/components/profiles/UserReviews.tsx
+++ b/src/components/profiles/UserReviews.tsx
@@ -2,7 +2,10 @@ import { Reviews } from '@mui/icons-material';
 import { Box, Button, Stack } from '@mui/material';
 import { memo, useCallback, useState, useTransition } from 'react';
 import type { Review } from '../../../types';
-import { fetchMoreUserReviews } from '../../actions/reviews';
+import {
+  fetchMoreMyReviews,
+  fetchMoreUserReviews
+} from '../../actions/reviews';
 import useDictionary from '../../hooks/useDictionary';
 import FootprintsLoader from '../common/FootprintsLoader';
 import NoContents from '../common/NoContents';
@@ -11,9 +14,14 @@ import ReviewGridList from '../reviews/ReviewGridList';
 type Props = {
   userId: number;
   initialReviews: Review[];
+  isOwnProfile: boolean;
 };
 
-export default memo(function UserReviews({ userId, initialReviews }: Props) {
+export default memo(function UserReviews({
+  userId,
+  initialReviews,
+  isOwnProfile
+}: Props) {
   const dictionary = useDictionary();
 
   const [reviews, setReviews] = useState(initialReviews);
@@ -30,14 +38,13 @@ export default memo(function UserReviews({ userId, initialReviews }: Props) {
     }
 
     startTransition(async () => {
-      const moreReviews = await fetchMoreUserReviews(
-        userId,
-        lastReview.created_at
-      );
+      const moreReviews = isOwnProfile
+        ? await fetchMoreMyReviews(lastReview.created_at)
+        : await fetchMoreUserReviews(userId, lastReview.created_at);
       setReviews((prev) => [...prev, ...moreReviews]);
       setNoMoreResults(moreReviews.length < 1);
     });
-  }, [userId, reviews, noMoreResults, isPending]);
+  }, [userId, isOwnProfile, reviews, noMoreResults, isPending]);
 
   return (
     <>

--- a/src/components/settings/DeleteAccountDialog.tsx
+++ b/src/components/settings/DeleteAccountDialog.tsx
@@ -9,9 +9,8 @@ import {
   FormControlLabel
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useActionState, useContext, useState } from 'react';
+import { memo, useActionState, useState } from 'react';
 import { deleteAccount } from '../../actions/users';
-import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
 
 type Props = {
@@ -22,19 +21,13 @@ type Props = {
 
 function DeleteAccountDialog({ open, onClose, onDeleted }: Props) {
   const dictionary = useDictionary();
-  const { uid } = useContext(AuthContext);
 
   const [check, setCheck] = useState(false);
 
   const [, submitAction, isPending] = useActionState<null, FormData>(
     async (_prevState, _formData) => {
-      if (!uid) {
-        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
-        return null;
-      }
-
       try {
-        const result = await deleteAccount(uid);
+        const result = await deleteAccount();
 
         if (result.success) {
           enqueueSnackbar(dictionary['delete account success'], {

--- a/src/components/settings/PushNotificationsCard.tsx
+++ b/src/components/settings/PushNotificationsCard.tsx
@@ -12,6 +12,7 @@ import {
   Switch,
   Typography
 } from '@mui/material';
+import { useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import {
   type ChangeEvent,
@@ -21,8 +22,7 @@ import {
   useEffect,
   useState
 } from 'react';
-import { updatePushNotification } from '../../actions/users';
-import AuthContext from '../../context/AuthContext';
+import { updatePreferences } from '../../actions/users';
 import ProfileContext from '../../context/ProfileContext';
 import ServiceWorkerContext from '../../context/ServiceWorkerContext';
 import useDictionary from '../../hooks/useDictionary';
@@ -30,12 +30,12 @@ import { usePushManager } from '../../hooks/usePushManager';
 
 function PushNotificationsCard() {
   const dictionary = useDictionary();
+  const router = useRouter();
 
   const { registration } = useContext(ServiceWorkerContext);
 
   const { isSubscribed, subscribe, unsubscribe } = usePushManager(registration);
 
-  const { uid } = useContext(AuthContext);
   const profile = useContext(ProfileContext);
 
   const [loading, setLoading] = useState(false);
@@ -69,17 +69,21 @@ function PushNotificationsCard() {
     setLoading(true);
 
     try {
-      const result = await updatePushNotification(uid, {
-        liked: likedEnabled,
-        coauthor_invited: coauthorInvitedEnabled,
-        comment: commentEnabled,
-        published: publishedEnabled
+      const result = await updatePreferences({
+        web_push: {
+          liked: likedEnabled,
+          coauthor_invited: coauthorInvitedEnabled,
+          comment: commentEnabled,
+          published: publishedEnabled
+        }
       });
 
       if (result.success) {
         enqueueSnackbar(dictionary['push update success'], {
           variant: 'success'
         });
+
+        router.refresh();
       } else {
         enqueueSnackbar(result.error, { variant: 'error' });
       }
@@ -89,12 +93,12 @@ function PushNotificationsCard() {
       setLoading(false);
     }
   }, [
-    uid,
     likedEnabled,
     coauthorInvitedEnabled,
     commentEnabled,
     publishedEnabled,
-    dictionary
+    dictionary,
+    router
   ]);
 
   useEffect(() => {

--- a/src/lib/coauthorshipInvitations.ts
+++ b/src/lib/coauthorshipInvitations.ts
@@ -5,7 +5,7 @@ export async function getCoauthorshipInvitations(
   lang: string
 ): Promise<CoauthorshipInvitation[]> {
   const { data } = await apiFetch<CoauthorshipInvitation[]>(
-    '/coauthorship_invitations',
+    '/me/coauthorship_invitations',
     {
       lang,
       next: { revalidate: 0 }

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -21,6 +21,21 @@ export async function getProfile(
   return data;
 }
 
+export async function getMyProfile(
+  lang: string,
+  token?: string
+): Promise<Profile | null> {
+  if (!token) {
+    return null;
+  }
+
+  const { data } = await apiFetch<Profile>('/me/profile', {
+    lang,
+    next: { revalidate: 0 }
+  });
+  return data;
+}
+
 export async function getUserMaps(
   userId: string,
   lang: string,
@@ -35,6 +50,21 @@ export async function getUserMaps(
   return data ?? [];
 }
 
+export async function getMyMaps(
+  lang: string,
+  token?: string
+): Promise<AppMap[]> {
+  if (!token) {
+    return [];
+  }
+
+  const { data } = await apiFetch<AppMap[]>('/me/maps', {
+    lang,
+    next: { revalidate: 0 }
+  });
+  return data ?? [];
+}
+
 export async function getUserJournal(
   userId: string,
   lang: string,
@@ -45,6 +75,21 @@ export async function getUserJournal(
   }
 
   const { data } = await apiFetch<Journal>(`/users/${userId}/journal`, {
+    lang,
+    next: { revalidate: 0 }
+  });
+  return data;
+}
+
+export async function getMyJournal(
+  lang: string,
+  token?: string
+): Promise<Journal | null> {
+  if (!token) {
+    return null;
+  }
+
+  const { data } = await apiFetch<Journal>('/me/journal', {
     lang,
     next: { revalidate: 0 }
   });
@@ -97,8 +142,20 @@ export async function getUserReviews(
   return data ?? [];
 }
 
+export async function getMyReviews(
+  lang?: string,
+  nextTimestamp?: string
+): Promise<Review[]> {
+  const query = nextTimestamp ? `?next_timestamp=${nextTimestamp}` : '';
+  const { data } = await apiFetch<Review[]>(`/me/reviews${query}`, {
+    lang,
+    next: { revalidate: 0 }
+  });
+  return data ?? [];
+}
+
 export async function getNotifications(lang: string): Promise<Notification[]> {
-  const { data } = await apiFetch<Notification[]>('/notifications', {
+  const { data } = await apiFetch<Notification[]>('/me/notifications', {
     lang,
     next: { revalidate: 0 }
   });


### PR DESCRIPTION
# Summary

Switches every API call that targets the current user's own resources to the new `/me` endpoints added in yusuke-suzuki/qoodish#583. Calls that target other users' resources keep using the `/users/:id` routes.

# Motivation

Journeys, chapters, and bookmarks already access the current user's resources through the `/me` namespace, while older calls still address them through `/users/:id` (passing the user's own uid or id) or top-level routes such as `/notifications` and `/devices`. Migrating the remaining calls lets the backend remove the old endpoints and their current-user special cases in a follow-up release.

# Changes

- `src/lib/users.ts` gains `getMyProfile`, `getMyMaps`, `getMyJournal`, and `getMyReviews`, and `getNotifications` now calls `/me/notifications`. The `getUser*` fetchers remain for other users' pages.
- The profile page branches on `isOwnProfile` for reviews, maps, and journal, matching the branching that already existed for chapters. `UserReviews` pagination follows the same branch via the new `fetchMoreMyReviews` action.
- The layout and map detail page fetch the signed-in user's profile via `getMyProfile` instead of `getProfile(uid)`.
- Server Actions now call `/me/profile`, `/me/account`, `/me/journal`, `/me/devices/:token`, `/me/notifications/:id`, `/me/reviews/:id`, and `/me/coauthorship_invitations/:id/accept|decline`. The `uid` / `id` parameters that existed only to address the current user are removed, since `/me` resolves the user from the auth token.
- The web push settings save becomes `updatePreferences`, calling `PUT /me/preferences` with the flags nested under `web_push`, following the backend's move to a general preferences resource. Reading the current values is unchanged: the settings card keeps consuming the `push_notification` key from the profile response.

# Testing

`pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass.

# Release procedure

Merge this only after the qoodish release that carries yusuke-suzuki/qoodish#583 is live, because the `/me` endpoints must exist before this deploys. The removal of the old endpoints on the backend follows after this is deployed and confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RA213VYU2N35uNySLAFkq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading and managing the signed-in user’s profile, journal, maps, and reviews.
  * Added loading of additional reviews for the signed-in user.
  * Added updated preference management for web push notifications.
* **Bug Fixes**
  * Improved account, notification, device, and coauthorship invitation actions for signed-in users.
  * Updated profile pages to correctly display the current user’s data.
  * Simplified profile, journal, and account management without requiring user identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->