### PR TITLE
feat: read the pick-up map from the API

### DIFF
--- a/src/app/[lang]/(contained)/discover/page.tsx
+++ b/src/app/[lang]/(contained)/discover/page.tsx
@@ -4,7 +4,11 @@ import type { Metadata } from 'next';
 import PickUpMap from '../../../../components/discover/PickUpMap';
 import MapGridList from '../../../../components/maps/MapGridList';
 import ReviewGridList from '../../../../components/reviews/ReviewGridList';
-import { getActiveMaps, getMap, getRecentMaps } from '../../../../lib/maps';
+import {
+  getActiveMaps,
+  getFeaturedMap,
+  getRecentMaps
+} from '../../../../lib/maps';
 import { getRecentReviews } from '../../../../lib/reviews';
 import { getDictionary } from '../../../../utils/getDictionary';
 import { localePath } from '../../../../utils/locales';
@@ -47,12 +51,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function DiscoverPage({ params }: Props) {
   const { lang } = await params;
   const dict = getDictionary(lang);
-  const mapId = process.env.NEXT_PUBLIC_PICKED_UP_MAP_ID;
   const [recentReviews, activeMaps, recentMaps, pickUpMap] = await Promise.all([
     getRecentReviews(lang),
     getActiveMaps(lang),
     getRecentMaps(lang),
-    mapId ? getMap(mapId, lang) : Promise.resolve(null)
+    getFeaturedMap(lang)
   ]);
 
   return (

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -16,6 +16,18 @@ export async function getMap(
   return data;
 }
 
+export async function getFeaturedMap(lang: string): Promise<AppMap | null> {
+  // A 404 here means nothing is featured, which the discover page renders as an
+  // empty slot — only an unreachable API should surface as an error.
+  const { data, status } = await apiFetch<AppMap>('/maps/featured', {
+    lang,
+    guest: true,
+    next: { revalidate: 900 }
+  });
+  assertApiAvailable(status, '/maps/featured');
+  return data;
+}
+
 export async function getMapReviews(
   mapId: string,
   lang: string,


### PR DESCRIPTION
# Summary

Replaces `NEXT_PUBLIC_PICKED_UP_MAP_ID` with `GET /guest/maps/featured`, added in yusuke-suzuki/qoodish#588. This is the last of the six build variables identified in #1100, bringing the Cloudflare build variables down to 11.

# Motivation

Which map appears in the discover page's pick-up slot is editorial content, not configuration. `NEXT_PUBLIC_` values are baked into the bundle, so changing the pick meant a rebuild and a redeploy of the whole frontend — a cost out of proportion to swapping one map. Serving it from the API makes the change a single row insert with no build.

# Changes

- Add `getFeaturedMap(lang)` to `src/lib/maps.ts`, cached for 15 minutes to match the other guest feeds the discover page already loads
- The discover page calls it in the same `Promise.all` as the other feeds, so the pick-up map no longer needs a conditional fetch

A 404 from the endpoint means nothing is currently featured; `assertApiAvailable` lets it through as `null` and the slot renders empty, which is what an unset variable did. An unreachable API still raises, so an outage does not silently blank the section.

# Testing

- `pnpm biome ci ./src` and `pnpm exec tsc --noEmit` pass

# Release procedure

This pull request depends on the backend. Merging it before the endpoint exists would leave the pick-up slot empty.

1. Release yusuke-suzuki/qoodish#588 and run its migration through the `qoodish-runner` Job
2. Record the current pick: `FeaturedMap.create!(map_id: 198)`
3. Merge and release this pull request
4. Remove `NEXT_PUBLIC_PICKED_UP_MAP_ID` from the Cloudflare build variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_