### PR TITLE
refactor: drop six build-time env variables

### DIFF
--- a/src/app/[lang]/(contained)/(home)/page.tsx
+++ b/src/app/[lang]/(contained)/(home)/page.tsx
@@ -5,7 +5,7 @@ import { getServerAuthState } from '../../../../lib/auth';
 import { getPopularReviews, getTimelineReviews } from '../../../../lib/reviews';
 import { getDictionary } from '../../../../utils/getDictionary';
 import { localePath } from '../../../../utils/locales';
-import { buildAlternates } from '../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -16,10 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const dict = getDictionary(lang);
   const title = 'Qoodish';
   const description = dict['meta description'];
-  const thumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const thumbnailUrl = defaultOgImage(lang);
 
   return {
     title,

--- a/src/app/[lang]/(contained)/assets/page.tsx
+++ b/src/app/[lang]/(contained)/assets/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import AssetGenerator from '../../../../components/assets/AssetGenerator';
 import { getDictionary } from '../../../../utils/getDictionary';
 import { localePath } from '../../../../utils/locales';
-import { buildAlternates } from '../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -12,10 +12,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { lang } = await params;
   const dict = getDictionary(lang);
   const description = dict['meta description'];
-  const thumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const thumbnailUrl = defaultOgImage(lang);
 
   return {
     title: 'Assets | Qoodish',

--- a/src/app/[lang]/(contained)/chapters/[chapterId]/page.tsx
+++ b/src/app/[lang]/(contained)/chapters/[chapterId]/page.tsx
@@ -7,7 +7,7 @@ import { getMap } from '../../../../../lib/maps';
 import { getUserJournal } from '../../../../../lib/users';
 import { getDictionary } from '../../../../../utils/getDictionary';
 import { localePath } from '../../../../../utils/locales';
-import { buildAlternates } from '../../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string; chapterId: string }>;
@@ -25,11 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const keywords = `${
     chapter?.title ? `${chapter.title}, ` : ''
   }Qoodish, qoodish, 食べ物, グルメ, 食事, マップ, 地図, 友だち, グループ, 旅行, 観光, 観光スポット, maps, travel, food, group, trip`;
-  const defaultThumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
-  const thumbnailUrl = chapter?.image?.ogp ?? defaultThumbnailUrl;
+  const thumbnailUrl = chapter?.image?.ogp ?? defaultOgImage(lang);
   const path = `/chapters/${chapterId}`;
 
   return {

--- a/src/app/[lang]/(contained)/discover/page.tsx
+++ b/src/app/[lang]/(contained)/discover/page.tsx
@@ -8,7 +8,7 @@ import { getActiveMaps, getMap, getRecentMaps } from '../../../../lib/maps';
 import { getRecentReviews } from '../../../../lib/reviews';
 import { getDictionary } from '../../../../utils/getDictionary';
 import { localePath } from '../../../../utils/locales';
-import { buildAlternates } from '../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -19,10 +19,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const dict = getDictionary(lang);
   const title = `${dict.discover} | Qoodish`;
   const description = dict['meta description'];
-  const thumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const thumbnailUrl = defaultOgImage(lang);
 
   return {
     title,

--- a/src/app/[lang]/(contained)/maps/[mapId]/reports/[reviewId]/page.tsx
+++ b/src/app/[lang]/(contained)/maps/[mapId]/reports/[reviewId]/page.tsx
@@ -6,7 +6,10 @@ import { getServerAuthState } from '../../../../../../../lib/auth';
 import { getReview } from '../../../../../../../lib/reviews';
 import { getDictionary } from '../../../../../../../utils/getDictionary';
 import { localePath } from '../../../../../../../utils/locales';
-import { buildAlternates } from '../../../../../../../utils/metadata';
+import {
+  buildAlternates,
+  defaultOgImage
+} from '../../../../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string; mapId: string; reviewId: string }>;
@@ -24,14 +27,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const keywords = `${
     review ? `${review.map.name}, ${review.name}, ` : ''
   }Qoodish, qoodish, 食べ物, グルメ, 食事, マップ, 地図, 友だち, グループ, 旅行, 観光, 観光スポット, maps, travel, food, group, trip`;
-  const defaultThumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
   const thumbnailUrl =
     review && review.images.length > 0
       ? review.images[0].ogp
-      : defaultThumbnailUrl;
+      : defaultOgImage(lang);
   const path = `/maps/${mapId}/reports/${reviewId}`;
 
   return {

--- a/src/app/[lang]/(contained)/notifications/page.tsx
+++ b/src/app/[lang]/(contained)/notifications/page.tsx
@@ -3,7 +3,7 @@ import NotificationsFeed from '../../../../components/notifications/Notification
 import { getNotifications } from '../../../../lib/users';
 import { getDictionary } from '../../../../utils/getDictionary';
 import { localePath } from '../../../../utils/locales';
-import { buildAlternates } from '../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -14,10 +14,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const dict = getDictionary(lang);
   const title = `${dict.notifications} | Qoodish`;
   const description = dict['meta description'];
-  const thumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const thumbnailUrl = defaultOgImage(lang);
 
   return {
     title,

--- a/src/app/[lang]/(contained)/privacy/page.tsx
+++ b/src/app/[lang]/(contained)/privacy/page.tsx
@@ -3,7 +3,7 @@ import MarkdownContent from '../../../../components/common/MarkdownContent';
 import { getDictionary } from '../../../../utils/getDictionary';
 import { getLegalDocument } from '../../../../utils/getLegalDocument';
 import { localePath } from '../../../../utils/locales';
-import { buildAlternates } from '../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -14,10 +14,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const dict = getDictionary(lang);
   const title = `${dict['privacy policy']} | Qoodish`;
   const description = dict['meta description'];
-  const thumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const thumbnailUrl = defaultOgImage(lang);
 
   return {
     title,

--- a/src/app/[lang]/(contained)/settings/page.tsx
+++ b/src/app/[lang]/(contained)/settings/page.tsx
@@ -6,7 +6,7 @@ import ProvidersCard from '../../../../components/settings/ProvidersCard';
 import PushNotificationsCard from '../../../../components/settings/PushNotificationsCard';
 import { getDictionary } from '../../../../utils/getDictionary';
 import { localePath } from '../../../../utils/locales';
-import { buildAlternates } from '../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -17,10 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const dict = getDictionary(lang);
   const title = `${dict.settings} | Qoodish`;
   const description = dict['meta description'];
-  const thumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const thumbnailUrl = defaultOgImage(lang);
 
   return {
     title,

--- a/src/app/[lang]/(contained)/terms/page.tsx
+++ b/src/app/[lang]/(contained)/terms/page.tsx
@@ -3,7 +3,7 @@ import MarkdownContent from '../../../../components/common/MarkdownContent';
 import { getDictionary } from '../../../../utils/getDictionary';
 import { getLegalDocument } from '../../../../utils/getLegalDocument';
 import { localePath } from '../../../../utils/locales';
-import { buildAlternates } from '../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -14,10 +14,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const dict = getDictionary(lang);
   const title = `${dict['terms of service']} | Qoodish`;
   const description = dict['meta description'];
-  const thumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const thumbnailUrl = defaultOgImage(lang);
 
   return {
     title,

--- a/src/app/[lang]/(contained)/users/[userId]/page.tsx
+++ b/src/app/[lang]/(contained)/users/[userId]/page.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../../../lib/users';
 import { getDictionary } from '../../../../../utils/getDictionary';
 import { localePath } from '../../../../../utils/locales';
-import { buildAlternates } from '../../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string; userId: string }>;
@@ -24,10 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { lang, userId } = await params;
   const dict = getDictionary(lang);
   const description = dict['meta description'];
-  const thumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const thumbnailUrl = defaultOgImage(lang);
   const path = `/users/${userId}`;
 
   return {

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -9,7 +9,7 @@ import ShellProvider from '../../components/layouts/ShellProvider';
 import { getServerAuthState } from '../../lib/auth';
 import { getMyProfile, getNotifications } from '../../lib/users';
 import { getDictionary } from '../../utils/getDictionary';
-import { SITE_ORIGIN } from '../../utils/metadata';
+import { SITE_ORIGIN, defaultOgImage } from '../../utils/metadata';
 import Providers from './Providers';
 
 const lobster = Lobster({
@@ -49,10 +49,7 @@ export const viewport: Viewport = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { lang } = await params;
   const dict = getDictionary(lang);
-  const defaultThumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const defaultThumbnailUrl = defaultOgImage(lang);
 
   return {
     metadataBase: new URL(SITE_ORIGIN),
@@ -106,9 +103,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       card: 'summary_large_image'
     },
     other: {
-      'fb:app_id': process.env.NEXT_PUBLIC_FB_APP_ID ?? '',
       'og:type': 'website',
-      'og:site_name': 'Qoodish',
       'twitter:domain': 'qoodish.com',
       'mobile-web-app-capable': 'yes'
     }

--- a/src/app/[lang]/login/page.tsx
+++ b/src/app/[lang]/login/page.tsx
@@ -13,7 +13,14 @@ import LoginCard from '../../../components/auth/LoginCard';
 import Footer from '../../../components/layouts/Footer';
 import { getDictionary } from '../../../utils/getDictionary';
 import { localePath } from '../../../utils/locales';
-import { buildAlternates } from '../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../utils/metadata';
+
+const HERO_IMAGE_URL =
+  'https://storage.googleapis.com/qoodish.appspot.com/assets/qoodish-lp-carousel-1-2019-05-06.jpg';
+const SHARE_FEATURE_IMAGE_URL =
+  'https://storage.googleapis.com/qoodish.appspot.com/assets/qoodish-lp-map-detail-2019-05-06.png';
+const DISCOVER_FEATURE_IMAGE_URL =
+  'https://storage.googleapis.com/qoodish.appspot.com/assets/qoodish-lp-discover-2019-05-06.png';
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -24,10 +31,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const dict = getDictionary(lang);
   const title = `${dict.login} | Qoodish`;
   const description = dict['meta description'];
-  const thumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
+  const thumbnailUrl = defaultOgImage(lang);
 
   return {
     title,
@@ -58,7 +62,7 @@ export default async function LoginPage({ params }: Props) {
       <Box sx={{ display: 'flex', position: 'relative' }}>
         <CardMedia
           component="img"
-          image={process.env.NEXT_PUBLIC_LP_CAROUSEL_1}
+          image={HERO_IMAGE_URL}
           width={4592}
           height={2576}
           alt="Qoodish"
@@ -152,7 +156,7 @@ export default async function LoginPage({ params }: Props) {
               <Card>
                 <CardMedia
                   component="img"
-                  image={process.env.NEXT_PUBLIC_LP_IMAGE_1}
+                  image={SHARE_FEATURE_IMAGE_URL}
                   width={2878}
                   height={1578}
                   alt="Qoodish"
@@ -190,7 +194,7 @@ export default async function LoginPage({ params }: Props) {
               <Card>
                 <CardMedia
                   component="img"
-                  image={process.env.NEXT_PUBLIC_LP_IMAGE_2}
+                  image={DISCOVER_FEATURE_IMAGE_URL}
                   width={2878}
                   height={1578}
                   alt="Qoodish"

--- a/src/app/[lang]/maps/[mapId]/(detail)/page.tsx
+++ b/src/app/[lang]/maps/[mapId]/(detail)/page.tsx
@@ -13,7 +13,7 @@ import {
 import { getMyProfile } from '../../../../../lib/users';
 import { getDictionary } from '../../../../../utils/getDictionary';
 import { localePath } from '../../../../../utils/locales';
-import { buildAlternates } from '../../../../../utils/metadata';
+import { buildAlternates, defaultOgImage } from '../../../../../utils/metadata';
 
 type Props = {
   params: Promise<{ lang: string; mapId: string }>;
@@ -29,11 +29,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const keywords = `${
     map ? `${map.name}, ` : ''
   }Qoodish, qoodish, 食べ物, グルメ, 食事, マップ, 地図, 友だち, グループ, 旅行, 観光, 観光スポット, maps, travel, food, group, trip`;
-  const defaultThumbnailUrl =
-    lang === 'en'
-      ? process.env.NEXT_PUBLIC_OGP_IMAGE_URL_EN
-      : process.env.NEXT_PUBLIC_OGP_IMAGE_URL_JA;
-  const thumbnailUrl = map?.image?.ogp ?? defaultThumbnailUrl;
+  const thumbnailUrl = map?.image?.ogp ?? defaultOgImage(lang);
   const path = `/maps/${mapId}`;
 
   return {

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -6,6 +6,15 @@ import { DEFAULT_LOCALE, localePath } from './locales';
 // and an undefined origin would emit a canonical pointing at https://undefined/.
 export const SITE_ORIGIN = 'https://qoodish.com';
 
+const DEFAULT_OG_IMAGES = {
+  en: 'https://storage.googleapis.com/qoodish.appspot.com/assets/ogp-image-en-2023-09-12.webp',
+  ja: 'https://storage.googleapis.com/qoodish.appspot.com/assets/ogp-image-ja-2023-09-12.webp'
+} as const;
+
+export function defaultOgImage(lang: string): string {
+  return lang === 'en' ? DEFAULT_OG_IMAGES.en : DEFAULT_OG_IMAGES.ja;
+}
+
 export function buildAlternates(
   lang: string,
   path = ''


### PR DESCRIPTION
# Summary

Replaces six `NEXT_PUBLIC_*` variables with values written directly in the source: the two OGP image URLs, the three landing-page image URLs, and `fb:app_id`. The Cloudflare build variables shrink from 18 to 12.

# Motivation

None of these six values varies by environment. The OGP and landing-page images resolve to the same objects in `storage.googleapis.com/qoodish.appspot.com/assets/` everywhere, so routing them through `NEXT_PUBLIC_*` only meant that changing a constant required a rebuild. The favicon and touch-icon URLs in the same metadata block were already written inline, so this brings the rest of the block in line with them.

`fb:app_id` has no consumer left. The tag feeds Facebook's share insights, and both Facebook authentication and the Facebook SDK have been removed from the app.

# Changes

- Add `defaultOgImage(lang)` to `src/utils/metadata.ts`, next to `SITE_ORIGIN`, and use it in the thirteen metadata builders that each carried their own copy of the `lang === 'en' ? EN : JA` ternary
- Name the three landing-page images by the section they illustrate rather than by index: `HERO_IMAGE_URL`, `SHARE_FEATURE_IMAGE_URL`, `DISCOVER_FEATURE_IMAGE_URL`. `NEXT_PUBLIC_LP_CAROUSEL_1` was neither a carousel nor one of several
- Drop the `fb:app_id` meta tag, and `og:site_name` with it — `openGraph.siteName` already emits that tag, so it was rendered twice

The images themselves are unchanged; they still load from the same URLs. Refreshing the landing-page artwork (the files are dated 2019-05-06) and moving `NEXT_PUBLIC_PICKED_UP_MAP_ID` behind an API endpoint are separate pieces of work.

# Testing

- `pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_