### PR TITLE
fix: tolerate slow API cold starts

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/google.maps": "^3.54.6",
     "@types/lodash.debounce": "^4.0.7",
     "@types/lodash.throttle": "^4.1.7",
+    "@types/node": "^22.20.1",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@types/react-swipeable-views": "^0.13.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@types/lodash.throttle':
         specifier: ^4.1.7
         version: 4.1.9
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.2
@@ -1279,6 +1282,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/node@24.9.2':
     resolution: {integrity: sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==}
@@ -3110,6 +3116,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -4457,6 +4466,10 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/ms@2.1.0': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@24.9.2':
     dependencies:
@@ -6743,6 +6756,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 

--- a/src/app/api/v1/[...path]/route.ts
+++ b/src/app/api/v1/[...path]/route.ts
@@ -61,7 +61,8 @@ async function proxyRequest(request: NextRequest, { params }: Params) {
 
   const init: RequestInit = {
     method: request.method,
-    headers
+    headers,
+    signal: AbortSignal.timeout(30000)
   };
 
   if (request.method === 'POST') {
@@ -81,6 +82,11 @@ async function proxyRequest(request: NextRequest, { params }: Params) {
     });
   } catch (error) {
     console.error(`Proxy error for /${joinedPath}:`, error);
+
+    if (error instanceof DOMException && error.name === 'TimeoutError') {
+      return NextResponse.json({ detail: 'Upstream timeout' }, { status: 504 });
+    }
+
     return NextResponse.json(
       { detail: 'Internal proxy error' },
       { status: 502 }

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -36,6 +36,7 @@ function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
   const [loading, setLoading] = useState(true);
   const [signInRequired, setSignInRequired] = useState(false);
   const authStateRef = useRef(serverAuthenticated);
+  const pendingRegistrationRef = useRef(false);
 
   useEmailLinkHandler({ isLoading: loading });
 
@@ -53,11 +54,78 @@ function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
     }
   }, []);
 
