### PR TITLE
fix: redirect the root path to /en in one hop

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -51,7 +51,8 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
 
   const locale = getPreferredLocale(request);
   const newUrl = request.nextUrl.clone();
-  newUrl.pathname = `/${locale}${pathname}`;
+  // '/' must not become '/en/', which Next would 308 again to '/en'.
+  newUrl.pathname = `/${locale}${pathname === '/' ? '' : pathname}`;
 
   // Redirect instead of rewriting so every page is reachable under exactly one
   // URL; serving locale-less paths with a 200 duplicates every localized page.


### PR DESCRIPTION
# Summary

`https://qoodish.com/` redirected twice — middleware 308 to `/en/`, then Next's trailing-slash normalization 308 to `/en`. Stripping the slash before prefixing makes it a single hop.

# Motivation

The bare domain is the most-linked URL on the site, and since the locale middleware switched from rewriting to redirecting, every visitor and crawler paid the double hop. Found by an automated review of #1088.

# Changes

- `newUrl.pathname` construction special-cases `'/'`, matching the normalization `localePath()` already applies to links

# Testing

- `pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_