### PR TITLE
fix: let the service worker finish installing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,11 @@ const withSerwist = withSerwistInit({
   swSrc: 'src/worker/index.ts',
   swDest: 'public/sw.js',
   reloadOnOnline: true,
-  disable: process.env.NODE_ENV === 'development'
+  disable: process.env.NODE_ENV === 'development',
+  // _headers configures the Cloudflare asset host and is not served as an
+  // asset, so precaching it leaves the install waiting on a redirect that
+  // never resolves into a response the worker can store.
+  globPublicPatterns: ['**/!(_headers)']
 });
 
 const nextConfig: NextConfig = {

--- a/src/app/[lang]/Providers.tsx
+++ b/src/app/[lang]/Providers.tsx
@@ -151,9 +151,13 @@ export default function Providers({
         reg?.scope
       );
 
-      if (reg) {
-        setRegistration(reg);
+      if (!reg) {
+        return;
       }
+
+      // register() resolves while the worker is still installing, and the push
+      // API rejects a subscription until one is active; ready holds until then.
+      setRegistration(await navigator.serviceWorker.ready);
     } catch (error) {
       console.log('ServiceWorker registration failed: ', error);
     }

--- a/src/components/settings/PushNotificationsCard.tsx
+++ b/src/components/settings/PushNotificationsCard.tsx
@@ -46,20 +46,26 @@ function PushNotificationsCard() {
 
   const handleSubscriptionChange = useCallback(
     async (_event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
-      if (checked) {
-        const permission = await Notification.requestPermission();
+      try {
+        if (checked) {
+          const permission = await Notification.requestPermission();
 
-        if (permission === 'granted') {
-          await subscribe();
+          if (permission === 'granted') {
+            await subscribe();
 
-          enqueueSnackbar(dictionary['push enabled'], { variant: 'success' });
+            enqueueSnackbar(dictionary['push enabled'], { variant: 'success' });
+          } else {
+            enqueueSnackbar(dictionary['push denied'], { variant: 'error' });
+          }
         } else {
-          enqueueSnackbar(dictionary['push denied'], { variant: 'error' });
-        }
-      } else {
-        await unsubscribe();
+          await unsubscribe();
 
-        enqueueSnackbar(dictionary['push disabled'], { variant: 'success' });
+          enqueueSnackbar(dictionary['push disabled'], { variant: 'success' });
+        }
+      } catch (error) {
+        console.error('Failed to change push subscription', error);
+
+        enqueueSnackbar(dictionary['an error occurred'], { variant: 'error' });
       }
     },
     [subscribe, unsubscribe, dictionary]

--- a/src/components/settings/PushNotificationsCard.tsx
+++ b/src/components/settings/PushNotificationsCard.tsx
@@ -57,10 +57,12 @@ function PushNotificationsCard() {
           } else {
             enqueueSnackbar(dictionary['push denied'], { variant: 'error' });
           }
-        } else {
-          await unsubscribe();
-
+        } else if (await unsubscribe()) {
           enqueueSnackbar(dictionary['push disabled'], { variant: 'success' });
+        } else {
+          enqueueSnackbar(dictionary['an error occurred'], {
+            variant: 'error'
+          });
         }
       } catch (error) {
         console.error('Failed to change push subscription', error);

--- a/src/hooks/usePushManager.ts
+++ b/src/hooks/usePushManager.ts
@@ -133,7 +133,11 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
       const sub = await registration.pushManager.getSubscription();
 
       if (!cancelled) {
-        setSubscription(sub);
+        // The lookup only seeds the initial state, so it must not undo a
+        // subscription the user created while it was still in flight;
+        // neither the registration nor the session changes then, which
+        // leaves the cleanup above unable to catch it.
+        setSubscription((current) => current ?? sub);
       }
     };
 

--- a/src/hooks/usePushManager.ts
+++ b/src/hooks/usePushManager.ts
@@ -10,20 +10,6 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
 
   const [registrationToken, setRegistrationToken] = useState(null);
 
-  const initPushStatus = useCallback(async () => {
-    const sub = await registration.pushManager.getSubscription();
-
-    setSubscription(sub);
-  }, [registration]);
-
-  const persistRegistrationToken = useCallback(async () => {
-    try {
-      await registerDevice(registrationToken);
-    } catch (error) {
-      console.error('Failed to send registration token', error);
-    }
-  }, [registrationToken]);
-
   const subscribe = useCallback(async () => {
     const sub = await registration.pushManager.subscribe({
       userVisibleOnly: true,
@@ -45,44 +31,117 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
     }
   }, [subscription, isLoading]);
 
-  const getRegistrationToken = useCallback(async () => {
-    const messaging = getMessaging();
-    const token = await getToken(messaging, {
-      serviceWorkerRegistration: registration,
-      vapidKey: process.env.NEXT_PUBLIC_VAPID_KEY
-    });
-
-    if (!token) {
-      console.log('Unable to get registration token.');
+  useEffect(() => {
+    if (authenticated || isLoading || !subscription) {
       return;
     }
 
-    setRegistrationToken(token);
-  }, [registration]);
+    let cancelled = false;
+    const subscriptionToRemove = subscription;
+
+    // The browser-side unsubscribe cannot be cancelled, so once it succeeds
+    // the state must drop the removed subscription even after cleanup ran;
+    // the identity check keeps a newer subscription intact.
+    subscriptionToRemove
+      .unsubscribe()
+      .then((successful) => {
+        if (successful) {
+          setSubscription((current) =>
+            current === subscriptionToRemove ? null : current
+          );
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error('Failed to unsubscribe push subscription', error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated, isLoading, subscription]);
 
   useEffect(() => {
-    if (!authenticated && !isLoading) {
-      unsubscribe();
+    if (!registrationToken) {
+      return;
     }
-  }, [authenticated, isLoading, unsubscribe]);
+
+    const persistRegistrationToken = async () => {
+      const { success, error } = await registerDevice(registrationToken);
+
+      if (!success) {
+        console.error('Failed to send registration token', error);
+      }
+    };
+
+    persistRegistrationToken().catch((error) => {
+      console.error('Failed to send registration token', error);
+    });
+  }, [registrationToken]);
 
   useEffect(() => {
-    if (registrationToken) {
-      persistRegistrationToken();
+    if (!subscription) {
+      return;
     }
-  }, [registrationToken, persistRegistrationToken]);
+
+    let cancelled = false;
+
+    const getRegistrationToken = async () => {
+      const messaging = getMessaging();
+      const token = await getToken(messaging, {
+        serviceWorkerRegistration: registration,
+        vapidKey: process.env.NEXT_PUBLIC_VAPID_KEY
+      });
+
+      if (cancelled) {
+        return;
+      }
+
+      if (!token) {
+        console.log('Unable to get registration token.');
+        return;
+      }
+
+      setRegistrationToken(token);
+    };
+
+    getRegistrationToken().catch((error) => {
+      if (!cancelled) {
+        console.error('Failed to get registration token', error);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [subscription, registration]);
 
   useEffect(() => {
-    if (subscription) {
-      getRegistrationToken();
+    if (!registration || !authenticated) {
+      return;
     }
-  }, [subscription, getRegistrationToken]);
 
-  useEffect(() => {
-    if (registration && authenticated) {
-      initPushStatus();
-    }
-  }, [registration, authenticated, initPushStatus]);
+    let cancelled = false;
+
+    const initPushStatus = async () => {
+      const sub = await registration.pushManager.getSubscription();
+
+      if (!cancelled) {
+        setSubscription(sub);
+      }
+    };
+
+    initPushStatus().catch((error) => {
+      if (!cancelled) {
+        console.error('Failed to get push subscription', error);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [registration, authenticated]);
 
   return {
     subscribe: subscribe,

--- a/src/hooks/usePushManager.ts
+++ b/src/hooks/usePushManager.ts
@@ -21,7 +21,7 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
 
   const unsubscribe = useCallback(async () => {
     if (!subscription || isLoading) {
-      return;
+      return false;
     }
 
     const successful = await subscription.unsubscribe();
@@ -29,6 +29,8 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
     if (successful) {
       setSubscription(null);
     }
+
+    return successful;
   }, [subscription, isLoading]);
 
   useEffect(() => {

--- a/src/hooks/usePushManager.ts
+++ b/src/hooks/usePushManager.ts
@@ -63,7 +63,10 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
   }, [authenticated, isLoading, subscription]);
 
   useEffect(() => {
-    if (!registrationToken) {
+    // Signing out does not change the token, so without this guard a token
+    // resolved just before sign-out would still be registered against the
+    // session that just ended.
+    if (!registrationToken || !authenticated) {
       return;
     }
 
@@ -78,10 +81,10 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
     persistRegistrationToken().catch((error) => {
       console.error('Failed to send registration token', error);
     });
-  }, [registrationToken]);
+  }, [registrationToken, authenticated]);
 
   useEffect(() => {
-    if (!subscription) {
+    if (!subscription || !authenticated) {
       return;
     }
 
@@ -115,7 +118,7 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
     return () => {
       cancelled = true;
     };
-  }, [subscription, registration]);
+  }, [subscription, registration, authenticated]);
 
   useEffect(() => {
     if (!registration || !authenticated) {

--- a/src/hooks/usePushManager.ts
+++ b/src/hooks/usePushManager.ts
@@ -26,11 +26,16 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
 
     const successful = await subscription.unsubscribe();
 
-    if (successful) {
-      setSubscription(null);
+    if (!successful) {
+      console.warn('Push subscription was already inactive');
     }
 
-    return successful;
+    // Either outcome leaves no active subscription behind, and the token
+    // belongs to the subscription that is now gone.
+    setSubscription(null);
+    setRegistrationToken(null);
+
+    return true;
   }, [subscription, isLoading]);
 
   useEffect(() => {
@@ -41,17 +46,20 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
     let cancelled = false;
     const subscriptionToRemove = subscription;
 
-    // The browser-side unsubscribe cannot be cancelled, so once it succeeds
+    // The browser-side unsubscribe cannot be cancelled, so once it settles
     // the state must drop the removed subscription even after cleanup ran;
     // the identity check keeps a newer subscription intact.
     subscriptionToRemove
       .unsubscribe()
       .then((successful) => {
-        if (successful) {
-          setSubscription((current) =>
-            current === subscriptionToRemove ? null : current
-          );
+        if (!successful) {
+          console.warn('Push subscription was already inactive');
         }
+
+        setSubscription((current) =>
+          current === subscriptionToRemove ? null : current
+        );
+        setRegistrationToken(null);
       })
       .catch((error) => {
         if (!cancelled) {
@@ -105,6 +113,7 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
 
       if (!token) {
         console.log('Unable to get registration token.');
+        setRegistrationToken(null);
         return;
       }
 


### PR DESCRIPTION
# Summary

Fixes the device switch on the settings screen, which failed with `AbortError: Subscription failed - no active Service Worker`, along with the async correctness problems in `usePushManager` extracted from the closed #1109 so they are not lost with the React Compiler rollback.
All of them predate #1109 and are unrelated to memoization; the manual memoization that #1109 removed is kept intact here.

# Motivation

The service worker precaches everything under `public`, and `_headers` belongs to the Cloudflare asset host rather than the app, so the request for it met the locale redirect instead of a response the worker could store. Its install waited on that one entry forever — 480 of the 481 manifest entries reached the cache and the worker never left `installing` — which left the registration without an active worker and every push subscription rejected.

Registering also resolves while the worker is still installing, and the push API rejects a subscription until one is active. Publishing that registration straight to the context enabled the switch before it could do anything.

Nothing said so. `handleSubscriptionChange` had no rejection handling, so the browser push API rejecting on its own terms left the switch looking as if it had done nothing, with no trace anywhere. And it announced that push had been disabled even when the hook had declined to act at all because the session was still loading.

Underneath, the hook&#39;s effects start async work and write state when it resolves, with nothing tying the completion back to the run that started it. A superseded run could register an obsolete device token or restore an outdated subscription, and a rejection surfaced as an unhandled promise rejection. Separately, a failed device registration was reported as a success.

Reading the current subscription on mount had the same shape but a worse outcome: it overwrote whatever the state held by the time it resolved, so a subscription the user created while that read was in flight was dropped, leaving the switch off and no device token registered. The effect watches the registration and the session, neither of which moves when the user subscribes, so its cleanup could not catch that either.

The registration token also outlived every path that removed the subscription it belonged to. Once the persistence effect watches the session, signing out and back in re-runs it with that stale token and registers a device whose subscription no longer exists.

# Changes

- Glob the public directory around `_headers`, so the install has no unstorable entry to wait on
- Wait for the registration to be ready before publishing it, so the switch is enabled only once a subscription can actually be made
- Report a subscription change the hook declined to make through the snackbar, and log a failed one to the console
- Cancel each run on cleanup in the effects that read the registration token and the current push subscription, so only the latest run writes state
- Let the subscription lookup seed the state only when it is still empty, so it cannot undo a subscription made while it was in flight
- Attach a rejection handler to those fire-and-forget calls; they now log instead of leaving the rejection unhandled
- Check the `registerDevice` result: it resolves with `{ success: false, error }` on an API failure rather than rejecting, so the previous `try`/`catch` treated failed registrations as successful
- Move the sign-out unsubscribe into its effect, where it needs a cancellation-aware, identity-checked state update — the exported `unsubscribe` stays a plain user-initiated action, and both it and `subscribe` keep their `useCallback` since `PushNotificationsCard` depends on their identity
- Gate the token effects on `authenticated`, so signing out stops them instead of registering a token against the session that just ended
- Clear the registration token wherever the subscription goes, and treat an unsubscribe reporting the subscription was already inactive as the removal it is

# Testing

- `pnpm biome ci ./src` passes
- `pnpm exec tsc --noEmit` passes
- `pnpm build` succeeds

The stalled install was reproduced against a production build in a browser: the worker sat in `installing` past a 60-second watch with `/_headers` the only manifest entry missing from the cache, and `/_headers` answered 308. After the change the same run reports `installing → installed → activating → activated` with all 480 entries cached.

The remaining paths need a signed-in session with push permission granted and were not driven end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i1gaN8w1tmSTK358C9Qhe

---
_Generated by [Claude Code](https://claude.ai/code/session_018i1gaN8w1tmSTK358C9Qhe)_