### PR TITLE
feat: include published chapters in the sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from 'next';
+import { getRecentChapters } from '../lib/chapters';
 import { getActiveMaps, getPopularMaps, getRecentMaps } from '../lib/maps';
 import { getPopularReviews, getRecentReviews } from '../lib/reviews';
 import { DEFAULT_LOCALE, LOCALES, localePath } from '../utils/locales';
@@ -46,14 +47,21 @@ function expand({
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const [activeMaps, popularMaps, recentMaps, popularReviews, recentReviews] =
-    await Promise.all([
-      getActiveMaps(DEFAULT_LOCALE),
-      getPopularMaps(DEFAULT_LOCALE),
-      getRecentMaps(DEFAULT_LOCALE),
-      getPopularReviews(DEFAULT_LOCALE),
-      getRecentReviews(DEFAULT_LOCALE)
-    ]);
+  const [
+    activeMaps,
+    popularMaps,
+    recentMaps,
+    popularReviews,
+    recentReviews,
+    recentChapters
+  ] = await Promise.all([
+    getActiveMaps(DEFAULT_LOCALE),
+    getPopularMaps(DEFAULT_LOCALE),
+    getRecentMaps(DEFAULT_LOCALE),
+    getPopularReviews(DEFAULT_LOCALE),
+    getRecentReviews(DEFAULT_LOCALE),
+    getRecentChapters(DEFAULT_LOCALE)
+  ]);
 
   const mapEntries = new Map<number, Entry>();
 
@@ -83,9 +91,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
   }
 
+  const chapterEntries = new Map<number, Entry>();
+
+  for (const chapter of recentChapters) {
+    if (chapter.status !== 'published') {
+      continue;
+    }
+
+    chapterEntries.set(chapter.id, {
+      path: `/chapters/${chapter.id}`,
+      lastModified: chapter.updated_at,
+      priority: 0.6
+    });
+  }
+
   return [
     ...STATIC_ENTRIES,
     ...Array.from(mapEntries.values()),
-    ...Array.from(reviewEntries.values())
+    ...Array.from(reviewEntries.values()),
+    ...Array.from(chapterEntries.values())
   ].flatMap(expand);
 }

--- a/src/lib/chapters.ts
+++ b/src/lib/chapters.ts
@@ -15,6 +15,15 @@ export async function getChapter(
   return data;
 }
 
+export async function getRecentChapters(lang: string): Promise<Chapter[]> {
+  const { data } = await apiFetch<Chapter[]>('/chapters', {
+    lang,
+    guest: true,
+    next: { revalidate: 900 }
+  });
+  return data ?? [];
+}
+
 export async function getUserChapters(
   userId: string | number,
   lang: string,


### PR DESCRIPTION
# Summary

Adds published chapters to `/sitemap.xml` via the guest chapters feed, alongside the existing map and review entries.

# Motivation

`/[lang]/chapters/[chapterId]` emits canonical and hreflang metadata and leaves `robots` indexable for published chapters, but nothing pointed crawlers at those URLs: the sitemap omitted them and the map page's chapters tab is not rendered in the initial HTML. Found by an automated review of #1088.

# Changes

- Add `getRecentChapters` to `src/lib/chapters.ts`, backed by `GET /guest/chapters` (the API's `public_open` feed) with a 15-minute guest cache like the other recency feeds
- Emit chapter entries at priority 0.6 with `lastModified`, deduplicated and expanded per locale with the same hreflang set as maps and reviews; a defensive `status === 'published'` filter mirrors the `map.private` checks

# Testing

- `pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_