### PR TITLE
fix: show skeleton cards while loading timeline

### DIFF
--- a/src/components/common/LoadingStatus.tsx
+++ b/src/components/common/LoadingStatus.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { memo } from 'react';
+import useDictionary from '../../hooks/useDictionary';
+
+type Props = {
+  loading: boolean;
+};
+
+// Skeletons already carry the loading state visually, so the live region
+// stays in the accessibility tree only.
+export default memo(function LoadingStatus({ loading }: Props) {
+  const dictionary = useDictionary();
+
+  return (
+    <Box
+      component="output"
+      sx={{
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: 0,
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0 0 0 0)',
+        whiteSpace: 'nowrap',
+        border: 0
+      }}
+    >
+      {loading ? dictionary.loading : ''}
+    </Box>
+  );
+});

--- a/src/components/home/Timeline.tsx
+++ b/src/components/home/Timeline.tsx
@@ -6,10 +6,11 @@ import { memo, useCallback, useState, useTransition } from 'react';
 import type { Review } from '../../../types';
 import { fetchMoreTimelineReviews } from '../../actions/reviews';
 import useDictionary from '../../hooks/useDictionary';
-import FootprintsLoader from '../common/FootprintsLoader';
 import IssueDialog from '../common/IssueDialog';
+import LoadingStatus from '../common/LoadingStatus';
 import NoContents from '../common/NoContents';
 import TimelineReviewCard from './TimelineReviewCard';
