### PR TITLE
fix: cap guest ranking caches at 15 minutes

### DIFF
--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -61,7 +61,7 @@ export async function getActiveMaps(lang: string): Promise<AppMap[]> {
   const { data } = await apiFetch<AppMap[]>('/maps?active=true', {
     lang,
     guest: true,
-    next: { revalidate: 3600 }
+    next: { revalidate: 900 }
   });
   return data ?? [];
 }
@@ -70,7 +70,7 @@ export async function getPopularMaps(lang: string): Promise<AppMap[]> {
   const { data } = await apiFetch<AppMap[]>('/maps?popular=true', {
     lang,
     guest: true,
-    next: { revalidate: 3600 }
+    next: { revalidate: 900 }
   });
   return data ?? [];
 }

--- a/src/lib/reviews.ts
+++ b/src/lib/reviews.ts
@@ -24,7 +24,7 @@ export async function getPopularReviews(lang: string): Promise<Review[]> {
   const { data } = await apiFetch<Review[]>('/reviews?popular=true', {
     lang,
     guest: true,
-    next: { revalidate: 3600 }
+    next: { revalidate: 900 }
   });
   return data ?? [];
 }


### PR DESCRIPTION
# Summary

Lowers the guest cache TTL on the ranking feeds (`getActiveMaps`, `getPopularMaps`, `getPopularReviews`) from one hour to 15 minutes, matching the recency feeds.

# Motivation

These feeds drive the public discover and home pages, and the sitemap builds from the same cached fetches. With no `revalidateTag` purge path, the TTL is also the upper bound on how long a map that was just deleted or made private keeps being served publicly — one hour was a meaningful privacy window for a knob whose only benefit is cold-start avoidance. Found by an automated review of #1088.

# Changes

- `revalidate: 3600` → `900` on the three ranking feeds; detail pages (300s) and recency feeds (900s) are unchanged

# Testing

- `pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_