### PR TITLE
fix: narrow the API warmup to page requests

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,12 +7,18 @@ import { DEFAULT_LOCALE, LOCALES, type Locale } from './utils/locales';
 
 const WARMUP_INTERVAL_MS = 60000;
 
+// Module state resets with every fresh runtime instance, so this throttle is
+// best-effort: each new instance pings once immediately. The healthcheck
+// renders a constant string, so those extra pings are cheap; the throttle
+// only keeps warm instances from pinging on every request.
 let lastWarmupAt = 0;
 
 async function warmUpApi(): Promise<void> {
   try {
+    // The response is irrelevant — the connection alone starts the boot, so
+    // the timeout only bounds how long this background task lingers.
     await fetch(`${process.env.API_ENDPOINT}/healthcheck`, {
-      signal: AbortSignal.timeout(60000)
+      signal: AbortSignal.timeout(10000)
     });
   } catch (error) {
     console.warn('API warmup request failed:', error);
@@ -34,11 +40,6 @@ function getPreferredLocale(request: NextRequest): Locale {
 }
 
 export function middleware(request: NextRequest, event: NextFetchEvent) {
-  if (Date.now() - lastWarmupAt >= WARMUP_INTERVAL_MS) {
-    lastWarmupAt = Date.now();
-    event.waitUntil(warmUpApi());
-  }
-
   const { pathname } = request.nextUrl;
 
   const pathnameHasLocale = LOCALES.some(
@@ -46,6 +47,11 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   );
 
   if (pathnameHasLocale) {
+    if (Date.now() - lastWarmupAt >= WARMUP_INTERVAL_MS) {
+      lastWarmupAt = Date.now();
+      event.waitUntil(warmUpApi());
+    }
+
     return NextResponse.next();
   }
 


### PR DESCRIPTION
# Summary

Limits the middleware API warmup to requests that will render a page, and shortens its timeout from 60s to 10s.

# Motivation

The warmup exists only to open a connection so the API starts booting; its response is discarded. A 60s `AbortSignal` therefore kept the background task alive long after it had done its work. The ping also fired on locale-less requests, which the middleware answers with a 308 without ever reaching the API, so the upstream call shortened no one's wait. Found by an automated review of #1088.

# Changes

- Warmup timeout 60s → 10s
- The ping moves inside the `pathnameHasLocale` branch, so redirect-only requests no longer trigger it
- The throttle's reliance on module state is documented: it resets with each fresh runtime instance, so it is best-effort rather than a global rate limit, and the healthcheck is cheap enough that this is fine

Nothing here depends on the hosting platform — the warmup shipped independently of #1088 and this change applies wherever the middleware runs.

# Testing

- `pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_