### PR TITLE
ci: route qoodish.com to the production Worker

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,9 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2026-07-01",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "routes": [{ "pattern": "qoodish.com", "custom_domain": true }],
+  "workers_dev": false,
+  "preview_urls": false,
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"
@@ -45,6 +48,11 @@
   "env": {
     "dev": {
       "name": "dev-qoodish-web",
+      // Routes and URL toggles are inherited from the top level, so dev has to
+      // restate them or it would claim qoodish.com and lose the workers.dev URL
+      // it is reached through.
+      "routes": [],
+      "workers_dev": true,
       "preview_urls": true,
       "services": [
         {


### PR DESCRIPTION
# Summary

Declares `qoodish.com` as a custom domain of the production Worker in `wrangler.jsonc`, and turns off the `workers.dev` and preview URLs for production. The dev environment restates the same keys so that it keeps the URL it is reached through.

# Motivation

The domain was attached from the Cloudflare dashboard during the cutover from Vercel. An assignment that lives only in the dashboard drifts from the config, and the config is what every deploy applies. The same gap already broke the dev Worker once: runtime variables that wrangler had applied were removed by hand, and nothing restored them until the cause was traced.

The `workers.dev` and preview URLs are no longer needed for production now that the custom domain serves traffic. Either one exposes an unauthenticated copy of the site that reads the production API and writes into the production incremental cache.

# Changes

- Declare `qoodish.com` as a custom domain route at the top level
- Set `workers_dev` and `preview_urls` to `false` for production
- Restate `routes`, `workers_dev`, and `preview_urls` under `env.dev`, since named environments inherit these keys from the top level

# Testing

`pnpm biome ci ./src` and `pnpm exec tsc --noEmit` both pass. Neither covers `wrangler.jsonc`, so the file was additionally parsed as JSON with comments stripped to confirm the resulting values for both environments.

`qoodish.com` already serves the production Worker; the domain was attached ahead of this change and verified in the browser. This PR records that state in the config, so the deploy it triggers is expected to leave the domain assignment unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013zwd4mmNgF8j9tHpKRRFR4)_