### PR TITLE
fix: keep API outages from rendering as 404s

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -95,3 +95,12 @@ export async function apiFetchOrThrow<T>(
 
   return data;
 }
+
+// A missing resource must stay distinguishable from an unreachable API:
+// detail pages translate null into notFound(), and serving 404s for
+// timeouts or 5xx would let crawlers deindex live content.
+export function assertApiAvailable(status: number, path: string): void {
+  if (status === 0 || status >= 500) {
+    throw new Error(`API request for ${path} failed with status ${status}`);
+  }
+}

--- a/src/lib/chapters.ts
+++ b/src/lib/chapters.ts
@@ -1,5 +1,5 @@
 import type { Chapter } from '../../types';
-import { apiFetch } from './api';
+import { apiFetch, assertApiAvailable } from './api';
 
 export async function getChapter(
   chapterId: string | number,
@@ -7,11 +7,12 @@ export async function getChapter(
   token?: string
 ): Promise<Chapter | null> {
   const guest = !token;
-  const { data } = await apiFetch<Chapter>(`/chapters/${chapterId}`, {
+  const { data, status } = await apiFetch<Chapter>(`/chapters/${chapterId}`, {
     lang,
     guest,
     next: { revalidate: guest ? 300 : 0 }
   });
+  assertApiAvailable(status, `/chapters/${chapterId}`);
   return data;
 }
 

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -1,5 +1,5 @@
 import type { AppMap, Chapter, Coauthor, Review } from '../../types';
-import { apiFetch } from './api';
+import { apiFetch, assertApiAvailable } from './api';
 
 export async function getMap(
   mapId: string,
@@ -7,11 +7,12 @@ export async function getMap(
   token?: string
 ): Promise<AppMap | null> {
   const guest = !token;
-  const { data } = await apiFetch<AppMap>(`/maps/${mapId}`, {
+  const { data, status } = await apiFetch<AppMap>(`/maps/${mapId}`, {
     lang,
     guest,
     next: { revalidate: guest ? 300 : 0 }
   });
+  assertApiAvailable(status, `/maps/${mapId}`);
   return data;
 }
 

--- a/src/lib/reviews.ts
+++ b/src/lib/reviews.ts
@@ -1,5 +1,5 @@
 import type { Review } from '../../types';
-import { apiFetch } from './api';
+import { apiFetch, assertApiAvailable } from './api';
 
 export async function getReview(
   reviewId: string,
@@ -12,11 +12,12 @@ export async function getReview(
     !guest && mapId
       ? `/maps/${mapId}/reviews/${reviewId}`
       : `/reviews/${reviewId}`;
-  const { data } = await apiFetch<Review>(path, {
+  const { data, status } = await apiFetch<Review>(path, {
     lang,
     guest,
     next: { revalidate: guest ? 300 : 0 }
   });
+  assertApiAvailable(status, path);
   return data;
 }
 

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -5,7 +5,7 @@ import type {
   Profile,
   Review
 } from '../../types';
-import { apiFetch } from './api';
+import { apiFetch, assertApiAvailable } from './api';
 
 export async function getProfile(
   userId: string,
@@ -13,11 +13,12 @@ export async function getProfile(
   token?: string
 ): Promise<Profile | null> {
   const guest = !token;
-  const { data } = await apiFetch<Profile>(`/users/${userId}`, {
+  const { data, status } = await apiFetch<Profile>(`/users/${userId}`, {
     lang,
     guest,
     next: { revalidate: guest ? 300 : 0 }
   });
+  assertApiAvailable(status, `/users/${userId}`);
   return data;
 }
 


### PR DESCRIPTION
# Summary

Detail fetchers (`getMap`, `getChapter`, `getReview`, `getProfile`) now throw when the API is unreachable (network error, timeout, 5xx) instead of returning null, so detail pages render an error response rather than `notFound()`.

# Motivation

`apiFetch` collapses every failure into `data: null`, and detail pages translate null into `notFound()`. Since the 15s fetch timeout landed (#1090), an API cold start slower than the timeout makes real maps, chapters, reviews and profiles respond with genuine 404s — which crawlers treat as content removal and may deindex. This was found by an automated review of #1088.

# Changes

- Add `assertApiAvailable` to `src/lib/api.ts`: throws when the upstream status is 0 (network/timeout) or 5xx
- Call it from the four detail fetchers whose null result drives `notFound()`; a 4xx from the API still returns null, so genuinely missing or hidden resources keep responding 404

# Testing

- `pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass
- The thrown error surfaces through Next's error handling as a 500-class response, which crawlers retry instead of deindexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_