### PR TITLE
build: enable the React Compiler again

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,7 +17,8 @@ const withSerwist = withSerwistInit({
 
 const nextConfig: NextConfig = {
   experimental: {
-    globalNotFound: true
+    globalNotFound: true,
+    reactCompiler: true
   },
   webpack: (config) => {
     config.module.rules.push({

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/node": "^22.20.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint-config-next": "^15.5.18",
     "serwist": "^9.2.1",
     "typescript": "^5.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 7.3.4(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@mui/material-nextjs':
         specifier: ^7.3.3
-        version: 7.3.3(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/server@11.11.0)(@types/react@19.2.18)(next@15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 7.3.3(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/server@11.11.0)(@types/react@19.2.18)(next@15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@serwist/window':
         specifier: ^9.2.1
         version: 9.2.1(typescript@5.9.2)
@@ -88,7 +88,7 @@ importers:
         version: 4.1.1
       next:
         specifier: ^15.5.18
-        version: 15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       notistack:
         specifier: ^3.0.1
         version: 3.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -110,10 +110,10 @@ importers:
         version: 1.9.4
       '@opennextjs/cloudflare':
         specifier: ^1.20.2
-        version: 1.20.2(next@15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(wrangler@4.118.0)
+        version: 1.20.2(next@15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(wrangler@4.118.0)
       '@serwist/next':
         specifier: ^9.2.1
-        version: 9.2.1(next@15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.2)
+        version: 9.2.1(next@15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.2)
       '@types/google.maps':
         specifier: ^3.54.6
         version: 3.58.1
@@ -132,6 +132,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       eslint-config-next:
         specifier: ^15.5.18
         version: 15.5.18(eslint@8.57.1)(typescript@5.9.2)
@@ -2598,6 +2601,9 @@ packages:
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -6627,11 +6633,11 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
       '@types/react': 19.2.18
 
-  '@mui/material-nextjs@7.3.3(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/server@11.11.0)(@types/react@19.2.18)(next@15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@mui/material-nextjs@7.3.3(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/server@11.11.0)(@types/react@19.2.18)(next@15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.8)
-      next: 15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
     optionalDependencies:
       '@emotion/cache': 11.14.0
@@ -6789,7 +6795,7 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@opennextjs/aws@4.1.0(next@15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@opennextjs/aws@4.1.0(next@15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0
@@ -6805,24 +6811,24 @@ snapshots:
       cookie: 1.1.1
       esbuild: 0.25.4
       express: 5.2.1
-      next: 15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       path-to-regexp: 6.3.0
       urlpattern-polyfill: 10.1.0
       yaml: 2.9.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opennextjs/cloudflare@1.20.2(next@15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(wrangler@4.118.0)':
+  '@opennextjs/cloudflare@1.20.2(next@15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(wrangler@4.118.0)':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 4.1.0(next@15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@opennextjs/aws': 4.1.0(next@15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       ci-info: 4.4.0
       cloudflare: 4.5.0
       comment-json: 4.6.2
       enquirer: 2.4.1
       glob: 12.0.0
-      next: 15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       ts-tqdm: 0.8.6
       wrangler: 4.118.0
       yargs: 18.1.0
@@ -6886,14 +6892,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  '@serwist/next@9.2.1(next@15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.2)':
+  '@serwist/next@9.2.1(next@15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.2)':
     dependencies:
       '@serwist/build': 9.2.1(typescript@5.9.2)
       '@serwist/webpack-plugin': 9.2.1(typescript@5.9.2)
       '@serwist/window': 9.2.1(typescript@5.9.2)
       chalk: 5.6.0
       glob: 10.4.5
-      next: 15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       serwist: 9.2.1(typescript@5.9.2)
       zod: 4.1.5
     optionalDependencies:
@@ -7485,6 +7491,10 @@ snapshots:
       '@babel/runtime': 7.28.4
       cosmiconfig: 7.1.0
       resolve: 1.22.10
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.28.2
 
   bail@2.0.2: {}
 
@@ -9141,7 +9151,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@15.5.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@15.5.18(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
@@ -9159,6 +9169,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.18
       '@next/swc-win32-arm64-msvc': 15.5.18
       '@next/swc-win32-x64-msvc': 15.5.18
+      babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.4
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
# Summary

Turns `experimental.reactCompiler` back on with `babel-plugin-react-compiler`, reversing the rollback in #1110.

The first attempt reached production and broke the client, and it was reverted before anyone could read what had failed. Nothing about that rollback said the compiler is wrong for this codebase, only that it shipped without anyone watching a console. This time the build is examined before it reaches anyone.

React itself is already on 19.2.8 from #1108, so this only adds the plugin and the flag.

# Changes

- Add `babel-plugin-react-compiler` and set `experimental.reactCompiler`

# Testing

- `pnpm biome ci ./src` passes
- `pnpm exec tsc --noEmit` passes
- `pnpm build` succeeds, and the output carries compiler memoization: 422 memo-cache slots across 24 client chunks
- A browser crawled 22 routes against a local production build — every unauthenticated page plus map, report and user detail pages — watching for uncaught exceptions, non-network console errors and the error boundary. No findings.

What the crawl does not cover, and what the deployed build has to answer:

- Signed-in pages. The crawl has no session, so nothing behind authentication rendered.
- Anything driven by the Google Maps JavaScript API, which the crawl host cannot reach, so the map components never mounted.
- Interaction. Pages were loaded and left alone; no dialogs, forms or navigation were driven.

The first attempt failed on exactly this kind of gap, so the preview deployment is to be exercised with the console open before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i1gaN8w1tmSTK358C9Qhe

---
_Generated by [Claude Code](https://claude.ai/code/session_018i1gaN8w1tmSTK358C9Qhe)_