+  const registerBackendUser = useCallback(async () => {
+    // Retry across the API's cold start; delays add up to ~30s on top of
+    // the proxy's own 30s timeout per attempt.
+    const retryDelays = [1000, 2000, 4000, 8000, 16000];
+
+    for (let attempt = 0; attempt <= retryDelays.length; attempt++) {
+      try {
+        const res = await fetch('/api/v1/users', { method: 'POST' });
+
+        if (res.ok) {
+          return true;
+        }
+
+        if (res.status < 500) {
+          return false;
+        }
+      } catch (error) {
+        console.error('Failed to register backend user:', error);
+      }
+
+      if (attempt < retryDelays.length) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, retryDelays[attempt])
+        );
+      }
+    }
+
+    return false;
+  }, []);
+
   const handleIdTokenChanged = useCallback(
     async (user: User | null) => {
-      if (user) {
-        if (user.isAnonymous) {
-          await user.delete();
+      try {
+        if (user) {
+          if (user.isAnonymous) {
+            await user.delete();
+
+            setAuthenticated(false);
+            setUid(null);
+            setLoading(false);
+
+            if (authStateRef.current) {
+              authStateRef.current = false;
+              await clearNavigationCache();
+              router.refresh();
+            }
+          } else {
+            const accessToken = await user.getIdToken();
+            await syncSessionCookie(accessToken);
+
+            setAuthenticated(true);
+            setUid(user.uid);
+            setLoading(false);
+
+            if (!authStateRef.current) {
+              authStateRef.current = true;
+              pendingRegistrationRef.current = !(await registerBackendUser());
+              await clearNavigationCache();
+              router.refresh();
+            } else if (pendingRegistrationRef.current) {
+              pendingRegistrationRef.current = !(await registerBackendUser());
+
+              if (!pendingRegistrationRef.current) {
+                await clearNavigationCache();
+                router.refresh();
+              }
+            }
+          }
+        } else {
+          await syncSessionCookie(null);
+
+          pendingRegistrationRef.current = false;
 
           setAuthenticated(false);
           setUid(null);
@@ -68,36 +136,13 @@ function AuthProvider({ children, serverAuthenticated, serverUid }: Props) {
             await clearNavigationCache();
             router.refresh();
           }
-        } else {
-          const accessToken = await user.getIdToken();
-          await syncSessionCookie(accessToken);
-
-          if (!authStateRef.current) {
-            await fetch('/api/v1/users', { method: 'POST' });
-            authStateRef.current = true;
-            await clearNavigationCache();
-            router.refresh();
-          }
-
-          setAuthenticated(true);
-          setUid(user.uid);
-          setLoading(false);
         }
-      } else {
-        await syncSessionCookie(null);
-
-        setAuthenticated(false);
-        setUid(null);
+      } catch (error) {
+        console.error('Failed to handle auth state change:', error);
         setLoading(false);
-
-        if (authStateRef.current) {
-          authStateRef.current = false;
-          await clearNavigationCache();
-          router.refresh();
-        }
       }
     },
-    [syncSessionCookie, clearNavigationCache, router]
+    [syncSessionCookie, clearNavigationCache, registerBackendUser, router]
   );
 
   useEffect(() => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,8 +3,11 @@ import { cookies, headers } from 'next/headers';
 type ApiFetchOptions = RequestInit & {
   guest?: boolean;
   lang?: string;
+  timeoutMs?: number;
   next?: { revalidate?: number | false; tags?: string[] };
 };
+
+const DEFAULT_TIMEOUT_MS = 15000;
 
 async function getAuthToken(): Promise<string | null> {
   const cookieStore = await cookies();
@@ -24,7 +27,7 @@ export async function apiFetch<T>(
   path: string,
   options: ApiFetchOptions = {}
 ): Promise<{ data: T | null; error: string | null; status: number }> {
-  const { guest, lang, next, ...fetchOptions } = options;
+  const { guest, lang, timeoutMs, next, ...fetchOptions } = options;
 
   const token = guest ? null : await getAuthToken();
   const acceptLanguage = await getAcceptLanguage(lang);
@@ -44,6 +47,9 @@ export async function apiFetch<T>(
   try {
     const res = await fetch(`${process.env.API_ENDPOINT}${apiPath}`, {
       ...fetchOptions,
+      signal:
+        fetchOptions.signal ??
+        AbortSignal.timeout(timeoutMs ?? DEFAULT_TIMEOUT_MS),
       headers: {
         ...requestHeaders,
         ...Object.fromEntries(new Headers(fetchOptions.headers).entries())
@@ -65,7 +71,15 @@ export async function apiFetch<T>(
     return { data, error: null, status: res.status };
   } catch (error) {
     console.error(`API fetch error for ${path}:`, error);
-    return { data: null, error: 'Network error', status: 0 };
+
+    const timedOut =
+      error instanceof DOMException && error.name === 'TimeoutError';
+
+    return {
+      data: null,
+      error: timedOut ? 'Request timed out' : 'Network error',
+      status: 0
+    };
   }
 }
 

--- a/src/lib/chapters.ts
+++ b/src/lib/chapters.ts
@@ -10,7 +10,7 @@ export async function getChapter(
   const { data } = await apiFetch<Chapter>(`/chapters/${chapterId}`, {
     lang,
     guest,
-    next: { revalidate: 0 }
+    next: { revalidate: guest ? 300 : 0 }
   });
   return data;
 }

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -61,7 +61,7 @@ export async function getActiveMaps(lang: string): Promise<AppMap[]> {
   const { data } = await apiFetch<AppMap[]>('/maps?active=true', {
     lang,
     guest: true,
-    next: { revalidate: 300 }
+    next: { revalidate: 3600 }
   });
   return data ?? [];
 }
@@ -70,7 +70,7 @@ export async function getPopularMaps(lang: string): Promise<AppMap[]> {
   const { data } = await apiFetch<AppMap[]>('/maps?popular=true', {
     lang,
     guest: true,
-    next: { revalidate: 300 }
+    next: { revalidate: 3600 }
   });
   return data ?? [];
 }
@@ -79,7 +79,7 @@ export async function getRecentMaps(lang: string): Promise<AppMap[]> {
   const { data } = await apiFetch<AppMap[]>('/maps?recent=true', {
     lang,
     guest: true,
-    next: { revalidate: 300 }
+    next: { revalidate: 900 }
   });
   return data ?? [];
 }

--- a/src/lib/reviews.ts
+++ b/src/lib/reviews.ts
@@ -24,7 +24,7 @@ export async function getPopularReviews(lang: string): Promise<Review[]> {
   const { data } = await apiFetch<Review[]>('/reviews?popular=true', {
     lang,
     guest: true,
-    next: { revalidate: 300 }
+    next: { revalidate: 3600 }
   });
   return data ?? [];
 }
@@ -33,7 +33,7 @@ export async function getRecentReviews(lang: string): Promise<Review[]> {
   const { data } = await apiFetch<Review[]>('/reviews?recent=true', {
     lang,
     guest: true,
-    next: { revalidate: 300 }
+    next: { revalidate: 900 }
   });
   return data ?? [];
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,22 @@
-import { type NextRequest, NextResponse } from 'next/server';
+import {
+  type NextFetchEvent,
+  type NextRequest,
+  NextResponse
+} from 'next/server';
+
+const WARMUP_INTERVAL_MS = 60000;
+
+let lastWarmupAt = 0;
+
+async function warmUpApi(): Promise<void> {
+  try {
+    await fetch(`${process.env.API_ENDPOINT}/healthcheck`, {
+      signal: AbortSignal.timeout(60000)
+    });
+  } catch (error) {
+    console.warn('API warmup request failed:', error);
+  }
+}
 
 const locales = ['en', 'ja'] as const;
 type Locale = (typeof locales)[number];
@@ -18,7 +36,12 @@ function getPreferredLocale(request: NextRequest): Locale {
   return defaultLocale;
 }
 
-export function middleware(request: NextRequest) {
+export function middleware(request: NextRequest, event: NextFetchEvent) {
+  if (Date.now() - lastWarmupAt >= WARMUP_INTERVAL_MS) {
+    lastWarmupAt = Date.now();
+    event.waitUntil(warmUpApi());
+  }
+
   const { pathname } = request.nextUrl;
 
   const pathnameHasLocale = locales.some(


### PR DESCRIPTION
# Summary

Makes the web app tolerate the Rails API's slow Cloud Run cold starts: bounded fetch timeouts, a retrying auth recovery path, an early warmup ping, and wider guest data caching. These changes are platform-independent and effective on the current Vercel production as-is, so they ship separately from the Cloudflare Workers migration (#1088).

# Motivation

The API scales to zero on Cloud Run and takes tens of seconds to boot. SSR hung indefinitely waiting for a cold API, and when the client-side auth recovery failed against it, signed-in users got stuck on the guest view until the next token refresh.

# Changes

- Abort server-side fetches after 15s (overridable) and the internal proxy after 30s, so a cold API degrades pages instead of blocking them
- Reflect the signed-in state on the client before backend user registration, retry the registration with backoff across a cold start, and refresh the router afterwards so the guest view always recovers
- Ping the API healthcheck from the middleware (fire-and-forget, throttled per isolate) so booting starts while users are on cached or static content
- Extend the guest data cache: chapter detail now cached for guests (the guest endpoint only exposes published chapters), ranking feeds moved to a 1-hour TTL, recency feeds to 15 minutes — each cache hit avoids waking a cold API
- Declare `@types/node` directly so `tsc --noEmit` passes on a clean install

# Testing

- `pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass
- Smoke-tested with an unreachable `API_ENDPOINT`: pages render degraded instead of hanging, the proxy returns 401/504 as designed, and the middleware warmup failure is swallowed without affecting the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New accounts are automatically registered with the backend after sign-in, including retry handling for temporary failures.
  * API requests now support configurable timeouts.

* **Bug Fixes**
  * Upstream timeout errors now return a clear 504 response.
  * Client request timeouts display a specific timeout message.

* **Performance**
  * Improved caching for chapters, maps, and reviews.
  * Added periodic service warmup to improve API responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->