### PR TITLE
ci: upload a version for non-production branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "deploy:dev": "opennextjs-cloudflare build --env dev && opennextjs-cloudflare deploy --env dev",
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
+    "upload:dev": "opennextjs-cloudflare build --env dev && opennextjs-cloudflare upload --env dev",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {


### PR DESCRIPTION
# Summary

Adds an `upload:dev` script that uploads a version of the dev Worker instead of deploying it. Which command Workers Builds runs is configured in the Cloudflare dashboard, so this pull request alone does not change any behaviour — it only makes the right command available to point at.

# Motivation

`preview_urls` is enabled for `env.dev` in `wrangler.jsonc`, so every version uploaded to `dev-qoodish-web` is reachable at a URL of its own. That is not what pull request builds produce today: the Workers Builds comment on a pull request has no Preview URL column, and the Visit link on the build leads to the shared `dev-qoodish-web` URL rather than to anything specific to the branch. The build is running a deploy, so each pull request also takes over the Worker the previous one deployed.

`wrangler versions upload` is what creates a version with its own preview URL, and `opennextjs-cloudflare upload` wraps it. The existing `upload` script omits `--env`, so it targets `prod-qoodish-web`, where `preview_urls` is `false` — there was no command for the dev Worker to point at.

# Changes

- Add `upload:dev`, mirroring `deploy:dev` but calling `opennextjs-cloudflare upload --env dev`

# Testing

`pnpm exec opennextjs-cloudflare upload --help` confirms the command accepts `-e, --env`, and reading `dist/cli/commands/upload.js` in the installed package confirms it forwards that flag to `wrangler versions upload`. Neither `pnpm biome ci ./src` nor `pnpm exec tsc --noEmit` covers `package.json`.

The script itself was not run: it needs Cloudflare credentials, and it uploads to the dev Worker.

# Release procedure

Merging this changes nothing on its own. In the `dev-qoodish-web` Workers Build settings, the deploy command for non-production branches has to be set to `pnpm upload:dev`; the preview URL then appears on subsequent pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfvKLTZ812JfhSmpgZGKVD