### PR TITLE
refactor: type change event handler parameters

### DIFF
--- a/src/components/common/AddPhotoButton.tsx
+++ b/src/components/common/AddPhotoButton.tsx
@@ -1,6 +1,13 @@
 import { AddAPhoto } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
-import { memo, useCallback, useEffect, useId, useState } from 'react';
+import {
+  type ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useState
+} from 'react';
 import fileToDataUrl from '../../utils/fileToDataUrl';
 
 type Props = {
@@ -19,17 +26,20 @@ export default memo(function AddPhotoButton({
   const inputId = useId();
   const [dataUrls, setDataUrls] = useState<string[] | undefined>(undefined);
 
-  const handleImageFilesChange = useCallback(async (e) => {
-    const files: File[] = Array.from(e.target.files);
-    const items = [];
+  const handleImageFilesChange = useCallback(
+    async (e: ChangeEvent<HTMLInputElement>) => {
+      const files: File[] = Array.from(e.target.files);
+      const items = [];
 
-    for (const file of files) {
-      const dataUrl = await fileToDataUrl(file);
-      items.push(dataUrl);
-    }
+      for (const file of files) {
+        const dataUrl = await fileToDataUrl(file);
+        items.push(dataUrl);
+      }
 
-    setDataUrls(items);
-  }, []);
+      setDataUrls(items);
+    },
+    []
+  );
 
   useEffect(() => {
     if (dataUrls) {

--- a/src/components/maps/MapDescriptionForm.tsx
+++ b/src/components/maps/MapDescriptionForm.tsx
@@ -1,5 +1,11 @@
 import { TextField } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import {
+  type ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useState
+} from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 200;
@@ -19,7 +25,7 @@ export default memo(function MapDescriptionForm({
   const [error, setError] = useState<string | undefined>(undefined);
 
   const handleDescriptionChange = useCallback(
-    (e) => {
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const input = e.target.value;
 
       if (input) {

--- a/src/components/maps/MapNameForm.tsx
+++ b/src/components/maps/MapNameForm.tsx
@@ -1,5 +1,11 @@
 import { TextField } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import {
+  type ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useState
+} from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 30;
@@ -16,7 +22,7 @@ export default memo(function MapNameForm({ onChange, defaultValue }: Props) {
   const [error, setError] = useState<string | undefined>(undefined);
 
   const handleNameChange = useCallback(
-    (e) => {
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const input = e.target.value;
 
       if (input) {

--- a/src/components/profiles/BiographyForm.tsx
+++ b/src/components/profiles/BiographyForm.tsx
@@ -1,5 +1,11 @@
 import { TextField } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import {
+  type ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useState
+} from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 160;
@@ -16,7 +22,7 @@ function BiographyForm({ onChange, defaultValue }: Props) {
   const [error, setError] = useState<string | undefined>(undefined);
 
   const handleChange = useCallback(
-    (e) => {
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const input = e.target.value;
 
       if (input) {

--- a/src/components/profiles/ProfileNameForm.tsx
+++ b/src/components/profiles/ProfileNameForm.tsx
@@ -1,5 +1,11 @@
 import { TextField } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import {
+  type ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useState
+} from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 30;
@@ -16,7 +22,7 @@ function ProfileNameForm({ onChange, defaultValue }: Props) {
   const [error, setError] = useState<string | undefined>(undefined);
 
   const handleChange = useCallback(
-    (e) => {
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const input = e.target.value;
 
       if (input) {

--- a/src/components/reviews/ReviewDescriptionForm.tsx
+++ b/src/components/reviews/ReviewDescriptionForm.tsx
@@ -1,5 +1,11 @@
 import { TextField } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import {
+  type ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useState
+} from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 500;
@@ -16,7 +22,7 @@ function ReviewDescriptionForm({ onChange, defaultValue }: Props) {
   const [error, setError] = useState<string | undefined>(undefined);
 
   const handleCommentChange = useCallback(
-    (e) => {
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const input = e.target.value;
 
       if (input) {

--- a/src/components/reviews/ReviewNameForm.tsx
+++ b/src/components/reviews/ReviewNameForm.tsx
@@ -1,5 +1,11 @@
 import { TextField } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import {
+  type ChangeEvent,
+  memo,
+  useCallback,
+  useEffect,
+  useState
+} from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 30;
@@ -16,7 +22,7 @@ function ReviewNameForm({ onChange, defaultValue }: Props) {
   const [error, setError] = useState<string | undefined>(undefined);
 
   const handleChange = useCallback(
-    (e) => {
+    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const input = e.target.value;
 
       if (input) {


### PR DESCRIPTION
# Summary

Gives the form change handlers an explicit `ChangeEvent` parameter type instead of an implicit `any`, extracted from the closed #1109 so it is not lost with the React Compiler rollback.
Mechanical and behavior-neutral: only the parameter annotations and the `ChangeEvent` type imports change, and the existing `useCallback` wrappers are kept.

# Motivation

These handlers are passed straight to MUI inputs, but their `e` parameter was untyped, so nothing checked them against the contract they are wired into. `tsconfig.json` sets `strict` to false, which keeps the compiler quiet about the implicit `any`, while the repository guidelines still ask for strongly typed TypeScript.

# Changes

- Type the handler parameter as `ChangeEvent<HTMLInputElement | HTMLTextAreaElement>` in `BiographyForm`, `ProfileNameForm`, `ReviewNameForm`, `ReviewDescriptionForm`, `MapDescriptionForm` and `MapNameForm`, which back MUI text fields that may be multiline
- Type it as `ChangeEvent<HTMLInputElement>` in `AddPhotoButton`, whose handler reads `e.target.files` from a file input
- Import `ChangeEvent` as a type in each file

# Testing

- `pnpm biome ci ./src` passes
- `pnpm exec tsc --noEmit` passes
- `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i1gaN8w1tmSTK358C9Qhe

---
_Generated by [Claude Code](https://claude.ai/code/session_018i1gaN8w1tmSTK358C9Qhe)_