+import TimelineReviewCardSkeleton from './TimelineReviewCardSkeleton';
 
 type Props = {
   initialReviews: Review[];
@@ -19,6 +20,8 @@ type IssueReportOptions = {
   contentId: number | null;
   dialogOpen: boolean;
 };
+
+const skeletonKeys = ['skeleton-1', 'skeleton-2'];
 
 export default memo(function Timeline({ initialReviews }: Props) {
   const dictionary = useDictionary();
@@ -72,7 +75,9 @@ export default memo(function Timeline({ initialReviews }: Props) {
         />
       )}
 
-      <Box sx={{ display: 'grid', gap: 3 }}>
+      <LoadingStatus loading={isPending} />
+
+      <Box sx={{ display: 'grid', gap: 3 }} aria-busy={isPending}>
         {reviews.map((review) => (
           <TimelineReviewCard
             key={review.id}
@@ -80,13 +85,10 @@ export default memo(function Timeline({ initialReviews }: Props) {
             onReportClick={handleReportClick}
           />
         ))}
-      </Box>
 
-      {isPending && (
-        <Box sx={{ my: 2, height: { xs: 220, sm: 280 } }}>
-          <FootprintsLoader label={dictionary.loading} />
-        </Box>
-      )}
+        {isPending &&
+          skeletonKeys.map((key) => <TimelineReviewCardSkeleton key={key} />)}
+      </Box>
 
       <Stack alignItems="center" sx={{ mt: 2 }}>
         {!isPending && !noMoreResults && reviews.length > 0 && (

--- a/src/components/home/TimelineReviewCardSkeleton.tsx
+++ b/src/components/home/TimelineReviewCardSkeleton.tsx
@@ -1,0 +1,33 @@
+import {
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Skeleton,
+  Typography
+} from '@mui/material';
+import { memo } from 'react';
+
+export default memo(function TimelineReviewCardSkeleton() {
+  return (
+    <Card elevation={0}>
+      <CardHeader
+        avatar={<Skeleton variant="circular" width={40} height={40} />}
+        title={<Skeleton variant="text" width="40%" />}
+        subheader={<Skeleton variant="text" width="25%" />}
+      />
+      <CardContent sx={{ pt: 0 }}>
+        <Typography variant="h5" component="div" gutterBottom>
+          <Skeleton variant="text" width="60%" />
+        </Typography>
+
+        <Skeleton variant="text" />
+        <Skeleton variant="text" width="80%" />
+      </CardContent>
+      <CardActions>
+        <Skeleton variant="circular" width={40} height={40} />
+        <Skeleton variant="circular" width={40} height={40} />
+      </CardActions>
+    </Card>
+  );
+});

--- a/src/components/profiles/UserReviews.tsx
+++ b/src/components/profiles/UserReviews.tsx
@@ -1,5 +1,5 @@
 import { Reviews } from '@mui/icons-material';
-import { Box, Button, Stack } from '@mui/material';
+import { Button, Stack } from '@mui/material';
 import { memo, useCallback, useState, useTransition } from 'react';
 import type { Review } from '../../../types';
 import {
@@ -7,7 +7,7 @@ import {
   fetchMoreUserReviews
 } from '../../actions/reviews';
 import useDictionary from '../../hooks/useDictionary';
-import FootprintsLoader from '../common/FootprintsLoader';
+import LoadingStatus from '../common/LoadingStatus';
 import NoContents from '../common/NoContents';
 import ReviewGridList from '../reviews/ReviewGridList';
 
@@ -55,17 +55,9 @@ export default memo(function UserReviews({
         />
       )}
 
-      <Box sx={{ display: 'grid', gap: 1 }}>
-        {reviews.length > 0 && (
-          <ReviewGridList reviews={reviews} hideSkeleton />
-        )}
-      </Box>
+      <LoadingStatus loading={isPending} />
 
-      {isPending && (
-        <Box sx={{ my: 2, height: { xs: 220, sm: 280 } }}>
-          <FootprintsLoader label={dictionary.loading} />
-        </Box>
-      )}
+      <ReviewGridList reviews={reviews} hideSkeleton loading={isPending} />
 
       <Stack alignItems="center" sx={{ mt: 2 }}>
         {!isPending && !noMoreResults && reviews.length > 0 && (

--- a/src/components/reviews/ReviewGridList.tsx
+++ b/src/components/reviews/ReviewGridList.tsx
@@ -18,12 +18,22 @@ import type { Review } from '../../../types';
 type Props = {
   reviews: Review[];
   hideSkeleton?: boolean;
+  loading?: boolean;
 };
 
 const tileImageHeight = 180;
 
-function ReviewGridList({ reviews, hideSkeleton }: Props) {
-  if (reviews.length < 1 && hideSkeleton) {
+const loadingTileKeys = [
+  'loading-1',
+  'loading-2',
+  'loading-3',
+  'loading-4',
+  'loading-5',
+  'loading-6'
+];
+
+function ReviewGridList({ reviews, hideSkeleton, loading }: Props) {
+  if (reviews.length < 1 && hideSkeleton && !loading) {
     return null;
   }
 
@@ -37,8 +47,9 @@ function ReviewGridList({ reviews, hideSkeleton }: Props) {
           sm: 'repeat(3, 1fr)'
         }
       }}
+      aria-busy={loading}
     >
-      {(!reviews.length ? Array.from(new Array(6)) : reviews).map(
+      {(!reviews.length && !loading ? Array.from(new Array(6)) : reviews).map(
         (review: Review | null, i) => (
           <MuiLink
             href={review ? `/maps/${review.map.id}/reports/${review.id}` : '/'}
@@ -55,7 +66,7 @@ function ReviewGridList({ reviews, hideSkeleton }: Props) {
                 overflow: 'hidden'
               }}
             >
-              {!review && <Skeleton variant="rectangular" height="100%" />}
+              {!review && <Skeleton variant="rounded" height="100%" />}
 
               {review?.images.length > 0 && (
                 <Card sx={{ height: '100%' }} elevation={0}>
@@ -109,6 +120,11 @@ function ReviewGridList({ reviews, hideSkeleton }: Props) {
           </MuiLink>
         )
       )}
+
+      {loading &&
+        loadingTileKeys.map((key) => (
+          <Skeleton key={key} variant="rounded" height={tileImageHeight} />
+        ))}
     </Box>
   );
 }


### PR DESCRIPTION

# Summary

Replace the footprints animation shown while loading more reports with skeleton placeholders. The home timeline now appends placeholder cards to the feed, and the profile report grid appends placeholder tiles to the grid.

# Motivation

The footprints animation is a full-screen splash treatment used while the app boots. Reusing it for incremental loading swapped part of the list for an unrelated animation in a fixed-height block, which read as an interruption rather than a continuation of the list. Skeleton placeholders that mirror the incoming content are the conventional pattern for this kind of list.

# Changes

- Add `TimelineReviewCardSkeleton`, a placeholder shaped like `TimelineReviewCard` down to its action row, and render two of them at the end of the timeline feed while more reports load.
- Add a `loading` prop to `ReviewGridList` that appends placeholder tiles to the grid, and use it from `UserReviews` in place of the footprints animation.
- Add `LoadingStatus`, a visually hidden live region that carries the loading text for assistive technology now that the label the footprints loader rendered is gone. Both lists render it outside their `aria-busy` container.
- Use the `rounded` skeleton variant in `ReviewGridList` so placeholders match the corner radius of the real tiles.

The full-screen loader in `src/app/[lang]/Providers.tsx` is unchanged; it is the boot-time splash the animation was designed for.

# Testing

- `pnpm biome ci ./src`
- `pnpm exec tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx3ggJhCqrpfo9Qp1ein3B)_



## Summary by CodeRabbit

* **New Features**
  * Added card and grid loading placeholders for timeline and profile reviews.
  * Improved loading accessibility with busy-state indicators and loading labels.
* **Bug Fixes**
  * Review lists now maintain consistent layout while content is loading.
  * Empty review sections remain hidden when no loading state is active.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added card and grid loading placeholders for timeline and profile reviews.
  * Added accessible loading announcements and busy-state indicators.
  * Added rounded skeleton tiles for a more consistent loading experience.

* **Bug Fixes**
  * Review lists now maintain their layout while content is loading.
  * Empty review sections remain hidden when no content or loading state is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->