### PR TITLE
fix: URL-encode pagination timestamps

### DIFF
--- a/src/lib/reviews.ts
+++ b/src/lib/reviews.ts
@@ -41,7 +41,9 @@ export async function getRecentReviews(lang: string): Promise<Review[]> {
 export async function getTimelineReviews(
   nextTimestamp?: string
 ): Promise<Review[]> {
-  const query = nextTimestamp ? `?next_timestamp=${nextTimestamp}` : '';
+  const query = nextTimestamp
+    ? `?next_timestamp=${encodeURIComponent(nextTimestamp)}`
+    : '';
   const { data } = await apiFetch<Review[]>(`/reviews${query}`, {
     next: { revalidate: 0 }
   });

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -131,7 +131,9 @@ export async function getUserReviews(
   lang?: string,
   nextTimestamp?: string
 ): Promise<Review[]> {
-  const query = nextTimestamp ? `?next_timestamp=${nextTimestamp}` : '';
+  const query = nextTimestamp
+    ? `?next_timestamp=${encodeURIComponent(nextTimestamp)}`
+    : '';
   const { data } = await apiFetch<Review[]>(
     `/users/${userId}/reviews${query}`,
     {
@@ -146,7 +148,9 @@ export async function getMyReviews(
   lang?: string,
   nextTimestamp?: string
 ): Promise<Review[]> {
-  const query = nextTimestamp ? `?next_timestamp=${nextTimestamp}` : '';
+  const query = nextTimestamp
+    ? `?next_timestamp=${encodeURIComponent(nextTimestamp)}`
+    : '';
   const { data } = await apiFetch<Review[]>(`/me/reviews${query}`, {
     lang,
     next: { revalidate: 0 }


### PR DESCRIPTION
# Summary

Wraps the `next_timestamp` pagination cursor in `encodeURIComponent` in the three fetchers that interpolate it (`getTimelineReviews`, `getUserReviews`, `getMyReviews`).

# Motivation

The cursor is an ISO 8601 string that can carry a `+09:00`-style offset; an unencoded `+` decodes server-side as a space, so the timestamp parses to a wrong instant and "load more" returns wrong or duplicate pages. Found by an automated review of #1088.

# Testing

- `pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_