### PR TITLE
refactor: drop memoization the compiler owns

### DIFF
--- a/src/components/assets/AssetGenerator.tsx
+++ b/src/components/assets/AssetGenerator.tsx
@@ -3,7 +3,7 @@
 import { Map as MapIcon } from '@mui/icons-material';
 import { Box, Button, Stack, Typography } from '@mui/material';
 import html2canvas from 'html2canvas';
-import { type RefObject, useCallback, useRef } from 'react';
+import { type RefObject, useRef } from 'react';
 
 type Props = {
   lang: string;
@@ -14,22 +14,22 @@ export default function AssetGenerator({ lang, tagline }: Props) {
   const iconRef = useRef<HTMLDivElement>(null);
   const logoRef = useRef<HTMLDivElement>(null);
 
-  const handleConvertToImage = useCallback(
-    async (ref: RefObject<HTMLDivElement>, fileName: string) => {
-      if (!ref.current) {
-        return;
-      }
+  const handleConvertToImage = async (
+    ref: RefObject<HTMLDivElement>,
+    fileName: string
+  ) => {
+    if (!ref.current) {
+      return;
+    }
 
-      const canvas = await html2canvas(ref.current);
-      const link = document.createElement('a');
+    const canvas = await html2canvas(ref.current);
+    const link = document.createElement('a');
 
-      link.download = fileName;
-      link.href = canvas.toDataURL('image/webp');
+    link.download = fileName;
+    link.href = canvas.toDataURL('image/webp');
 
-      link.click();
-    },
-    []
-  );
+    link.click();
+  };
 
   return (
     <Box>

--- a/src/components/auth/LoginCard.tsx
+++ b/src/components/auth/LoginCard.tsx
@@ -10,7 +10,7 @@ import {
   useTheme
 } from '@mui/material';
 import { useRouter } from 'next/navigation';
-import { memo, useCallback } from 'react';
+import { memo } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 import useLocalePath from '../../hooks/useLocalePath';
 import SignInButtons from './SignInButtons';
@@ -22,9 +22,9 @@ export default memo(function LoginCard() {
   const theme = useTheme();
   const mdUp = useMediaQuery(theme.breakpoints.up('md'));
 
-  const handleSignInSuccess = useCallback(() => {
+  const handleSignInSuccess = () => {
     push(localePath('/discover'));
-  }, [push, localePath]);
+  };
 
   return (
     <Card>

--- a/src/components/auth/SignInRequiredDialog.tsx
+++ b/src/components/auth/SignInRequiredDialog.tsx
@@ -1,5 +1,5 @@
 import { Container, Typography } from '@mui/material';
-import { memo, useCallback, useContext } from 'react';
+import { memo, useContext } from 'react';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
 import BottomSheet from '../common/BottomSheet';
@@ -10,15 +10,9 @@ function SignInRequiredDialog() {
   const dictionary = useDictionary();
   const { signInRequired, setSignInRequired } = useContext(AuthContext);
 
-  const handleOpen = useCallback(
-    () => setSignInRequired(true),
-    [setSignInRequired]
-  );
+  const handleOpen = () => setSignInRequired(true);
 
-  const handleClose = useCallback(
-    () => setSignInRequired(false),
-    [setSignInRequired]
-  );
+  const handleClose = () => setSignInRequired(false);
 
   return (
     <BottomSheet

--- a/src/components/auth/SignInWithGoogleButton.tsx
+++ b/src/components/auth/SignInWithGoogleButton.tsx
@@ -1,6 +1,6 @@
 import { SvgIcon } from '@mui/material';
 import { GoogleAuthProvider } from 'firebase/auth';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import SignInWithProviderButton from './SignInWithProviderButton';
 
 type Props = {
@@ -8,9 +8,7 @@ type Props = {
 };
 
 function SignInWithGoogleButton({ onSignInSuccess }: Props) {
-  const provider = useMemo(() => {
-    return new GoogleAuthProvider();
-  }, []);
+  const provider = new GoogleAuthProvider();
 
   return (
     <SignInWithProviderButton

--- a/src/components/bookmarks/BookmarksView.tsx
+++ b/src/components/bookmarks/BookmarksView.tsx
@@ -2,7 +2,7 @@
 
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Card, Tab } from '@mui/material';
-import { type SyntheticEvent, memo, useCallback, useState } from 'react';
+import { type SyntheticEvent, memo, useState } from 'react';
 import type { AppMap, Journal } from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
 import UserBookmarks from '../profiles/UserBookmarks';
@@ -17,12 +17,12 @@ function BookmarksView({ maps, journals }: Props) {
   const dictionary = useDictionary();
   const [tabValue, setTabValue] = useState('1');
 
-  const handleTabChange = useCallback(
-    (_event: SyntheticEvent<Element, Event>, newValue: string) => {
-      setTabValue(newValue);
-    },
-    []
-  );
+  const handleTabChange = (
+    _event: SyntheticEvent<Element, Event>,
+    newValue: string
+  ) => {
+    setTabValue(newValue);
+  };
 
   return (
     <TabContext value={tabValue}>

--- a/src/components/chapters/ChapterContentEditor.tsx
+++ b/src/components/chapters/ChapterContentEditor.tsx
@@ -18,7 +18,7 @@ import type {
   LexicalEditor,
   SerializedEditorState
 } from 'lexical';
-import { type RefObject, memo, useCallback } from 'react';
+import { type RefObject, memo } from 'react';
 import ChapterFloatingToolbar from './ChapterFloatingToolbar';
 import ChapterSlashMenu from './ChapterSlashMenu';
 import ChapterToolbar from './ChapterToolbar';
@@ -50,12 +50,9 @@ function ChapterContentEditor({
     noSsr: true
   });
 
-  const handleChange = useCallback(
-    (editorState: EditorState) => {
-      onChange(editorState.toJSON());
-    },
-    [onChange]
-  );
+  const handleChange = (editorState: EditorState) => {
+    onChange(editorState.toJSON());
+  };
 
   return (
     <LexicalComposer

--- a/src/components/chapters/ChapterEditor.tsx
+++ b/src/components/chapters/ChapterEditor.tsx
@@ -29,7 +29,7 @@ import type { LexicalEditor } from 'lexical';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type { AppMap, Chapter, Journal, Journey, Review } from '../../../types';
 import useChapter from '../../hooks/useChapter';
 import useDictionary from '../../hooks/useDictionary';
@@ -94,65 +94,50 @@ export default function ChapterEditor({
     unpublishChapter
   } = useChapter(initialChapter);
 
-  const markerSpots = useMemo(
-    () => featureSpots(chapter.map_features),
-    [chapter.map_features]
-  );
+  const markerSpots = featureSpots(chapter.map_features);
 
-  const mapCenter = useMemo(
-    () =>
-      map ? { latitude: map.latitude, longitude: map.longitude } : undefined,
-    [map]
-  );
+  const mapCenter = map
+    ? { latitude: map.latitude, longitude: map.longitude }
+    : undefined;
 
   const [coverSaving, setCoverSaving] = useState(false);
   const [markerPickerOpen, setMarkerPickerOpen] = useState(false);
 
-  const usedReviewIds = useMemo(
-    () =>
-      new Set(
-        reviews
-          .filter((review) =>
-            markerSpots.some(
-              (spot) =>
-                spot.latitude === review.latitude &&
-                spot.longitude === review.longitude
-            )
-          )
-          .map((review) => review.id)
-      ),
-    [reviews, markerSpots]
-  );
-
-  const handleAddMarker = useCallback(
-    (review: Review) => {
-      setMarkerPickerOpen(false);
-      updateMapFeatures({
-        type: 'FeatureCollection',
-        features: [
-          ...chapter.map_features.features,
-          spotFeature({
-            name: review.name,
-            latitude: review.latitude,
-            longitude: review.longitude
-          })
-        ]
-      });
-    },
-    [chapter.map_features, updateMapFeatures]
-  );
-
-  const handleRemoveMarker = useCallback(
-    (index: number) => {
-      updateMapFeatures({
-        type: 'FeatureCollection',
-        features: chapter.map_features.features.filter(
-          (_, featureIndex) => featureIndex !== index
+  const usedReviewIds = new Set(
+    reviews
+      .filter((review) =>
+        markerSpots.some(
+          (spot) =>
+            spot.latitude === review.latitude &&
+            spot.longitude === review.longitude
         )
-      });
-    },
-    [chapter.map_features, updateMapFeatures]
+      )
+      .map((review) => review.id)
   );
+
+  const handleAddMarker = (review: Review) => {
+    setMarkerPickerOpen(false);
+    updateMapFeatures({
+      type: 'FeatureCollection',
+      features: [
+        ...chapter.map_features.features,
+        spotFeature({
+          name: review.name,
+          latitude: review.latitude,
+          longitude: review.longitude
+        })
+      ]
+    });
+  };
+
+  const handleRemoveMarker = (index: number) => {
+    updateMapFeatures({
+      type: 'FeatureCollection',
+      features: chapter.map_features.features.filter(
+        (_, featureIndex) => featureIndex !== index
+      )
+    });
+  };
 
   const [pageMenuAnchor, setPageMenuAnchor] = useState<HTMLElement | null>(
     null
@@ -164,7 +149,7 @@ export default function ChapterEditor({
 
   const editorRef = useRef<LexicalEditor | null>(null);
 
-  const handlePublishConfirm = useCallback(async () => {
+  const handlePublishConfirm = async () => {
     const { success } = await publishChapter();
     setPublishDialogOpen(false);
 
@@ -176,9 +161,9 @@ export default function ChapterEditor({
       variant: 'success'
     });
     router.push(readPath);
-  }, [publishChapter, dictionary, router, readPath]);
+  };
 
-  const handleUnpublishConfirm = useCallback(async () => {
+  const handleUnpublishConfirm = async () => {
     const { success } = await unpublishChapter();
     setUnpublishDialogOpen(false);
 
@@ -189,14 +174,14 @@ export default function ChapterEditor({
     enqueueSnackbar(dictionary['revert to draft success'], {
       variant: 'success'
     });
-  }, [unpublishChapter, dictionary]);
+  };
 
-  const handleRegenerateClick = useCallback(() => {
+  const handleRegenerateClick = () => {
     setPageMenuAnchor(null);
     setRegenerateDialogOpen(true);
-  }, []);
+  };
 
-  const handleRegenerateConfirm = useCallback(() => {
+  const handleRegenerateConfirm = () => {
     if (!journey) {
       return;
     }
@@ -211,14 +196,14 @@ export default function ChapterEditor({
     enqueueSnackbar(dictionary['regenerate chapter success'], {
       variant: 'success'
     });
-  }, [journey, dictionary, updateMapFeatures]);
+  };
 
-  const handleDeleteClick = useCallback(() => {
+  const handleDeleteClick = () => {
     setPageMenuAnchor(null);
     setDeleteDialogOpen(true);
-  }, []);
+  };
 
-  const handleDeleteConfirm = useCallback(async () => {
+  const handleDeleteConfirm = async () => {
     const { success } = await discardChapter();
 
     if (!success) {
@@ -237,7 +222,7 @@ export default function ChapterEditor({
           ? `/${lang}/maps/${map.id}`
           : `/${lang}`
     );
-  }, [discardChapter, dictionary, router, lang, map, journey]);
+  };
 
   return (
     <>

--- a/src/components/chapters/ChapterFloatingToolbar.tsx
+++ b/src/components/chapters/ChapterFloatingToolbar.tsx
@@ -30,9 +30,7 @@ import {
 import {
   type MouseEvent,
   type ReactNode,
-  useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState
 } from 'react';
@@ -88,40 +86,40 @@ export default function ChapterFloatingToolbar() {
     linkOpenRef.current = Boolean(linkAnchor);
   }, [linkAnchor]);
 
-  const update = useCallback(() => {
-    const selection = $getSelection();
-
-    if (
-      !$isRangeSelection(selection) ||
-      selection.isCollapsed() ||
-      !selection.getTextContent()
-    ) {
-      setVisible(false);
-      return;
-    }
-
-    setIsBold(selection.hasFormat('bold'));
-    setIsItalic(selection.hasFormat('italic'));
-    setIsUnderline(selection.hasFormat('underline'));
-    setIsStrikethrough(selection.hasFormat('strikethrough'));
-
-    const node = selection.anchor.getNode();
-    setIsLink($isLinkNode(node) || $isLinkNode(node.getParent()));
-
-    const domSelection = window.getSelection();
-
-    if (domSelection && domSelection.rangeCount > 0) {
-      const rect = domSelection.getRangeAt(0).getBoundingClientRect();
-
-      if (rect.width || rect.height) {
-        lastRectRef.current = rect;
-      }
-    }
-
-    setVisible(true);
-  }, []);
-
   useEffect(() => {
+    const update = () => {
+      const selection = $getSelection();
+
+      if (
+        !$isRangeSelection(selection) ||
+        selection.isCollapsed() ||
+        !selection.getTextContent()
+      ) {
+        setVisible(false);
+        return;
+      }
+
+      setIsBold(selection.hasFormat('bold'));
+      setIsItalic(selection.hasFormat('italic'));
+      setIsUnderline(selection.hasFormat('underline'));
+      setIsStrikethrough(selection.hasFormat('strikethrough'));
+
+      const node = selection.anchor.getNode();
+      setIsLink($isLinkNode(node) || $isLinkNode(node.getParent()));
+
+      const domSelection = window.getSelection();
+
+      if (domSelection && domSelection.rangeCount > 0) {
+        const rect = domSelection.getRangeAt(0).getBoundingClientRect();
+
+        if (rect.width || rect.height) {
+          lastRectRef.current = rect;
+        }
+      }
+
+      setVisible(true);
+    };
+
     return mergeRegister(
       editor.registerUpdateListener(({ editorState }) => {
         editorState.read(update);
@@ -135,67 +133,61 @@ export default function ChapterFloatingToolbar() {
         COMMAND_PRIORITY_LOW
       )
     );
-  }, [editor, update]);
+  }, [editor]);
 
-  const anchorEl = useMemo(
-    () => ({
-      getBoundingClientRect: () => {
-        if (!linkOpenRef.current) {
-          const domSelection = window.getSelection();
+  const anchorEl = {
+    getBoundingClientRect: () => {
+      if (!linkOpenRef.current) {
+        const domSelection = window.getSelection();
 
-          if (domSelection && domSelection.rangeCount > 0) {
-            const rect = domSelection.getRangeAt(0).getBoundingClientRect();
+        if (domSelection && domSelection.rangeCount > 0) {
+          const rect = domSelection.getRangeAt(0).getBoundingClientRect();
 
-            if (rect.width || rect.height) {
-              return rect;
-            }
+          if (rect.width || rect.height) {
+            return rect;
           }
         }
-
-        return lastRectRef.current ?? new DOMRect();
       }
-    }),
-    []
-  );
 
-  const openLinkEditor = useCallback(
-    (anchor: HTMLElement) => {
-      let current = '';
+      return lastRectRef.current ?? new DOMRect();
+    }
+  };
 
-      editor.getEditorState().read(() => {
-        const selection = $getSelection();
+  const openLinkEditor = (anchor: HTMLElement) => {
+    let current = '';
 
-        if ($isRangeSelection(selection)) {
-          savedSelectionRef.current = selection.clone();
+    editor.getEditorState().read(() => {
+      const selection = $getSelection();
 
-          const node = selection.anchor.getNode();
-          const linkNode = $isLinkNode(node)
-            ? node
-            : $isLinkNode(node.getParent())
-              ? node.getParent()
-              : null;
+      if ($isRangeSelection(selection)) {
+        savedSelectionRef.current = selection.clone();
 
-          if ($isLinkNode(linkNode)) {
-            current = linkNode.getURL();
-          }
+        const node = selection.anchor.getNode();
+        const linkNode = $isLinkNode(node)
+          ? node
+          : $isLinkNode(node.getParent())
+            ? node.getParent()
+            : null;
+
+        if ($isLinkNode(linkNode)) {
+          current = linkNode.getURL();
         }
-      });
+      }
+    });
 
-      setLinkValue(current);
-      setLinkAnchor(anchor);
-    },
-    [editor]
-  );
+    setLinkValue(current);
+    setLinkAnchor(anchor);
+  };
 
-  const restoreSelection = useCallback(() => {
+  const restoreSelection = () => {
     editor.update(() => {
       if (savedSelectionRef.current) {
         $setSelection(savedSelectionRef.current.clone());
       }
     });
-  }, [editor]);
+  };
 
-  const applyLink = useCallback(() => {
+  const applyLink = () => {
     const trimmed = linkValue.trim();
     const url = trimmed ? formatUrl(trimmed) : '';
 
@@ -205,13 +197,13 @@ export default function ChapterFloatingToolbar() {
       url ? { url, target: '_blank', rel: 'noopener noreferrer' } : null
     );
     setLinkAnchor(null);
-  }, [editor, linkValue, restoreSelection]);
+  };
 
-  const removeLink = useCallback(() => {
+  const removeLink = () => {
     restoreSelection();
     editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
     setLinkAnchor(null);
-  }, [editor, restoreSelection]);
+  };
 
   return (
     <>

--- a/src/components/chapters/ChapterReadView.tsx
+++ b/src/components/chapters/ChapterReadView.tsx
@@ -15,7 +15,7 @@ import {
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
-import { useCallback, useMemo, useState } from 'react';
+import { useState } from 'react';
 import type { AppMap, Chapter, Journal } from '../../../types';
 import { deleteChapter } from '../../actions/chapters';
 import useDictionary from '../../hooks/useDictionary';
@@ -58,23 +58,18 @@ export default function ChapterReadView({
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-  const markerSpots = useMemo(
-    () => featureSpots(chapter.map_features),
-    [chapter.map_features]
-  );
+  const markerSpots = featureSpots(chapter.map_features);
 
-  const mapCenter = useMemo(
-    () =>
-      map ? { latitude: map.latitude, longitude: map.longitude } : undefined,
-    [map]
-  );
+  const mapCenter = map
+    ? { latitude: map.latitude, longitude: map.longitude }
+    : undefined;
 
-  const handleDeleteClick = useCallback(() => {
+  const handleDeleteClick = () => {
     setMenuAnchor(null);
     setDeleteDialogOpen(true);
-  }, []);
+  };
 
-  const handleDeleteConfirm = useCallback(async () => {
+  const handleDeleteConfirm = async () => {
     const { success } = await deleteChapter(chapter.id);
 
     if (!success) {
@@ -93,7 +88,7 @@ export default function ChapterReadView({
     }
 
     router.push(map ? `/${lang}/maps/${map.id}` : `/${lang}`);
-  }, [chapter.id, chapter.journey_id, dictionary, router, lang, map]);
+  };
 
   return (
     <>

--- a/src/components/chapters/ChapterSlashMenu.tsx
+++ b/src/components/chapters/ChapterSlashMenu.tsx
@@ -14,7 +14,7 @@ import {
   Paper
 } from '@mui/material';
 import type { TextNode } from 'lexical';
-import { useCallback, useMemo, useState } from 'react';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { type BlockAction, useBlockActions } from './chapterBlockActions';
 
@@ -37,37 +37,29 @@ export default function ChapterSlashMenu() {
     minLength: 0
   });
 
-  const options = useMemo(() => {
-    const all = actions.map((action) => new BlockOption(action));
+  const allOptions = actions.map((action) => new BlockOption(action));
+  const query = queryString?.toLowerCase();
 
-    if (!queryString) {
-      return all;
-    }
+  const options = query
+    ? allOptions.filter(
+        (option) =>
+          option.action.label.toLowerCase().includes(query) ||
+          option.action.keywords.some((keyword) => keyword.includes(query))
+      )
+    : allOptions;
 
-    const query = queryString.toLowerCase();
+  const onSelectOption = (
+    option: BlockOption,
+    nodeToRemove: TextNode | null,
+    closeMenu: () => void
+  ) => {
+    editor.update(() => {
+      nodeToRemove?.remove();
+    });
 
-    return all.filter(
-      (option) =>
-        option.action.label.toLowerCase().includes(query) ||
-        option.action.keywords.some((keyword) => keyword.includes(query))
-    );
-  }, [actions, queryString]);
-
-  const onSelectOption = useCallback(
-    (
-      option: BlockOption,
-      nodeToRemove: TextNode | null,
-      closeMenu: () => void
-    ) => {
-      editor.update(() => {
-        nodeToRemove?.remove();
-      });
-
-      option.action.apply(editor);
-      closeMenu();
-    },
-    [editor]
-  );
+    option.action.apply(editor);
+    closeMenu();
+  };
 
   return (
     <LexicalTypeaheadMenuPlugin<BlockOption>

--- a/src/components/chapters/ChapterToolbar.tsx
+++ b/src/components/chapters/ChapterToolbar.tsx
@@ -46,7 +46,6 @@ import {
 import {
   type MouseEvent,
   type ReactNode,
-  useCallback,
   useEffect,
   useRef,
   useState
@@ -129,23 +128,23 @@ export default function ChapterToolbar() {
   const [linkValue, setLinkValue] = useState('');
   const savedSelectionRef = useRef<BaseSelection | null>(null);
 
-  const updateToolbar = useCallback(() => {
-    const selection = $getSelection();
-
-    if (!$isRangeSelection(selection)) {
-      return;
-    }
-
-    setIsBold(selection.hasFormat('bold'));
-    setIsItalic(selection.hasFormat('italic'));
-    setIsUnderline(selection.hasFormat('underline'));
-    setIsStrikethrough(selection.hasFormat('strikethrough'));
-
-    const anchorNode = selection.anchor.getNode();
-    setIsLink($isLinkNode(anchorNode) || $isLinkNode(anchorNode.getParent()));
-  }, []);
-
   useEffect(() => {
+    const updateToolbar = () => {
+      const selection = $getSelection();
+
+      if (!$isRangeSelection(selection)) {
+        return;
+      }
+
+      setIsBold(selection.hasFormat('bold'));
+      setIsItalic(selection.hasFormat('italic'));
+      setIsUnderline(selection.hasFormat('underline'));
+      setIsStrikethrough(selection.hasFormat('strikethrough'));
+
+      const anchorNode = selection.anchor.getNode();
+      setIsLink($isLinkNode(anchorNode) || $isLinkNode(anchorNode.getParent()));
+    };
+
     return mergeRegister(
       editor.registerUpdateListener(({ editorState }) => {
         editorState.read(updateToolbar);
@@ -175,110 +174,95 @@ export default function ChapterToolbar() {
         COMMAND_PRIORITY_LOW
       )
     );
-  }, [editor, updateToolbar]);
+  }, [editor]);
 
-  const captureSelection = useCallback(() => {
+  const captureSelection = () => {
     editor.getEditorState().read(() => {
       const selection = $getSelection();
       savedSelectionRef.current = $isRangeSelection(selection)
         ? selection.clone()
         : null;
     });
-  }, [editor]);
+  };
 
-  const restoreSelection = useCallback(() => {
+  const restoreSelection = () => {
     editor.update(() => {
       if (savedSelectionRef.current) {
         $setSelection(savedSelectionRef.current.clone());
       }
     });
-  }, [editor]);
+  };
 
-  const openBlockMenu = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      captureSelection();
-      setBlockMenuAnchor(event.currentTarget);
-    },
-    [captureSelection]
-  );
+  const openBlockMenu = (event: MouseEvent<HTMLButtonElement>) => {
+    captureSelection();
+    setBlockMenuAnchor(event.currentTarget);
+  };
 
-  const insertBlock = useCallback(
-    (action: BlockAction) => {
-      setBlockMenuAnchor(null);
+  const insertBlock = (action: BlockAction) => {
+    setBlockMenuAnchor(null);
 
-      editor.update(() => {
-        if (savedSelectionRef.current) {
-          $setSelection(savedSelectionRef.current.clone());
-        }
+    editor.update(() => {
+      if (savedSelectionRef.current) {
+        $setSelection(savedSelectionRef.current.clone());
+      }
 
-        const selection = $getSelection();
-        const anchorNode = $isRangeSelection(selection)
-          ? selection.anchor.getNode()
-          : null;
-        const block =
-          anchorNode && anchorNode.getKey() !== 'root'
-            ? anchorNode.getTopLevelElementOrThrow()
-            : null;
-
-        const paragraph = $createParagraphNode();
-
-        if (block) {
-          block.insertAfter(paragraph);
-        } else {
-          $getRoot().append(paragraph);
-        }
-
-        paragraph.select();
-      });
-
-      action.apply(editor);
-    },
-    [editor]
-  );
-
-  const openConvertMenu = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      captureSelection();
-      setConvertAnchor(event.currentTarget);
-    },
-    [captureSelection]
-  );
-
-  const convertBlock = useCallback(
-    (action: BlockAction) => {
-      setConvertAnchor(null);
-      restoreSelection();
-      action.apply(editor);
-    },
-    [editor, restoreSelection]
-  );
-
-  const openLinkEditor = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      editor.getEditorState().read(() => {
-        const selection = $getSelection();
-        savedSelectionRef.current = $isRangeSelection(selection)
-          ? selection.clone()
+      const selection = $getSelection();
+      const anchorNode = $isRangeSelection(selection)
+        ? selection.anchor.getNode()
+        : null;
+      const block =
+        anchorNode && anchorNode.getKey() !== 'root'
+          ? anchorNode.getTopLevelElementOrThrow()
           : null;
 
-        const anchorNode = $isRangeSelection(selection)
-          ? selection.anchor.getNode()
+      const paragraph = $createParagraphNode();
+
+      if (block) {
+        block.insertAfter(paragraph);
+      } else {
+        $getRoot().append(paragraph);
+      }
+
+      paragraph.select();
+    });
+
+    action.apply(editor);
+  };
+
+  const openConvertMenu = (event: MouseEvent<HTMLButtonElement>) => {
+    captureSelection();
+    setConvertAnchor(event.currentTarget);
+  };
+
+  const convertBlock = (action: BlockAction) => {
+    setConvertAnchor(null);
+    restoreSelection();
+    action.apply(editor);
+  };
+
+  const openLinkEditor = (event: MouseEvent<HTMLButtonElement>) => {
+    editor.getEditorState().read(() => {
+      const selection = $getSelection();
+      savedSelectionRef.current = $isRangeSelection(selection)
+        ? selection.clone()
+        : null;
+
+      const anchorNode = $isRangeSelection(selection)
+        ? selection.anchor.getNode()
+        : null;
+      const linkNode = $isLinkNode(anchorNode)
+        ? anchorNode
+        : $isLinkNode(anchorNode?.getParent())
+          ? anchorNode?.getParent()
           : null;
-        const linkNode = $isLinkNode(anchorNode)
-          ? anchorNode
-          : $isLinkNode(anchorNode?.getParent())
-            ? anchorNode?.getParent()
-            : null;
 
-        setLinkValue($isLinkNode(linkNode) ? linkNode.getURL() : '');
-      });
+      setLinkValue($isLinkNode(linkNode) ? linkNode.getURL() : '');
+    });
 
-      setLinkAnchor(event.currentTarget);
-    },
-    [editor]
-  );
+    setLinkAnchor(event.currentTarget);
+  };
 
-  const applyLink = useCallback(() => {
+  const applyLink = () => {
     const trimmed = linkValue.trim();
     const url = trimmed ? formatUrl(trimmed) : '';
 
@@ -288,13 +272,13 @@ export default function ChapterToolbar() {
       url ? { url, target: '_blank', rel: 'noopener noreferrer' } : null
     );
     setLinkAnchor(null);
-  }, [editor, linkValue, restoreSelection]);
+  };
 
-  const removeLink = useCallback(() => {
+  const removeLink = () => {
     restoreSelection();
     editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
     setLinkAnchor(null);
-  }, [editor, restoreSelection]);
+  };
 
   return (
     <AppBar

--- a/src/components/chapters/chapterBlockActions.tsx
+++ b/src/components/chapters/chapterBlockActions.tsx
@@ -26,7 +26,7 @@ import {
   type ElementNode,
   type LexicalEditor
 } from 'lexical';
-import { type ReactNode, useMemo } from 'react';
+import type { ReactNode } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 export type BlockAction = {
@@ -60,61 +60,58 @@ const tagIcon = (tag: string) => (
 export function useBlockActions(): BlockAction[] {
   const dictionary = useDictionary();
 
-  return useMemo(
-    () => [
-      {
-        key: 'paragraph',
-        label: dictionary.text,
-        keywords: ['text', 'paragraph'],
-        icon: <Notes fontSize="small" />,
-        apply: (editor) => setBlock(editor, () => $createParagraphNode())
-      },
-      {
-        key: 'h2',
-        label: dictionary['heading 2'],
-        keywords: ['h2', 'heading'],
-        icon: tagIcon('H2'),
-        apply: (editor) => headingAction(editor, 'h2')
-      },
-      {
-        key: 'h3',
-        label: dictionary['heading 3'],
-        keywords: ['h3', 'heading'],
-        icon: tagIcon('H3'),
-        apply: (editor) => headingAction(editor, 'h3')
-      },
-      {
-        key: 'ul',
-        label: dictionary['bulleted list'],
-        keywords: ['ul', 'list'],
-        icon: <FormatListBulleted fontSize="small" />,
-        apply: (editor) =>
-          editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined)
-      },
-      {
-        key: 'ol',
-        label: dictionary['numbered list'],
-        keywords: ['ol', 'list'],
-        icon: <FormatListNumbered fontSize="small" />,
-        apply: (editor) =>
-          editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined)
-      },
-      {
-        key: 'quote',
-        label: dictionary.quote,
-        keywords: ['quote', 'blockquote'],
-        icon: <FormatQuote fontSize="small" />,
-        apply: (editor) => setBlock(editor, () => $createQuoteNode())
-      },
-      {
-        key: 'divider',
-        label: dictionary.divider,
-        keywords: ['divider', 'hr', 'rule'],
-        icon: <HorizontalRule fontSize="small" />,
-        apply: (editor) =>
-          editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined)
-      }
-    ],
-    [dictionary]
-  );
+  return [
+    {
+      key: 'paragraph',
+      label: dictionary.text,
+      keywords: ['text', 'paragraph'],
+      icon: <Notes fontSize="small" />,
+      apply: (editor) => setBlock(editor, () => $createParagraphNode())
+    },
+    {
+      key: 'h2',
+      label: dictionary['heading 2'],
+      keywords: ['h2', 'heading'],
+      icon: tagIcon('H2'),
+      apply: (editor) => headingAction(editor, 'h2')
+    },
+    {
+      key: 'h3',
+      label: dictionary['heading 3'],
+      keywords: ['h3', 'heading'],
+      icon: tagIcon('H3'),
+      apply: (editor) => headingAction(editor, 'h3')
+    },
+    {
+      key: 'ul',
+      label: dictionary['bulleted list'],
+      keywords: ['ul', 'list'],
+      icon: <FormatListBulleted fontSize="small" />,
+      apply: (editor) =>
+        editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined)
+    },
+    {
+      key: 'ol',
+      label: dictionary['numbered list'],
+      keywords: ['ol', 'list'],
+      icon: <FormatListNumbered fontSize="small" />,
+      apply: (editor) =>
+        editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined)
+    },
+    {
+      key: 'quote',
+      label: dictionary.quote,
+      keywords: ['quote', 'blockquote'],
+      icon: <FormatQuote fontSize="small" />,
+      apply: (editor) => setBlock(editor, () => $createQuoteNode())
+    },
+    {
+      key: 'divider',
+      label: dictionary.divider,
+      keywords: ['divider', 'hr', 'rule'],
+      icon: <HorizontalRule fontSize="small" />,
+      apply: (editor) =>
+        editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined)
+    }
+  ];
 }

--- a/src/components/chapters/useBlockSelection.ts
+++ b/src/components/chapters/useBlockSelection.ts
@@ -14,7 +14,7 @@ import {
   KEY_DELETE_COMMAND,
   type NodeKey
 } from 'lexical';
-import { type RefObject, useCallback, useEffect } from 'react';
+import { type RefObject, useEffect } from 'react';
 
 export default function useBlockSelection(
   nodeKey: NodeKey,
@@ -25,8 +25,12 @@ export default function useBlockSelection(
   const [isSelected, setSelected, clearSelection] =
     useLexicalNodeSelection(nodeKey);
 
-  const handleDelete = useCallback(
-    (event: KeyboardEvent) => {
+  useEffect(() => {
+    if (!isEditable) {
+      return;
+    }
+
+    const handleDelete = (event: KeyboardEvent) => {
       const selection = $getSelection();
 
       if (!isSelected || !$isNodeSelection(selection)) {
@@ -40,14 +44,7 @@ export default function useBlockSelection(
       }
 
       return true;
-    },
-    [isSelected]
-  );
-
-  useEffect(() => {
-    if (!isEditable) {
-      return;
-    }
+    };
 
     return mergeRegister(
       editor.registerCommand<MouseEvent>(
@@ -77,21 +74,13 @@ export default function useBlockSelection(
         COMMAND_PRIORITY_LOW
       )
     );
-  }, [
-    editor,
-    isEditable,
-    isSelected,
-    setSelected,
-    clearSelection,
-    handleDelete,
-    targetRef
-  ]);
+  }, [editor, isEditable, isSelected, setSelected, clearSelection, targetRef]);
 
-  const remove = useCallback(() => {
+  const remove = () => {
     editor.update(() => {
       $getNodeByKey(nodeKey)?.remove();
     });
-  }, [editor, nodeKey]);
+  };
 
   return { selected: isEditable && isSelected, remove };
 }

--- a/src/components/coauthors/CoauthorshipInvitationList.tsx
+++ b/src/components/coauthors/CoauthorshipInvitationList.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useState, useTransition } from 'react';
+import { memo, useState, useTransition } from 'react';
 import type { CoauthorshipInvitation } from '../../../types';
 import {
   acceptCoauthorshipInvitation,
@@ -31,53 +31,47 @@ function CoauthorshipInvitationList({ invitations }: Props) {
   const [actingId, setActingId] = useState<number | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  const handleAccept = useCallback(
-    (invitation: CoauthorshipInvitation) => {
-      setActingId(invitation.id);
+  const handleAccept = (invitation: CoauthorshipInvitation) => {
+    setActingId(invitation.id);
 
-      startTransition(async () => {
-        const result = await acceptCoauthorshipInvitation(invitation.id);
+    startTransition(async () => {
+      const result = await acceptCoauthorshipInvitation(invitation.id);
 
-        if (result.success) {
-          enqueueSnackbar(dictionary['accept invitation success'], {
-            variant: 'success'
-          });
-          router.refresh();
-        } else {
-          enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
-            variant: 'error'
-          });
-        }
+      if (result.success) {
+        enqueueSnackbar(dictionary['accept invitation success'], {
+          variant: 'success'
+        });
+        router.refresh();
+      } else {
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+      }
 
-        setActingId(null);
-      });
-    },
-    [dictionary, router]
-  );
+      setActingId(null);
+    });
+  };
 
-  const handleDecline = useCallback(
-    (invitation: CoauthorshipInvitation) => {
-      setActingId(invitation.id);
+  const handleDecline = (invitation: CoauthorshipInvitation) => {
+    setActingId(invitation.id);
 
-      startTransition(async () => {
-        const result = await declineCoauthorshipInvitation(invitation.id);
+    startTransition(async () => {
+      const result = await declineCoauthorshipInvitation(invitation.id);
 
-        if (result.success) {
-          enqueueSnackbar(dictionary['decline invitation success'], {
-            variant: 'success'
-          });
-          router.refresh();
-        } else {
-          enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
-            variant: 'error'
-          });
-        }
+      if (result.success) {
+        enqueueSnackbar(dictionary['decline invitation success'], {
+          variant: 'success'
+        });
+        router.refresh();
+      } else {
+        enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
+          variant: 'error'
+        });
+      }
 
-        setActingId(null);
-      });
-    },
-    [dictionary, router]
-  );
+      setActingId(null);
+    });
+  };
 
   if (invitations.length < 1) {
     return (

--- a/src/components/common/AddPhotoButton.tsx
+++ b/src/components/common/AddPhotoButton.tsx
@@ -1,13 +1,6 @@
 import { AddAPhoto } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
-import {
-  type ChangeEvent,
-  memo,
-  useCallback,
-  useEffect,
-  useId,
-  useState
-} from 'react';
+import { type ChangeEvent, memo, useEffect, useId, useState } from 'react';
 import fileToDataUrl from '../../utils/fileToDataUrl';
 
 type Props = {
@@ -26,20 +19,17 @@ export default memo(function AddPhotoButton({
   const inputId = useId();
   const [dataUrls, setDataUrls] = useState<string[] | undefined>(undefined);
 
-  const handleImageFilesChange = useCallback(
-    async (e: ChangeEvent<HTMLInputElement>) => {
-      const files: File[] = Array.from(e.target.files);
-      const items = [];
+  const handleImageFilesChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const files: File[] = Array.from(e.target.files);
+    const items = [];
 
-      for (const file of files) {
-        const dataUrl = await fileToDataUrl(file);
-        items.push(dataUrl);
-      }
+    for (const file of files) {
+      const dataUrl = await fileToDataUrl(file);
+      items.push(dataUrl);
+    }
 
-      setDataUrls(items);
-    },
-    []
-  );
+    setDataUrls(items);
+  };
 
   useEffect(() => {
     if (dataUrls) {

--- a/src/components/common/AutocompleteListItem.tsx
+++ b/src/components/common/AutocompleteListItem.tsx
@@ -7,7 +7,7 @@ import {
 } from '@mui/material';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
-import { type ReactNode, memo, useMemo } from 'react';
+import { type ReactNode, memo } from 'react';
 import type { AutocompleteOption } from '../../../types';
 
 type Props = {
@@ -23,12 +23,8 @@ export default memo(function AutocompleteListItem({
   onClick,
   avatar
 }: Props) {
-  const parts = useMemo(() => {
-    const text = option.label;
-    const matches = match(text, inputValue);
-
-    return matches ? parse(text, matches) : [];
-  }, [option, inputValue]);
+  const matches = match(option.label, inputValue);
+  const parts = matches ? parse(option.label, matches) : [];
 
   return (
     <ListItem key={option.value} disableGutters dense>

--- a/src/components/common/EmailField.tsx
+++ b/src/components/common/EmailField.tsx
@@ -1,5 +1,5 @@
 import { TextField } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 type Props = {
@@ -20,32 +20,26 @@ function EmailField({ value, onChange, disabled }: Props) {
     }
   }, [value]);
 
-  const validate = useCallback(
-    (inputValue: string, validity: ValidityState): string | null => {
-      const valid = !inputValue || validity.valid;
-      return valid ? null : dictionary['email link error invalid email'];
-    },
-    [dictionary]
-  );
+  const validate = (
+    inputValue: string,
+    validity: ValidityState
+  ): string | null => {
+    const valid = !inputValue || validity.valid;
+    return valid ? null : dictionary['email link error invalid email'];
+  };
 
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const valid = !e.target.value || e.target.validity.valid;
-      if (touched) {
-        setEmailError(validate(e.target.value, e.target.validity));
-      }
-      onChange(e.target.value, valid);
-    },
-    [touched, validate, onChange]
-  );
-
-  const handleBlur = useCallback(
-    (e: React.FocusEvent<HTMLInputElement>) => {
-      setTouched(true);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const valid = !e.target.value || e.target.validity.valid;
+    if (touched) {
       setEmailError(validate(e.target.value, e.target.validity));
-    },
-    [validate]
-  );
+    }
+    onChange(e.target.value, valid);
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    setTouched(true);
+    setEmailError(validate(e.target.value, e.target.validity));
+  };
 
   return (
     <TextField

--- a/src/components/common/ProfileAvatar.tsx
+++ b/src/components/common/ProfileAvatar.tsx
@@ -1,6 +1,6 @@
 import { AccountCircle } from '@mui/icons-material';
 import { Avatar, type SxProps } from '@mui/material';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import type { ImageVariants } from '../../../types';
 
 type Props = {
@@ -10,13 +10,11 @@ type Props = {
 };
 
 function ProfileAvatar({ profile, size, variant }: Props) {
-  const avatarStyle = useMemo<SxProps>(() => {
-    return size ? { width: size, height: size } : { width: 40, height: 40 };
-  }, [size]);
+  const avatarStyle = size
+    ? { width: size, height: size }
+    : { width: 40, height: 40 };
 
-  const iconStyle = useMemo<SxProps>(() => {
-    return size ? { fontSize: size } : { fontSize: 40 };
-  }, [size]);
+  const iconStyle = size ? { fontSize: size } : { fontSize: 40 };
 
   if (!profile) {
     return (

--- a/src/components/home/Timeline.tsx
+++ b/src/components/home/Timeline.tsx
@@ -2,7 +2,7 @@
 
 import { Reviews } from '@mui/icons-material';
 import { Box, Button, Stack } from '@mui/material';
-import { memo, useCallback, useState, useTransition } from 'react';
+import { memo, useState, useTransition } from 'react';
 import type { Review } from '../../../types';
 import { fetchMoreTimelineReviews } from '../../actions/reviews';
 import useDictionary from '../../hooks/useDictionary';
@@ -36,7 +36,7 @@ export default memo(function Timeline({ initialReviews }: Props) {
       dialogOpen: false
     });
 
-  const loadMore = useCallback(() => {
+  const loadMore = () => {
     if (noMoreResults || isPending) return;
 
     const lastReview = reviews[reviews.length - 1];
@@ -50,21 +50,21 @@ export default memo(function Timeline({ initialReviews }: Props) {
       setReviews((prev) => [...prev, ...moreReviews]);
       setNoMoreResults(moreReviews.length < 1);
     });
-  }, [reviews, noMoreResults, isPending]);
+  };
 
-  const handleReportClick = useCallback((review: Review) => {
+  const handleReportClick = (review: Review) => {
     setIssueReportOptions({
       contentId: review.id,
       dialogOpen: true
     });
-  }, []);
+  };
 
-  const handleIssueDialogClose = useCallback(() => {
+  const handleIssueDialogClose = () => {
     setIssueReportOptions({
       contentId: null,
       dialogOpen: false
     });
-  }, []);
+  };
 
   return (
     <>

--- a/src/components/journeys/JourneyFab.tsx
+++ b/src/components/journeys/JourneyFab.tsx
@@ -35,11 +35,21 @@ function JourneyFab({
       return;
     }
 
+    let cancelled = false;
+
     (async () => {
       const { ControlPosition } = await loader.importLibrary('core');
 
+      if (cancelled) {
+        return;
+      }
+
       setControlPosition(ControlPosition.BOTTOM_CENTER);
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [googleMap, loader]);
 
   const active = Boolean(journey?.started_at && !journey?.finished_at);

--- a/src/components/journeys/JourneyFab.tsx
+++ b/src/components/journeys/JourneyFab.tsx
@@ -1,6 +1,6 @@
 import { DirectionsWalk, Pause } from '@mui/icons-material';
 import { Box, Fab } from '@mui/material';
-import { memo, useCallback, useContext, useEffect, useState } from 'react';
+import { memo, useContext, useEffect, useState } from 'react';
 import type { Journey } from '../../../types';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
@@ -46,7 +46,7 @@ function JourneyFab({
 
   // A journey that exists but has not started still holds milestones worth
   // reviewing, so the sheet opens first and starting happens from there.
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     if (journey) {
       onOpenProgress();
       return;
@@ -58,7 +58,7 @@ function JourneyFab({
     }
 
     onStartClick();
-  }, [journey, onOpenProgress, onStartClick, authenticated, setSignInRequired]);
+  };
 
   const icon = !active ? (
     <DirectionsWalk sx={{ mr: 1 }} />

--- a/src/components/journeys/JourneyMap.tsx
+++ b/src/components/journeys/JourneyMap.tsx
@@ -170,8 +170,15 @@ const JourneyMapOverlay = memo(function JourneyMapOverlay({
       return;
     }
 
+    let cancelled = false;
+
     (async () => {
       const { LatLngBounds } = await loader.importLibrary('core');
+
+      if (cancelled) {
+        return;
+      }
+
       const bounds = new LatLngBounds();
 
       for (const point of points) {
@@ -184,6 +191,10 @@ const JourneyMapOverlay = memo(function JourneyMapOverlay({
         googleMap.setZoom(17);
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [googleMap, loader, path, spots, milestones, fallbackCenter]);
 
   return (

--- a/src/components/layouts/AccountMenuButton.tsx
+++ b/src/components/layouts/AccountMenuButton.tsx
@@ -11,7 +11,7 @@ import {
 import { getAuth, signOut } from 'firebase/auth';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { memo, useCallback, useContext, useRef, useState } from 'react';
+import { memo, useContext, useRef, useState } from 'react';
 import AuthContext from '../../context/AuthContext';
 import ProfileContext from '../../context/ProfileContext';
 import useDictionary from '../../hooks/useDictionary';
@@ -29,18 +29,18 @@ export default memo(function AccountMenuButton() {
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-  const handleLinkClick = useCallback(() => {
+  const handleLinkClick = () => {
     setAnchorEl(null);
-  }, []);
+  };
 
-  const handleSignOutClick = useCallback(async () => {
+  const handleSignOutClick = async () => {
     setAnchorEl(null);
 
     const auth = getAuth();
     await signOut(auth);
 
     push(localePath('/login'));
-  }, [push, localePath]);
+  };
 
   return (
     <>

--- a/src/components/layouts/MiniDrawer.tsx
+++ b/src/components/layouts/MiniDrawer.tsx
@@ -29,7 +29,7 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { memo, useCallback, useContext, useRef, useState } from 'react';
+import { memo, useContext, useRef, useState } from 'react';
 import AuthContext from '../../context/AuthContext';
 import NotificationsContext from '../../context/NotificationsContext';
 import ProfileContext from '../../context/ProfileContext';
@@ -50,9 +50,9 @@ export default memo(function MiniDrawer() {
   const profile = useContext(ProfileContext);
   const notifications = useContext(NotificationsContext);
 
-  const refreshNotifications = useCallback(() => {
+  const refreshNotifications = () => {
     router.refresh();
-  }, [router]);
+  };
 
   const unreadNotifications = notifications.filter((notification) => {
     return notification.read === false;

--- a/src/components/layouts/MobileDrawer.tsx
+++ b/src/components/layouts/MobileDrawer.tsx
@@ -28,7 +28,7 @@ import {
 import { getAuth, signOut } from 'firebase/auth';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { memo, useCallback, useContext } from 'react';
+import { memo, useContext } from 'react';
 import AuthContext from '../../context/AuthContext';
 import ProfileContext from '../../context/ProfileContext';
 import useDictionary from '../../hooks/useDictionary';
@@ -57,19 +57,19 @@ export default memo(function MobileDrawer({
   const { authenticated, uid } = useContext(AuthContext);
   const profile = useContext(ProfileContext);
 
-  const handleSignOutClick = useCallback(async () => {
+  const handleSignOutClick = async () => {
     onClose();
 
     const auth = getAuth();
     await signOut(auth);
 
     push(localePath('/login'));
-  }, [onClose, push, localePath]);
+  };
 
-  const handleCreateMapClick = useCallback(() => {
+  const handleCreateMapClick = () => {
     onClose();
     onCreateMapClick();
-  }, [onClose, onCreateMapClick]);
+  };
 
   return (
     <SwipeableDrawer open={open} onOpen={onOpen} onClose={onClose}>

--- a/src/components/layouts/SearchDialog.tsx
+++ b/src/components/layouts/SearchDialog.tsx
@@ -15,7 +15,7 @@ import {
   useTheme
 } from '@mui/material';
 import { useRouter } from 'next/navigation';
-import { memo, useCallback, useDeferredValue, useState } from 'react';
+import { memo, useDeferredValue, useState } from 'react';
 import type { AppMap } from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
 import useLocalePath from '../../hooks/useLocalePath';
@@ -43,17 +43,14 @@ const SearchDialog = ({ open, onClose }: Props) => {
 
   const { options } = useMapSearch(deferredInputValue);
 
-  const handleMapClick = useCallback(
-    (option: AppMap) => {
-      onClose();
-      push(localePath(`/maps/${option.id}`));
-    },
-    [onClose, push, localePath]
-  );
+  const handleMapClick = (option: AppMap) => {
+    onClose();
+    push(localePath(`/maps/${option.id}`));
+  };
 
-  const handleExited = useCallback(() => {
+  const handleExited = () => {
     setInputValue('');
-  }, []);
+  };
 
   return (
     <Dialog

--- a/src/components/layouts/ShellProvider.tsx
+++ b/src/components/layouts/ShellProvider.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import {
-  type ReactNode,
-  useCallback,
-  useContext,
-  useMemo,
-  useState
-} from 'react';
+import { type ReactNode, useContext, useState } from 'react';
 import type { AppMap } from '../../../types';
 import AuthContext from '../../context/AuthContext';
 import ShellContext from '../../context/ShellContext';
@@ -28,27 +22,26 @@ export default function ShellProvider({ children }: Props) {
   const [createMapOpen, setCreateMapOpen] = useState(false);
   const [appBarHidden, setAppBarHidden] = useState(false);
 
-  const openSearch = useCallback(() => setSearchOpen(true), []);
-  const openCreateMap = useCallback(() => {
+  const openSearch = () => setSearchOpen(true);
+  const openCreateMap = () => {
     if (!authenticated) {
       setSignInRequired(true);
       return;
     }
     setCreateMapOpen(true);
-  }, [authenticated, setSignInRequired]);
+  };
 
-  const handleCreatedMap = useCallback(
-    (map: AppMap) => {
-      setCreateMapOpen(false);
-      push(localePath(`/maps/${map.id}`));
-    },
-    [push, localePath]
-  );
+  const handleCreatedMap = (map: AppMap) => {
+    setCreateMapOpen(false);
+    push(localePath(`/maps/${map.id}`));
+  };
 
-  const contextValue = useMemo(
-    () => ({ openSearch, openCreateMap, appBarHidden, setAppBarHidden }),
-    [openSearch, openCreateMap, appBarHidden]
-  );
+  const contextValue = {
+    openSearch,
+    openCreateMap,
+    appBarHidden,
+    setAppBarHidden
+  };
 
   return (
     <ShellContext.Provider value={contextValue}>

--- a/src/components/maps/CoauthorsDialog.tsx
+++ b/src/components/maps/CoauthorsDialog.tsx
@@ -14,7 +14,7 @@ import {
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
-import { memo, useCallback, useState } from 'react';
+import { memo, useState } from 'react';
 import type { AppMap, Coauthor } from '../../../types';
 import { removeCoauthor } from '../../actions/coauthors';
 import useDictionary from '../../hooks/useDictionary';
@@ -35,7 +35,7 @@ function CoauthorsDialog({ open, onClose, map, coauthors }: Props) {
 
   const [confirmTarget, setConfirmTarget] = useState<Coauthor | null>(null);
 
-  const handleConfirm = useCallback(async () => {
+  const handleConfirm = async () => {
     if (!map || !confirmTarget) {
       return;
     }
@@ -54,7 +54,7 @@ function CoauthorsDialog({ open, onClose, map, coauthors }: Props) {
     enqueueSnackbar(result.error ?? dictionary['an error occurred'], {
       variant: 'error'
     });
-  }, [map, confirmTarget, dictionary, router]);
+  };
 
   return (
     <>

--- a/src/components/maps/CoodinatesConverter.tsx
+++ b/src/components/maps/CoodinatesConverter.tsx
@@ -1,5 +1,5 @@
 import { Box, Paper } from '@mui/material';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { useGoogleMap } from '../../hooks/useGoogleMap';
 import DraggableMarker from './DraggableMarker';
 import MapControl from './MapControl';
@@ -22,38 +22,33 @@ function CoodinatesConverter({ onChange, defaultValue }: Props) {
   const [pacPosition, setPacPosition] =
     useState<google.maps.ControlPosition | null>(null);
 
-  const handlePlaceChange = useCallback(
-    (place: google.maps.places.Place) => {
-      if (!googleMap || !place || !place.location) {
-        return;
-      }
-
-      googleMap.setCenter(place.location);
-
-      setDefaultPosition(place.location);
-      setCenter({
-        lat: place.location.lat(),
-        lng: place.location.lng()
-      });
-    },
-    [googleMap]
-  );
-
-  const initControlPosition = useCallback(async () => {
-    if (!loader) {
+  const handlePlaceChange = (place: google.maps.places.Place) => {
+    if (!googleMap || !place || !place.location) {
       return;
     }
 
-    const { ControlPosition } = await loader.importLibrary('core');
+    googleMap.setCenter(place.location);
 
-    setPacPosition(ControlPosition.TOP_CENTER);
-  }, [loader]);
+    setDefaultPosition(place.location);
+    setCenter({
+      lat: place.location.lat(),
+      lng: place.location.lng()
+    });
+  };
 
   useEffect(() => {
-    if (googleMap && loader) {
-      initControlPosition();
+    if (!googleMap || !loader) {
+      return;
     }
-  }, [googleMap, loader, initControlPosition]);
+
+    const initControlPosition = async () => {
+      const { ControlPosition } = await loader.importLibrary('core');
+
+      setPacPosition(ControlPosition.TOP_CENTER);
+    };
+
+    initControlPosition();
+  }, [googleMap, loader]);
 
   useEffect(() => {
     if (center) {

--- a/src/components/maps/CoodinatesConverter.tsx
+++ b/src/components/maps/CoodinatesConverter.tsx
@@ -41,13 +41,23 @@ function CoodinatesConverter({ onChange, defaultValue }: Props) {
       return;
     }
 
+    let cancelled = false;
+
     const initControlPosition = async () => {
       const { ControlPosition } = await loader.importLibrary('core');
+
+      if (cancelled) {
+        return;
+      }
 
       setPacPosition(ControlPosition.TOP_CENTER);
     };
 
     initControlPosition();
+
+    return () => {
+      cancelled = true;
+    };
   }, [googleMap, loader]);
 
   useEffect(() => {

--- a/src/components/maps/CurrentPositionButton.tsx
+++ b/src/components/maps/CurrentPositionButton.tsx
@@ -1,6 +1,6 @@
 import { MyLocation } from '@mui/icons-material';
 import { Box, CircularProgress, Fab } from '@mui/material';
-import { memo, useCallback, useState } from 'react';
+import { memo, useState } from 'react';
 import { useGoogleMap } from '../../hooks/useGoogleMap';
 
 function CurrentPositionButton() {
@@ -8,34 +8,28 @@ function CurrentPositionButton() {
 
   const [loading, setLoading] = useState<boolean>(false);
 
-  const handlePosition = useCallback(
-    (position: GeolocationPosition) => {
-      setLoading(false);
+  const handlePosition = (position: GeolocationPosition) => {
+    setLoading(false);
 
-      if (!googleMap) {
-        return;
-      }
+    if (!googleMap) {
+      return;
+    }
 
-      setCurrentPosition(position);
+    setCurrentPosition(position);
 
-      googleMap.panTo({
-        lat: position.coords.latitude,
-        lng: position.coords.longitude
-      });
-      googleMap.setZoom(17);
-    },
-    [googleMap, setCurrentPosition]
-  );
+    googleMap.panTo({
+      lat: position.coords.latitude,
+      lng: position.coords.longitude
+    });
+    googleMap.setZoom(17);
+  };
 
-  const handlePositionError = useCallback(
-    (positionError: GeolocationPositionError) => {
-      console.error(positionError);
-      setLoading(false);
-    },
-    []
-  );
+  const handlePositionError = (positionError: GeolocationPositionError) => {
+    console.error(positionError);
+    setLoading(false);
+  };
 
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     setLoading(true);
 
     navigator.geolocation.getCurrentPosition(
@@ -46,7 +40,7 @@ function CurrentPositionButton() {
         maximumAge: 30000
       }
     );
-  }, [handlePosition, handlePositionError]);
+  };
 
   return (
     <Box position="relative">

--- a/src/components/maps/CurrentPositionMarker.tsx
+++ b/src/components/maps/CurrentPositionMarker.tsx
@@ -16,7 +16,7 @@ import {
   Typography,
   styled
 } from '@mui/material';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import type { Profile } from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
 import { useGoogleMap } from '../../hooks/useGoogleMap';
@@ -75,56 +75,50 @@ function CurrentPositionMarker({
   const [popoverAnchorEl, setPopoverAnchorEl] =
     useState<HTMLButtonElement | null>(null);
 
-  const handlePopoverOpen = useCallback(() => {
+  const handlePopoverOpen = () => {
     setPopoverAnchorEl(ref.current);
-  }, []);
+  };
 
-  const handlePopoverClose = useCallback(() => {
+  const handlePopoverClose = () => {
     setPopoverAnchorEl(null);
-  }, []);
+  };
 
-  const handleTooltipClose = useCallback(() => {
+  const handleTooltipClose = () => {
     setOpen(false);
-  }, []);
+  };
 
-  const handleTooltipOpen = useCallback(() => {
+  const handleTooltipOpen = () => {
     setOpen(true);
-  }, []);
+  };
 
-  const handleCreateReviewClick = useCallback(() => {
+  const handleCreateReviewClick = () => {
     setPopoverAnchorEl(null);
 
     onCreateReviewClick();
-  }, [onCreateReviewClick]);
+  };
 
   const popoverOpen = Boolean(popoverAnchorEl);
 
-  const popoverId = useMemo(() => {
-    return popoverOpen ? 'current-position' : undefined;
-  }, [popoverOpen]);
+  const popoverId = popoverOpen ? 'current-position' : undefined;
 
-  const initPosition = useCallback(async () => {
+  useEffect(() => {
     if (!loader || !currentPosition) {
       return;
     }
 
-    const { LatLng } = await loader.importLibrary('core');
+    const initPosition = async () => {
+      const { LatLng } = await loader.importLibrary('core');
 
-    setPosition(
-      new LatLng(
-        currentPosition.coords.latitude,
-        currentPosition.coords.longitude
-      )
-    );
-  }, [loader, currentPosition]);
-
-  useEffect(() => {
-    if (!loader) {
-      return;
-    }
+      setPosition(
+        new LatLng(
+          currentPosition.coords.latitude,
+          currentPosition.coords.longitude
+        )
+      );
+    };
 
     initPosition();
-  }, [loader, initPosition]);
+  }, [loader, currentPosition]);
 
   if (!position) {
     return null;

--- a/src/components/maps/CurrentPositionMarker.tsx
+++ b/src/components/maps/CurrentPositionMarker.tsx
@@ -106,8 +106,14 @@ function CurrentPositionMarker({
       return;
     }
 
+    let cancelled = false;
+
     const initPosition = async () => {
       const { LatLng } = await loader.importLibrary('core');
+
+      if (cancelled) {
+        return;
+      }
 
       setPosition(
         new LatLng(
@@ -118,6 +124,10 @@ function CurrentPositionMarker({
     };
 
     initPosition();
+
+    return () => {
+      cancelled = true;
+    };
   }, [loader, currentPosition]);
 
   if (!position) {

--- a/src/components/maps/CustomMapControls.tsx
+++ b/src/components/maps/CustomMapControls.tsx
@@ -1,5 +1,5 @@
 import { Box, Paper, Stack, useMediaQuery, useTheme } from '@mui/material';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 import { useGoogleMap } from '../../hooks/useGoogleMap';
 import CurrentPositionButton from './CurrentPositionButton';
@@ -25,42 +25,40 @@ function CustomMapControls({ onPlaceChange }: Props) {
   const [buttonPosition, setButtonPosition] =
     useState<google.maps.ControlPosition | null>(null);
 
-  const handleMapClick = useCallback(() => {
-    if (pacRef.current) {
-      pacRef.current.blur();
-    }
-  }, []);
-
-  const initControlPositions = useCallback(async () => {
+  useEffect(() => {
     if (!googleMap || !loader) {
       return;
     }
 
-    const { ControlPosition } = await loader.importLibrary('core');
+    const initControlPositions = async () => {
+      const { ControlPosition } = await loader.importLibrary('core');
 
-    setPacPosition(
-      mdDown ? ControlPosition.TOP_CENTER : ControlPosition.TOP_LEFT
-    );
-    setButtonPosition(ControlPosition.RIGHT_BOTTOM);
+      setPacPosition(
+        mdDown ? ControlPosition.TOP_CENTER : ControlPosition.TOP_LEFT
+      );
+      setButtonPosition(ControlPosition.RIGHT_BOTTOM);
+    };
+
+    initControlPositions();
   }, [googleMap, loader, mdDown]);
-
-  useEffect(() => {
-    if (googleMap && loader) {
-      initControlPositions();
-    }
-  }, [googleMap, loader, initControlPositions]);
 
   useEffect(() => {
     if (!googleMap) {
       return;
     }
 
+    const handleMapClick = () => {
+      if (pacRef.current) {
+        pacRef.current.blur();
+      }
+    };
+
     const clickListener = googleMap.addListener('click', handleMapClick);
 
     return () => {
       clickListener.remove();
     };
-  }, [googleMap, handleMapClick]);
+  }, [googleMap]);
 
   return (
     <>

--- a/src/components/maps/CustomMapControls.tsx
+++ b/src/components/maps/CustomMapControls.tsx
@@ -30,8 +30,14 @@ function CustomMapControls({ onPlaceChange }: Props) {
       return;
     }
 
+    let cancelled = false;
+
     const initControlPositions = async () => {
       const { ControlPosition } = await loader.importLibrary('core');
+
+      if (cancelled) {
+        return;
+      }
 
       setPacPosition(
         mdDown ? ControlPosition.TOP_CENTER : ControlPosition.TOP_LEFT
@@ -40,6 +46,10 @@ function CustomMapControls({ onPlaceChange }: Props) {
     };
 
     initControlPositions();
+
+    return () => {
+      cancelled = true;
+    };
   }, [googleMap, loader, mdDown]);
 
   useEffect(() => {

--- a/src/components/maps/CustomOverlays.tsx
+++ b/src/components/maps/CustomOverlays.tsx
@@ -3,10 +3,8 @@ import { usePathname, useRouter } from 'next/navigation';
 import {
   type MutableRefObject,
   memo,
-  useCallback,
   useContext,
   useEffect,
-  useMemo,
   useRef,
   useState
 } from 'react';
@@ -78,88 +76,78 @@ function CustomOverlays({
   const [pinnedPosition, setPinnedPosition] =
     useState<google.maps.LatLng | null>(null);
 
-  const filteredReviews = useMemo(() => {
-    if (!currentBounds) {
-      return [];
-    }
-
-    return reviews.filter((review) =>
-      positionInBounds(
-        { lat: review.latitude, lng: review.longitude },
-        currentBounds
+  const filteredReviews = currentBounds
+    ? reviews.filter((review) =>
+        positionInBounds(
+          { lat: review.latitude, lng: review.longitude },
+          currentBounds
+        )
       )
-    );
-  }, [reviews, currentBounds]);
+    : [];
 
-  const handleReviewDeleted = useCallback(() => {
+  const handleReviewDeleted = () => {
     setCurrentReview(null);
     setPopoverAnchorEl(null);
     onReviewSaved();
-  }, [onReviewSaved]);
+  };
 
-  const handleReviewClick = useCallback(
-    (review: Review, ref: MutableRefObject<HTMLButtonElement>) => {
-      setCurrentReview(review);
-      onReviewClick(review);
+  const handleReviewClick = (
+    review: Review,
+    ref: MutableRefObject<HTMLButtonElement>
+  ) => {
+    setCurrentReview(review);
+    onReviewClick(review);
 
-      setPopoverAnchorEl(ref.current);
-    },
-    [onReviewClick]
-  );
+    setPopoverAnchorEl(ref.current);
+  };
 
-  const handleCreateReviewOpen = useCallback(() => {
+  const handleCreateReviewOpen = () => {
     setCreateReviewDialogOpen(true);
-  }, []);
+  };
 
-  const handleCreateReviewClose = useCallback(() => {
+  const handleCreateReviewClose = () => {
     setCreateReviewDialogOpen(false);
-  }, []);
+  };
 
-  const handlePlaceClose = useCallback(() => {
+  const handlePlaceClose = () => {
     setCurrentPlace(null);
-  }, []);
+  };
 
-  const handlePinnedPositionClose = useCallback(() => {
+  const handlePinnedPositionClose = () => {
     setPinnedPosition(null);
-  }, []);
+  };
 
-  const handlePopoverClose = useCallback(() => {
+  const handlePopoverClose = () => {
     setPopoverAnchorEl(null);
-  }, []);
-
-  const handleMapClick = useCallback(
-    async (event: google.maps.MapMouseEvent | google.maps.IconMouseEvent) => {
-      if ('placeId' in event) {
-        // Prevent POI Click Events
-        event.stop();
-      }
-    },
-    []
-  );
-
-  const handleMapRightClick = useCallback(
-    async (event: google.maps.MapMouseEvent | google.maps.IconMouseEvent) => {
-      setPinnedPosition(event.latLng);
-    },
-    []
-  );
-
-  const handleIdle = useCallback(() => {
-    if (!googleMap) {
-      return;
-    }
-
-    const bounds = googleMap.getBounds();
-
-    if (bounds) {
-      setCurrentBounds(bounds);
-    }
-  }, [googleMap]);
+  };
 
   useEffect(() => {
     if (!googleMap) {
       return;
     }
+
+    const handleIdle = () => {
+      const bounds = googleMap.getBounds();
+
+      if (bounds) {
+        setCurrentBounds(bounds);
+      }
+    };
+
+    const handleMapClick = (
+      event: google.maps.MapMouseEvent | google.maps.IconMouseEvent
+    ) => {
+      if ('placeId' in event) {
+        // Prevent POI Click Events
+        event.stop();
+      }
+    };
+
+    const handleMapRightClick = (
+      event: google.maps.MapMouseEvent | google.maps.IconMouseEvent
+    ) => {
+      setPinnedPosition(event.latLng);
+    };
 
     const idleListener = googleMap.addListener('idle', handleIdle);
     const clickListener = googleMap.addListener('click', handleMapClick);
@@ -173,7 +161,7 @@ function CustomOverlays({
       clickListener.remove();
       rightCickListener.remove();
     };
-  }, [googleMap, handleIdle, handleMapClick, handleMapRightClick]);
+  }, [googleMap]);
 
   const initializedRef = useRef(false);
 
@@ -205,11 +193,10 @@ function CustomOverlays({
 
   const popoverOpen = Boolean(popoverAnchorEl);
 
-  const reviewPopoverId = useMemo(() => {
-    return popoverOpen && currentReview
+  const reviewPopoverId =
+    popoverOpen && currentReview
       ? `review-popover-${currentReview.id}`
       : undefined;
-  }, [popoverOpen, currentReview]);
 
   return (
     <>

--- a/src/components/maps/DraggableMarker.tsx
+++ b/src/components/maps/DraggableMarker.tsx
@@ -46,7 +46,11 @@ export default memo(function DraggableMarker({
       return;
     }
 
-    markerView.addListener('dragend', handleDragEnd);
+    const listener = markerView.addListener('dragend', handleDragEnd);
+
+    return () => {
+      listener.remove();
+    };
   }, [markerView, handleDragEnd]);
 
   useEffect(() => {

--- a/src/components/maps/InfoWindow.tsx
+++ b/src/components/maps/InfoWindow.tsx
@@ -30,18 +30,28 @@ function InfoWindow({ children, position, open, onClose }: Props) {
       return;
     }
 
+    let cancelled = false;
+
     const initWindow = async () => {
       const { InfoWindow } = await loader.importLibrary('maps');
 
-      const window = new InfoWindow({
-        content: container,
-        disableAutoPan: true
-      });
+      if (cancelled) {
+        return;
+      }
 
-      setInfoWindow(window);
+      setInfoWindow(
+        new InfoWindow({
+          content: container,
+          disableAutoPan: true
+        })
+      );
     };
 
     initWindow();
+
+    return () => {
+      cancelled = true;
+    };
   }, [infoWindow, loader, container]);
 
   useEffect(() => {

--- a/src/components/maps/InfoWindow.tsx
+++ b/src/components/maps/InfoWindow.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, memo, useCallback, useEffect, useState } from 'react';
+import { type ReactNode, memo, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useGoogleMap } from '../../hooks/useGoogleMap';
 
@@ -17,21 +17,6 @@ function InfoWindow({ children, position, open, onClose }: Props) {
     null
   );
 
-  const initWindow = useCallback(async () => {
-    if (!loader) {
-      return;
-    }
-
-    const { InfoWindow } = await loader.importLibrary('maps');
-
-    const window = new InfoWindow({
-      content: container,
-      disableAutoPan: true
-    });
-
-    setInfoWindow(window);
-  }, [loader, container]);
-
   useEffect(() => {
     if (!container) {
       const div = document.createElement('div');
@@ -41,10 +26,23 @@ function InfoWindow({ children, position, open, onClose }: Props) {
   }, [container]);
 
   useEffect(() => {
-    if (!infoWindow && loader && container) {
-      initWindow();
+    if (infoWindow || !loader || !container) {
+      return;
     }
-  }, [infoWindow, loader, container, initWindow]);
+
+    const initWindow = async () => {
+      const { InfoWindow } = await loader.importLibrary('maps');
+
+      const window = new InfoWindow({
+        content: container,
+        disableAutoPan: true
+      });
+
+      setInfoWindow(window);
+    };
+
+    initWindow();
+  }, [infoWindow, loader, container]);
 
   useEffect(() => {
     if (!infoWindow) {

--- a/src/components/maps/MapAutocompleteOption.tsx
+++ b/src/components/maps/MapAutocompleteOption.tsx
@@ -2,7 +2,7 @@ import { Map as MapIcon } from '@mui/icons-material';
 import { Grid, Typography } from '@mui/material';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import type { AppMap } from '../../../types';
 
 type Props = {
@@ -14,12 +14,8 @@ export default memo(function MapAutocompleteOption({
   option,
   inputValue
 }: Props) {
-  const parts = useMemo(() => {
-    const text = option.name;
-    const matches = match(text, inputValue);
-
-    return matches ? parse(text, matches) : [];
-  }, [option, inputValue]);
+  const matches = match(option.name, inputValue);
+  const parts = matches ? parse(option.name, matches) : [];
 
   return (
     <Grid container alignItems="center" data-test="map-item">

--- a/src/components/maps/MapDescriptionForm.tsx
+++ b/src/components/maps/MapDescriptionForm.tsx
@@ -1,11 +1,5 @@
 import { TextField } from '@mui/material';
-import {
-  type ChangeEvent,
-  memo,
-  useCallback,
-  useEffect,
-  useState
-} from 'react';
+import { type ChangeEvent, memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 200;
@@ -24,23 +18,22 @@ export default memo(function MapDescriptionForm({
   const [description, setDescription] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
 
-  const handleDescriptionChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      const input = e.target.value;
+  const handleDescriptionChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const input = e.target.value;
 
-      if (input) {
-        if (input.length > MAX_LENGTH) {
-          setError(dictionary['max characters 200']);
-        } else {
-          setError(null);
-        }
+    if (input) {
+      if (input.length > MAX_LENGTH) {
+        setError(dictionary['max characters 200']);
       } else {
-        setError(dictionary['description is required']);
+        setError(null);
       }
-      setDescription(input);
-    },
-    [dictionary]
-  );
+    } else {
+      setError(dictionary['description is required']);
+    }
+    setDescription(input);
+  };
 
   useEffect(() => {
     onChange(description);

--- a/src/components/maps/MapDetailTabs.tsx
+++ b/src/components/maps/MapDetailTabs.tsx
@@ -1,7 +1,7 @@
 import { HistoryEdu, Place } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Tab } from '@mui/material';
-import { type SyntheticEvent, memo, useCallback, useState } from 'react';
+import { type SyntheticEvent, memo, useState } from 'react';
 import type { Chapter, Review } from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
 import MapChapterList from './MapChapterList';
@@ -18,12 +18,12 @@ function MapDetailTabs({ reviews, chapters, onReviewClick }: Props) {
 
   const [tabValue, setTabValue] = useState('spots');
 
-  const handleTabChange = useCallback(
-    (_event: SyntheticEvent<Element, Event>, newValue: string) => {
-      setTabValue(newValue);
-    },
-    []
-  );
+  const handleTabChange = (
+    _event: SyntheticEvent<Element, Event>,
+    newValue: string
+  ) => {
+    setTabValue(newValue);
+  };
 
   return (
     <TabContext value={tabValue}>

--- a/src/components/maps/MapDetailView.tsx
+++ b/src/components/maps/MapDetailView.tsx
@@ -3,7 +3,7 @@
 import { Box, useMediaQuery, useTheme } from '@mui/material';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type {
   AppMap,
   Chapter,
@@ -58,39 +58,30 @@ export default function MapDetailView({
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  const handleCheckin = useCallback(
-    (review: Review) => {
-      enqueueSnackbar(dictionary['checked in'].replace('{name}', review.name), {
-        variant: 'success'
-      });
-    },
-    [dictionary]
-  );
+  const handleCheckin = (review: Review) => {
+    enqueueSnackbar(dictionary['checked in'].replace('{name}', review.name), {
+      variant: 'success'
+    });
+  };
 
-  const handleLocationError = useCallback(() => {
+  const handleLocationError = () => {
     enqueueSnackbar(dictionary['location unavailable'], { variant: 'error' });
-  }, [dictionary]);
+  };
 
-  const handlePaused = useCallback(
-    (reason: PauseReason) => {
-      enqueueSnackbar(
-        reason === 'permission'
-          ? dictionary['journey paused permission']
-          : dictionary['journey paused inactivity'],
-        { variant: 'warning' }
-      );
-    },
-    [dictionary]
-  );
+  const handlePaused = (reason: PauseReason) => {
+    enqueueSnackbar(
+      reason === 'permission'
+        ? dictionary['journey paused permission']
+        : dictionary['journey paused inactivity'],
+      { variant: 'warning' }
+    );
+  };
 
-  const handleJourneyError = useCallback(
-    (message: string | null) => {
-      enqueueSnackbar(message ?? dictionary['an error occurred'], {
-        variant: 'error'
-      });
-    },
-    [dictionary]
-  );
+  const handleJourneyError = (message: string | null) => {
+    enqueueSnackbar(message ?? dictionary['an error occurred'], {
+      variant: 'error'
+    });
+  };
 
   const [journeyPosition, setJourneyPosition] =
     useState<GeolocationPosition | null>(null);
@@ -129,54 +120,45 @@ export default function MapDetailView({
 
   const journeyActive = Boolean(journey?.started_at && !journey?.finished_at);
 
-  const milestoneOrders = useMemo(
-    () =>
-      new Map(
-        (journey?.milestones ?? []).map((milestone, index) => [
-          milestone.review_id,
-          index + 1
-        ])
-      ),
-    [journey]
+  const milestoneOrders = new Map(
+    (journey?.milestones ?? []).map((milestone, index) => [
+      milestone.review_id,
+      index + 1
+    ])
   );
 
-  const checkedInReviewIds = useMemo(
-    () =>
-      new Set((journey?.checkins ?? []).map((checkin) => checkin.review_id)),
-    [journey]
+  const checkedInReviewIds = new Set(
+    (journey?.checkins ?? []).map((checkin) => checkin.review_id)
   );
 
-  const handleAddMilestone = useCallback(
-    async (review: Review) => {
-      const added = await addMilestone(review);
+  const handleAddMilestone = async (review: Review) => {
+    const added = await addMilestone(review);
 
-      if (added) {
-        enqueueSnackbar(
-          dictionary['added to milestones'].replace('{name}', review.name),
-          { variant: 'success' }
-        );
-        setReviewDrawerOpen(false);
-      }
-    },
-    [addMilestone, dictionary]
-  );
+    if (added) {
+      enqueueSnackbar(
+        dictionary['added to milestones'].replace('{name}', review.name),
+        { variant: 'success' }
+      );
+      setReviewDrawerOpen(false);
+    }
+  };
 
-  const handleStart = useCallback(async () => {
+  const handleStart = async () => {
     const started = await start();
 
     if (started) {
       setStartDialogOpen(false);
     }
-  }, [start]);
+  };
 
-  const handlePause = useCallback(() => {
+  const handlePause = () => {
     pause();
     enqueueSnackbar(dictionary['journey recording paused'], {
       variant: 'info'
     });
-  }, [pause, dictionary]);
+  };
 
-  const handleResume = useCallback(async () => {
+  const handleResume = async () => {
     const resumed = await resume();
 
     enqueueSnackbar(
@@ -185,9 +167,9 @@ export default function MapDetailView({
         : dictionary['journey resume unavailable'],
       { variant: resumed ? 'success' : 'error' }
     );
-  }, [resume, dictionary]);
+  };
 
-  const handleEnd = useCallback(async () => {
+  const handleEnd = async () => {
     const finished = await end();
 
     if (!finished) {
@@ -197,7 +179,7 @@ export default function MapDetailView({
     setEndDialogOpen(false);
     setProgressOpen(false);
     router.push(`/${lang}/journeys/${finished.journey.id}`);
-  }, [end, router, lang]);
+  };
 
   const lat = searchParams.get('lat');
   const lng = searchParams.get('lng');
@@ -210,14 +192,14 @@ export default function MapDetailView({
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-  const handleReviewSaved = useCallback(() => {
+  const handleReviewSaved = () => {
     router.refresh();
-  }, [router]);
+  };
 
-  const handleReviewClick = useCallback((review: Review) => {
+  const handleReviewClick = (review: Review) => {
     setCurrentReview(review);
     setReviewDrawerOpen(true);
-  }, []);
+  };
 
   useEffect(() => {
     if (lat && lng) {

--- a/src/components/maps/MapMenuButton.tsx
+++ b/src/components/maps/MapMenuButton.tsx
@@ -16,14 +16,7 @@ import {
 } from '@mui/material';
 import { useParams } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
-import {
-  memo,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import { memo, useContext, useRef, useState } from 'react';
 import type { AppMap, Profile } from '../../../types';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
@@ -55,13 +48,11 @@ export default memo(function MapMenuButton({
   const { lang } = useParams<{ lang: string }>();
   const dictionary = useDictionary();
 
-  const isAuthor = useMemo(() => {
-    return currentProfile?.id === map?.author.id;
-  }, [map, currentProfile]);
+  const isAuthor = currentProfile?.id === map?.author.id;
 
   const url = `${SITE_ORIGIN}${localePath(lang, `/maps/${map?.id}`)}`;
 
-  const handleCopyClick = useCallback(async () => {
+  const handleCopyClick = async () => {
     if (!url) {
       return;
     }
@@ -71,9 +62,9 @@ export default memo(function MapMenuButton({
     await navigator.clipboard.writeText(url);
 
     enqueueSnackbar(dictionary.copied);
-  }, [url, dictionary]);
+  };
 
-  const handleReportClick = useCallback(() => {
+  const handleReportClick = () => {
     setAnchorEl(null);
 
     if (!authenticated) {
@@ -82,25 +73,25 @@ export default memo(function MapMenuButton({
     }
 
     onReportClick();
-  }, [authenticated, setSignInRequired, onReportClick]);
+  };
 
-  const handleEditClick = useCallback(() => {
+  const handleEditClick = () => {
     setAnchorEl(null);
 
     onEditClick();
-  }, [onEditClick]);
+  };
 
-  const handleDeleteClick = useCallback(() => {
+  const handleDeleteClick = () => {
     setAnchorEl(null);
 
     onDeleteClick();
-  }, [onDeleteClick]);
+  };
 
-  const handleInviteClick = useCallback(() => {
+  const handleInviteClick = () => {
     setAnchorEl(null);
 
     setInviteDialogOpen(true);
-  }, []);
+  };
 
   return (
     <>

--- a/src/components/maps/MapNameForm.tsx
+++ b/src/components/maps/MapNameForm.tsx
@@ -1,11 +1,5 @@
 import { TextField } from '@mui/material';
-import {
-  type ChangeEvent,
-  memo,
-  useCallback,
-  useEffect,
-  useState
-} from 'react';
+import { type ChangeEvent, memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 30;
@@ -21,24 +15,23 @@ export default memo(function MapNameForm({ onChange, defaultValue }: Props) {
   const [name, setName] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
 
-  const handleNameChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      const input = e.target.value;
+  const handleNameChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const input = e.target.value;
 
-      if (input) {
-        if (input.length > MAX_LENGTH) {
-          setError(dictionary['max characters 30']);
-        } else {
-          setError(null);
-        }
+    if (input) {
+      if (input.length > MAX_LENGTH) {
+        setError(dictionary['max characters 30']);
       } else {
-        setError(dictionary['map name is required']);
+        setError(null);
       }
+    } else {
+      setError(dictionary['map name is required']);
+    }
 
-      setName(input);
-    },
-    [dictionary]
-  );
+    setName(input);
+  };
 
   useEffect(() => {
     onChange(name);

--- a/src/components/maps/MapReviewList.tsx
+++ b/src/components/maps/MapReviewList.tsx
@@ -8,7 +8,7 @@ import {
   ListItemText
 } from '@mui/material';
 import { usePathname, useRouter } from 'next/navigation';
-import { memo, useCallback } from 'react';
+import { memo } from 'react';
 import type { Review } from '../../../types';
 import useDictionary from '../../hooks/useDictionary';
 import AuthorAvatar from '../common/AuthorAvatar';
@@ -24,18 +24,14 @@ function MapReviewList({ reviews, onReviewClick }: Props) {
   const { push } = useRouter();
   const pathname = usePathname();
 
-  const handleClick = useCallback(
-    (review: Review) => {
-      if (onReviewClick) {
-        onReviewClick(review);
-      }
-      push(
-        `${pathname}?lat=${review.latitude}&lng=${review.longitude}&zoom=17`,
-        { scroll: false }
-      );
-    },
-    [onReviewClick, push, pathname]
-  );
+  const handleClick = (review: Review) => {
+    if (onReviewClick) {
+      onReviewClick(review);
+    }
+    push(`${pathname}?lat=${review.latitude}&lng=${review.longitude}&zoom=17`, {
+      scroll: false
+    });
+  };
 
   // The rows carry their own padding, so the panel around this list has none
   // to give the empty state.

--- a/src/components/maps/MobileMapDrawer.tsx
+++ b/src/components/maps/MobileMapDrawer.tsx
@@ -7,7 +7,7 @@ import {
   SwipeableDrawer,
   Typography
 } from '@mui/material';
-import { memo, useCallback, useContext, useEffect, useState } from 'react';
+import { memo, useContext, useEffect, useState } from 'react';
 import type {
   AppMap,
   Chapter,
@@ -59,13 +59,13 @@ function MobileMapDrawer({
   const { setAppBarHidden } = useContext(ShellContext);
   const dictionary = useDictionary();
 
-  const handleOpen = useCallback(() => {
+  const handleOpen = () => {
     setOpen(true);
-  }, []);
+  };
 
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     setOpen(false);
-  }, []);
+  };
 
   // The review drawer overrides this drawer's open prop, so while it is open
   // this drawer is visually closed even when `open` is still true. Keep the
@@ -78,12 +78,9 @@ function MobileMapDrawer({
     return () => setAppBarHidden(false);
   }, [setAppBarHidden]);
 
-  const handleReviewClick = useCallback(
-    (review: Review) => {
-      onReviewClick(review);
-    },
-    [onReviewClick]
-  );
+  const handleReviewClick = (review: Review) => {
+    onReviewClick(review);
+  };
 
   return (
     <>

--- a/src/components/maps/PlaceAutocomplete.tsx
+++ b/src/components/maps/PlaceAutocomplete.tsx
@@ -1,13 +1,7 @@
 import { Search } from '@mui/icons-material';
 import { InputAdornment, TextField } from '@mui/material';
 import { useParams } from 'next/navigation';
-import {
-  type MutableRefObject,
-  memo,
-  useCallback,
-  useEffect,
-  useState
-} from 'react';
+import { type MutableRefObject, memo, useEffect, useState } from 'react';
 import { useGoogleMap } from '../../hooks/useGoogleMap';
 
 type Props = {
@@ -25,40 +19,36 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
   const [place, setPlace] = useState<google.maps.places.Place | null>(null);
   const [pac, setPac] = useState<google.maps.places.Autocomplete | null>(null);
 
-  const initPac = useCallback(async () => {
-    const { Autocomplete } = await loader.importLibrary('places');
-
-    const autocomplete = new Autocomplete(ref.current, {
-      fields: ['place_id', 'plus_code', 'name', 'formatted_address', 'geometry']
-    });
-
-    setPac(autocomplete);
-  }, [loader, ref]);
-
-  const handlePlaceChanged = useCallback(async () => {
-    const placeResult = pac.getPlace();
-
-    const { Place } = await loader.importLibrary('places');
-
-    const place = new Place({
-      id: placeResult.place_id,
-      requestedLanguage: lang
-    });
-
-    const data = await place.fetchFields({
-      fields: ['id', 'location', 'displayName', 'plusCode', 'formattedAddress']
-    });
-
-    setPlace(data.place);
-  }, [pac, loader, lang]);
-
   useEffect(() => {
     if (!pac) {
       return;
     }
 
+    const handlePlaceChanged = async () => {
+      const placeResult = pac.getPlace();
+
+      const { Place } = await loader.importLibrary('places');
+
+      const place = new Place({
+        id: placeResult.place_id,
+        requestedLanguage: lang
+      });
+
+      const data = await place.fetchFields({
+        fields: [
+          'id',
+          'location',
+          'displayName',
+          'plusCode',
+          'formattedAddress'
+        ]
+      });
+
+      setPlace(data.place);
+    };
+
     pac.addListener('place_changed', handlePlaceChanged);
-  }, [pac, handlePlaceChanged]);
+  }, [pac, loader, lang]);
 
   useEffect(() => {
     if (place) {
@@ -71,8 +61,24 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
       return;
     }
 
+    const initPac = async () => {
+      const { Autocomplete } = await loader.importLibrary('places');
+
+      const autocomplete = new Autocomplete(ref.current, {
+        fields: [
+          'place_id',
+          'plus_code',
+          'name',
+          'formatted_address',
+          'geometry'
+        ]
+      });
+
+      setPac(autocomplete);
+    };
+
     initPac();
-  }, [loader, initPac]);
+  }, [loader, ref]);
 
   return (
     <TextField

--- a/src/components/maps/PlaceAutocomplete.tsx
+++ b/src/components/maps/PlaceAutocomplete.tsx
@@ -72,23 +72,33 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
       return;
     }
 
+    let cancelled = false;
+
     const initPac = async () => {
       const { Autocomplete } = await loader.importLibrary('places');
 
-      const autocomplete = new Autocomplete(ref.current, {
-        fields: [
-          'place_id',
-          'plus_code',
-          'name',
-          'formatted_address',
-          'geometry'
-        ]
-      });
+      if (cancelled) {
+        return;
+      }
 
-      setPac(autocomplete);
+      setPac(
+        new Autocomplete(ref.current, {
+          fields: [
+            'place_id',
+            'plus_code',
+            'name',
+            'formatted_address',
+            'geometry'
+          ]
+        })
+      );
     };
 
     initPac();
+
+    return () => {
+      cancelled = true;
+    };
   }, [loader, ref]);
 
   return (

--- a/src/components/maps/PlaceAutocomplete.tsx
+++ b/src/components/maps/PlaceAutocomplete.tsx
@@ -24,6 +24,8 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
       return;
     }
 
+    let cancelled = false;
+
     const handlePlaceChanged = async () => {
       const placeResult = pac.getPlace();
 
@@ -44,10 +46,19 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
         ]
       });
 
+      if (cancelled) {
+        return;
+      }
+
       setPlace(data.place);
     };
 
-    pac.addListener('place_changed', handlePlaceChanged);
+    const listener = pac.addListener('place_changed', handlePlaceChanged);
+
+    return () => {
+      cancelled = true;
+      listener.remove();
+    };
   }, [pac, loader, lang]);
 
   useEffect(() => {

--- a/src/components/maps/PlaceInfoWindow.tsx
+++ b/src/components/maps/PlaceInfoWindow.tsx
@@ -1,6 +1,6 @@
 import { Add } from '@mui/icons-material';
 import { Box, Button, Typography } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 import InfoWindow from './InfoWindow';
 
@@ -21,15 +21,15 @@ function PlaceInfoWindow({
 
   const [infoWindowOpen, setInfoWindowOpen] = useState(false);
 
-  const handleCreateReviewClick = useCallback(() => {
+  const handleCreateReviewClick = () => {
     setInfoWindowOpen(false);
     onCreateReviewClick();
-  }, [onCreateReviewClick]);
+  };
 
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     setInfoWindowOpen(false);
     onClose();
-  }, [onClose]);
+  };
 
   useEffect(() => {
     if (place) {

--- a/src/components/maps/PositionForm.tsx
+++ b/src/components/maps/PositionForm.tsx
@@ -1,6 +1,6 @@
 import { Done, Edit } from '@mui/icons-material';
 import { Box, Button, Chip, Stack } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 import CoodinatesConverter from './CoodinatesConverter';
 import GoogleMaps from './GoogleMaps';
@@ -19,11 +19,11 @@ function PositionForm({ onChange, defaultValue }: Props) {
 
   const dictionary = useDictionary();
 
-  const handleSave = useCallback(() => {
+  const handleSave = () => {
     onChange(position);
 
     setEditPosition(false);
-  }, [position, onChange]);
+  };
 
   useEffect(() => {
     if (defaultValue) {

--- a/src/components/maps/PositionInfoWindow.tsx
+++ b/src/components/maps/PositionInfoWindow.tsx
@@ -7,7 +7,7 @@ import {
   ListItemIcon,
   ListItemText
 } from '@mui/material';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 import InfoWindow from './InfoWindow';
 
@@ -28,15 +28,15 @@ function PositionInfoWindow({
 
   const [infoWindowOpen, setInfoWindowOpen] = useState(false);
 
-  const handleCreateReviewClick = useCallback(() => {
+  const handleCreateReviewClick = () => {
     setInfoWindowOpen(false);
     onCreateReviewClick();
-  }, [onCreateReviewClick]);
+  };
 
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     setInfoWindowOpen(false);
     onClose();
-  }, [onClose]);
+  };
 
   useEffect(() => {
     if (position) {

--- a/src/components/maps/ReviewMarker.tsx
+++ b/src/components/maps/ReviewMarker.tsx
@@ -54,13 +54,23 @@ function ReviewMarker({ review, milestone, onClick }: Props) {
       return;
     }
 
+    let cancelled = false;
+
     const updatePosition = async () => {
       const { LatLng } = await loader.importLibrary('core');
+
+      if (cancelled) {
+        return;
+      }
 
       setPosition(new LatLng(review.latitude, review.longitude));
     };
 
     updatePosition();
+
+    return () => {
+      cancelled = true;
+    };
   }, [loader, review.latitude, review.longitude]);
 
   if (!position) {

--- a/src/components/maps/ReviewMarker.tsx
+++ b/src/components/maps/ReviewMarker.tsx
@@ -10,7 +10,6 @@ import {
 import {
   type MutableRefObject,
   memo,
-  useCallback,
   useEffect,
   useRef,
   useState
@@ -38,35 +37,31 @@ function ReviewMarker({ review, milestone, onClick }: Props) {
 
   const [open, setOpen] = useState(false);
 
-  const updatePosition = useCallback(async () => {
-    if (!loader) {
-      return;
-    }
-
-    const { LatLng } = await loader.importLibrary('core');
-
-    setPosition(new LatLng(review.latitude, review.longitude));
-  }, [loader, review]);
-
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     onClick(review, ref);
-  }, [review, onClick]);
+  };
 
-  const handleTooltipClose = useCallback(() => {
+  const handleTooltipClose = () => {
     setOpen(false);
-  }, []);
+  };
 
-  const handleTooltipOpen = useCallback(() => {
+  const handleTooltipOpen = () => {
     setOpen(true);
-  }, []);
+  };
 
   useEffect(() => {
     if (!loader) {
       return;
     }
 
+    const updatePosition = async () => {
+      const { LatLng } = await loader.importLibrary('core');
+
+      setPosition(new LatLng(review.latitude, review.longitude));
+    };
+
     updatePosition();
-  }, [loader, updatePosition]);
+  }, [loader, review.latitude, review.longitude]);
 
   if (!position) {
     return null;

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -13,7 +13,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { enUS, ja } from 'date-fns/locale';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useContext, useEffect, useRef, useState } from 'react';
 import type { Notification } from '../../../types';
 import { markNotificationAsRead } from '../../actions/notifications';
 import AuthContext from '../../context/AuthContext';
@@ -47,9 +47,8 @@ const NotificationList = ({
     setMounted(true);
   }, []);
 
-  const unreadNotifications = useMemo(
-    () => notifications.filter((notification) => !notification.read),
-    [notifications]
+  const unreadNotifications = notifications.filter(
+    (notification) => !notification.read
   );
 
   const didMarkRef = useRef(false);

--- a/src/components/notifications/NotificationsFeed.tsx
+++ b/src/components/notifications/NotificationsFeed.tsx
@@ -1,8 +1,6 @@
 'use client';
-
 import { List } from '@mui/material';
 import { useRouter } from 'next/navigation';
-import { useCallback } from 'react';
 import type { Notification } from '../../../types';
 import NotificationList from './NotificationList';
 
@@ -13,9 +11,9 @@ type Props = {
 export default function NotificationsFeed({ notifications }: Props) {
   const router = useRouter();
 
-  const handleReadNotifications = useCallback(() => {
+  const handleReadNotifications = () => {
     router.refresh();
-  }, [router]);
+  };
 
   return (
     <List>

--- a/src/components/profiles/BiographyForm.tsx
+++ b/src/components/profiles/BiographyForm.tsx
@@ -1,11 +1,5 @@
 import { TextField } from '@mui/material';
-import {
-  type ChangeEvent,
-  memo,
-  useCallback,
-  useEffect,
-  useState
-} from 'react';
+import { type ChangeEvent, memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 160;
@@ -21,24 +15,23 @@ function BiographyForm({ onChange, defaultValue }: Props) {
   const [biography, setBiography] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
 
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      const input = e.target.value;
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const input = e.target.value;
 
-      if (input) {
-        if (input.length > MAX_LENGTH) {
-          setError(dictionary['max characters 160']);
-        } else {
-          setError(undefined);
-        }
+    if (input) {
+      if (input.length > MAX_LENGTH) {
+        setError(dictionary['max characters 160']);
       } else {
-        setError(dictionary['biography is required']);
+        setError(undefined);
       }
+    } else {
+      setError(dictionary['biography is required']);
+    }
 
-      setBiography(input);
-    },
-    [dictionary]
-  );
+    setBiography(input);
+  };
 
   useEffect(() => {
     onChange(biography);

--- a/src/components/profiles/JournalTitleForm.tsx
+++ b/src/components/profiles/JournalTitleForm.tsx
@@ -1,11 +1,5 @@
 import { TextField } from '@mui/material';
-import {
-  type ChangeEvent,
-  memo,
-  useCallback,
-  useEffect,
-  useState
-} from 'react';
+import { type ChangeEvent, memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 50;
@@ -21,24 +15,21 @@ function JournalTitleForm({ onChange, defaultValue }: Props) {
   const [title, setTitle] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
 
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const input = e.target.value;
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const input = e.target.value;
 
-      if (input) {
-        if (input.length > MAX_LENGTH) {
-          setError(dictionary['max characters 50']);
-        } else {
-          setError(undefined);
-        }
+    if (input) {
+      if (input.length > MAX_LENGTH) {
+        setError(dictionary['max characters 50']);
       } else {
-        setError(dictionary['journal title required']);
+        setError(undefined);
       }
+    } else {
+      setError(dictionary['journal title required']);
+    }
 
-      setTitle(input);
-    },
-    [dictionary]
-  );
+    setTitle(input);
+  };
 
   // Reports undefined while invalid so the caller can block saving a title the
   // API would reject.

--- a/src/components/profiles/ProfileNameForm.tsx
+++ b/src/components/profiles/ProfileNameForm.tsx
@@ -1,11 +1,5 @@
 import { TextField } from '@mui/material';
-import {
-  type ChangeEvent,
-  memo,
-  useCallback,
-  useEffect,
-  useState
-} from 'react';
+import { type ChangeEvent, memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 30;
@@ -21,24 +15,23 @@ function ProfileNameForm({ onChange, defaultValue }: Props) {
   const [name, setName] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
 
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      const input = e.target.value;
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const input = e.target.value;
 
-      if (input) {
-        if (input.length > MAX_LENGTH) {
-          setError(dictionary['max characters 30']);
-        } else {
-          setError(undefined);
-        }
+    if (input) {
+      if (input.length > MAX_LENGTH) {
+        setError(dictionary['max characters 30']);
       } else {
-        setError(dictionary['name is required']);
+        setError(undefined);
       }
+    } else {
+      setError(dictionary['name is required']);
+    }
 
-      setName(input);
-    },
-    [dictionary]
-  );
+    setName(input);
+  };
 
   useEffect(() => {
     onChange(name);

--- a/src/components/profiles/UserChapters.tsx
+++ b/src/components/profiles/UserChapters.tsx
@@ -18,7 +18,7 @@ import {
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
-import { type MouseEvent, memo, useCallback, useState } from 'react';
+import { type MouseEvent, memo, useState } from 'react';
 import type { Chapter } from '../../../types';
 import { deleteChapter } from '../../actions/chapters';
 import useDictionary from '../../hooks/useDictionary';
@@ -45,22 +45,19 @@ function UserChapters({ chapters: initialChapters }: { chapters: Chapter[] }) {
   const [menuChapter, setMenuChapter] = useState<Chapter | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Chapter | null>(null);
 
-  const openMenu = useCallback(
-    (event: MouseEvent<HTMLElement>, chapter: Chapter) => {
-      setMenuAnchor(event.currentTarget);
-      setMenuChapter(chapter);
-    },
-    []
-  );
+  const openMenu = (event: MouseEvent<HTMLElement>, chapter: Chapter) => {
+    setMenuAnchor(event.currentTarget);
+    setMenuChapter(chapter);
+  };
 
-  const closeMenu = useCallback(() => setMenuAnchor(null), []);
+  const closeMenu = () => setMenuAnchor(null);
 
-  const handleDeleteClick = useCallback(() => {
+  const handleDeleteClick = () => {
     setDeleteTarget(menuChapter);
     closeMenu();
-  }, [menuChapter, closeMenu]);
+  };
 
-  const handleDeleteConfirm = useCallback(async () => {
+  const handleDeleteConfirm = async () => {
     if (!deleteTarget) {
       return;
     }
@@ -82,7 +79,7 @@ function UserChapters({ chapters: initialChapters }: { chapters: Chapter[] }) {
     setDeleteTarget(null);
     // The profile renders a server-fetched chapter count alongside this list.
     router.refresh();
-  }, [deleteTarget, dictionary, router]);
+  };
 
   if (chapters.length < 1) {
     return (

--- a/src/components/profiles/UserJourneys.tsx
+++ b/src/components/profiles/UserJourneys.tsx
@@ -17,7 +17,7 @@ import {
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
-import { type MouseEvent, memo, useCallback, useState } from 'react';
+import { type MouseEvent, memo, useState } from 'react';
 import type { JourneySummary } from '../../../types';
 import { deleteJourney } from '../../actions/journeys';
 import useDictionary from '../../hooks/useDictionary';
@@ -46,22 +46,22 @@ function UserJourneys({
   const [menuJourney, setMenuJourney] = useState<JourneySummary | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<JourneySummary | null>(null);
 
-  const openMenu = useCallback(
-    (event: MouseEvent<HTMLElement>, journey: JourneySummary) => {
-      setMenuAnchor(event.currentTarget);
-      setMenuJourney(journey);
-    },
-    []
-  );
+  const openMenu = (
+    event: MouseEvent<HTMLElement>,
+    journey: JourneySummary
+  ) => {
+    setMenuAnchor(event.currentTarget);
+    setMenuJourney(journey);
+  };
 
-  const closeMenu = useCallback(() => setMenuAnchor(null), []);
+  const closeMenu = () => setMenuAnchor(null);
 
-  const handleDeleteClick = useCallback(() => {
+  const handleDeleteClick = () => {
     setDeleteTarget(menuJourney);
     closeMenu();
-  }, [menuJourney, closeMenu]);
+  };
 
-  const handleDeleteConfirm = useCallback(async () => {
+  const handleDeleteConfirm = async () => {
     if (!deleteTarget) {
       return;
     }
@@ -82,7 +82,7 @@ function UserJourneys({
     });
     setDeleteTarget(null);
     router.refresh();
-  }, [deleteTarget, dictionary, router]);
+  };
 
   if (journeys.length < 1) {
     return (

--- a/src/components/profiles/UserProfile.tsx
+++ b/src/components/profiles/UserProfile.tsx
@@ -16,7 +16,6 @@ import {
   type SyntheticEvent,
   memo,
   startTransition,
-  useCallback,
   useContext,
   useState
 } from 'react';
@@ -55,18 +54,18 @@ function UserProfile({
 
   const isOwnProfile = uid === profile.uid;
 
-  const handleTabChange = useCallback(
-    (_event: SyntheticEvent<Element, Event>, newValue: string) => {
-      startTransition(() => {
-        setTabValue(newValue);
-      });
-    },
-    []
-  );
+  const handleTabChange = (
+    _event: SyntheticEvent<Element, Event>,
+    newValue: string
+  ) => {
+    startTransition(() => {
+      setTabValue(newValue);
+    });
+  };
 
-  const handleProfileSaved = useCallback(() => {
+  const handleProfileSaved = () => {
     router.refresh();
-  }, [router]);
+  };
 
   return (
     <>

--- a/src/components/profiles/UserReviews.tsx
+++ b/src/components/profiles/UserReviews.tsx
@@ -1,6 +1,6 @@
 import { Reviews } from '@mui/icons-material';
 import { Button, Stack } from '@mui/material';
-import { memo, useCallback, useState, useTransition } from 'react';
+import { memo, useState, useTransition } from 'react';
 import type { Review } from '../../../types';
 import {
   fetchMoreMyReviews,
@@ -28,7 +28,7 @@ export default memo(function UserReviews({
   const [noMoreResults, setNoMoreResults] = useState(initialReviews.length < 1);
   const [isPending, startTransition] = useTransition();
 
-  const loadMore = useCallback(() => {
+  const loadMore = () => {
     if (noMoreResults || isPending) return;
 
     const lastReview = reviews[reviews.length - 1];
@@ -44,7 +44,7 @@ export default memo(function UserReviews({
       setReviews((prev) => [...prev, ...moreReviews]);
       setNoMoreResults(moreReviews.length < 1);
     });
-  }, [userId, isOwnProfile, reviews, noMoreResults, isPending]);
+  };
 
   return (
     <>

--- a/src/components/reviews/CommentMenuButton.tsx
+++ b/src/components/reviews/CommentMenuButton.tsx
@@ -6,14 +6,7 @@ import {
   Menu,
   MenuItem
 } from '@mui/material';
-import {
-  memo,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import { memo, useContext, useRef, useState } from 'react';
 import type { Comment, Profile } from '../../../types';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
@@ -39,11 +32,9 @@ export default memo(function CommentMenuButton({
 
   const dictionary = useDictionary();
 
-  const isAuthor = useMemo(() => {
-    return currentProfile?.id === comment.author.id;
-  }, [comment, currentProfile]);
+  const isAuthor = currentProfile?.id === comment.author.id;
 
-  const handleReportClick = useCallback(() => {
+  const handleReportClick = () => {
     setAnchorEl(null);
 
     if (!authenticated) {
@@ -52,13 +43,13 @@ export default memo(function CommentMenuButton({
     }
 
     onReportClick(comment);
-  }, [authenticated, comment, onReportClick, setSignInRequired]);
+  };
 
-  const handleDeleteClick = useCallback(() => {
+  const handleDeleteClick = () => {
     setAnchorEl(null);
 
     onDeleteClick(comment);
-  }, [comment, onDeleteClick]);
+  };
 
   return (
     <>

--- a/src/components/reviews/ReviewComments.tsx
+++ b/src/components/reviews/ReviewComments.tsx
@@ -12,7 +12,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { enUS, ja } from 'date-fns/locale';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { memo, useCallback, useContext, useState } from 'react';
+import { memo, useContext, useState } from 'react';
 import type { Comment } from '../../../types';
 import ProfileContext from '../../context/ProfileContext';
 import useLocalePath from '../../hooks/useLocalePath';
@@ -36,15 +36,15 @@ const ReviewComments = ({ comments, onDeleted }: Props) => {
   const [issueDialogOpen, setIssueDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-  const handleDeleteClick = useCallback((comment: Comment) => {
+  const handleDeleteClick = (comment: Comment) => {
     setCurrentComment(comment);
     setDeleteDialogOpen(true);
-  }, []);
+  };
 
-  const handleReportClick = useCallback((comment: Comment) => {
+  const handleReportClick = (comment: Comment) => {
     setCurrentComment(comment);
     setIssueDialogOpen(true);
-  }, []);
+  };
 
   return (
     <>

--- a/src/components/reviews/ReviewDescriptionForm.tsx
+++ b/src/components/reviews/ReviewDescriptionForm.tsx
@@ -1,11 +1,5 @@
 import { TextField } from '@mui/material';
-import {
-  type ChangeEvent,
-  memo,
-  useCallback,
-  useEffect,
-  useState
-} from 'react';
+import { type ChangeEvent, memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 500;
@@ -21,24 +15,23 @@ function ReviewDescriptionForm({ onChange, defaultValue }: Props) {
   const [comment, setComment] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
 
-  const handleCommentChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      const input = e.target.value;
+  const handleCommentChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const input = e.target.value;
 
-      if (input) {
-        if (input.length > MAX_LENGTH) {
-          setError(dictionary['max characters 500']);
-        } else {
-          setError(null);
-        }
+    if (input) {
+      if (input.length > MAX_LENGTH) {
+        setError(dictionary['max characters 500']);
       } else {
-        setError(dictionary['comment is required']);
+        setError(null);
       }
+    } else {
+      setError(dictionary['comment is required']);
+    }
 
-      setComment(input);
-    },
-    [dictionary]
-  );
+    setComment(input);
+  };
 
   useEffect(() => {
     onChange(comment);

--- a/src/components/reviews/ReviewMenuButton.tsx
+++ b/src/components/reviews/ReviewMenuButton.tsx
@@ -16,14 +16,7 @@ import {
 } from '@mui/material';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar, useSnackbar } from 'notistack';
-import {
-  memo,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import { memo, useContext, useRef, useState } from 'react';
 import type { Profile, Review } from '../../../types';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
@@ -56,14 +49,12 @@ export default memo(function ReviewMenuButton({
   const { lang } = useParams<{ lang: string }>();
   const dictionary = useDictionary();
 
-  const isAuthor = useMemo(() => {
-    return currentProfile?.id === review?.author.id;
-  }, [review, currentProfile]);
+  const isAuthor = currentProfile?.id === review?.author.id;
 
   const reviewPath = `/maps/${review?.map.id}/reports/${review?.id}`;
   const url = `${SITE_ORIGIN}${localePath(lang, reviewPath)}`;
 
-  const handleCopyClick = useCallback(async () => {
+  const handleCopyClick = async () => {
     if (!url) {
       return;
     }
@@ -73,9 +64,9 @@ export default memo(function ReviewMenuButton({
     await navigator.clipboard.writeText(url);
 
     enqueueSnackbar(dictionary.copied);
-  }, [url, dictionary]);
+  };
 
-  const handleReportClick = useCallback(() => {
+  const handleReportClick = () => {
     setAnchorEl(null);
 
     if (!authenticated) {
@@ -84,25 +75,25 @@ export default memo(function ReviewMenuButton({
     }
 
     onReportClick(review);
-  }, [authenticated, review, onReportClick, setSignInRequired]);
+  };
 
-  const handleEditClick = useCallback(() => {
+  const handleEditClick = () => {
     setAnchorEl(null);
 
     onEditClick(review);
-  }, [review, onEditClick]);
+  };
 
-  const handleDeleteClick = useCallback(() => {
+  const handleDeleteClick = () => {
     setAnchorEl(null);
 
     onDeleteClick(review);
-  }, [review, onDeleteClick]);
+  };
 
-  const handleDetailClick = useCallback(() => {
+  const handleDetailClick = () => {
     setAnchorEl(null);
 
     push(localePath(lang, reviewPath));
-  }, [lang, reviewPath, push]);
+  };
 
   return (
     <>

--- a/src/components/reviews/ReviewNameForm.tsx
+++ b/src/components/reviews/ReviewNameForm.tsx
@@ -1,11 +1,5 @@
 import { TextField } from '@mui/material';
-import {
-  type ChangeEvent,
-  memo,
-  useCallback,
-  useEffect,
-  useState
-} from 'react';
+import { type ChangeEvent, memo, useEffect, useState } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 
 const MAX_LENGTH = 30;
@@ -21,24 +15,23 @@ function ReviewNameForm({ onChange, defaultValue }: Props) {
   const [name, setName] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
 
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      const input = e.target.value;
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const input = e.target.value;
 
-      if (input) {
-        if (input.length > MAX_LENGTH) {
-          setError(dictionary['max characters 30']);
-        } else {
-          setError(null);
-        }
+    if (input) {
+      if (input.length > MAX_LENGTH) {
+        setError(dictionary['max characters 30']);
       } else {
-        setError(dictionary['name is required']);
+        setError(null);
       }
+    } else {
+      setError(dictionary['name is required']);
+    }
 
-      setName(input);
-    },
-    [dictionary]
-  );
+    setName(input);
+  };
 
   useEffect(() => {
     onChange(name);

--- a/src/components/settings/DeleteAccountCard.tsx
+++ b/src/components/settings/DeleteAccountCard.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material';
 import { getAuth, signOut } from 'firebase/auth';
 import { useRouter } from 'next/navigation';
-import { memo, useCallback, useContext, useState } from 'react';
+import { memo, useContext, useState } from 'react';
 import AuthContext from '../../context/AuthContext';
 import useDictionary from '../../hooks/useDictionary';
 import useLocalePath from '../../hooks/useLocalePath';
@@ -24,12 +24,12 @@ function DeleteAccountCard() {
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-  const handleDeleted = useCallback(async () => {
+  const handleDeleted = async () => {
     const auth = getAuth();
     await signOut(auth);
 
     push(localePath('/login'));
-  }, [push, localePath]);
+  };
 
   return (
     <>

--- a/src/components/settings/UnlinkProviderDialog.tsx
+++ b/src/components/settings/UnlinkProviderDialog.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo } from 'react';
 import useDictionary from '../../hooks/useDictionary';
 import ConfirmDialog from '../common/ConfirmDialog';
 
@@ -11,10 +11,10 @@ type Props = {
 function UnlinkProviderDialog({ open, onClose, onUnlink }: Props) {
   const dictionary = useDictionary();
 
-  const handleConfirm = useCallback(async () => {
+  const handleConfirm = async () => {
     await onUnlink();
     onClose();
-  }, [onUnlink, onClose]);
+  };
 
   return (
     <ConfirmDialog

--- a/src/hooks/useLocalDateTime.ts
+++ b/src/hooks/useLocalDateTime.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useParams } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 // Rendered on the server before hydration, where the viewer's time zone is
 // unknown. A non-breaking space keeps the line height so the text appears
@@ -25,11 +25,8 @@ export default function useLocalDateTime() {
     setMounted(true);
   }, []);
 
-  return useCallback(
-    (value: string, options: Intl.DateTimeFormatOptions) =>
-      mounted
-        ? new Intl.DateTimeFormat(lang, options).format(new Date(value))
-        : LOCAL_DATE_TIME_PLACEHOLDER,
-    [mounted, lang]
-  );
+  return (value: string, options: Intl.DateTimeFormatOptions) =>
+    mounted
+      ? new Intl.DateTimeFormat(lang, options).format(new Date(value))
+      : LOCAL_DATE_TIME_PLACEHOLDER;
 }

--- a/src/hooks/useLocalePath.ts
+++ b/src/hooks/useLocalePath.ts
@@ -1,7 +1,5 @@
 'use client';
-
 import { useParams } from 'next/navigation';
-import { useCallback } from 'react';
 import { localePath } from '../utils/locales';
 
 /**
@@ -13,5 +11,5 @@ export default function useLocalePath() {
   const params = useParams<{ lang: string }>();
   const lang = params?.lang;
 
-  return useCallback((path = '') => localePath(lang, path), [lang]);
+  return (path = '') => localePath(lang, path);
 }

--- a/src/hooks/usePhotoUploads.ts
+++ b/src/hooks/usePhotoUploads.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useState } from 'react';
 import type { Image } from '../../types';
 import uploadImage from '../utils/uploadImage';
 
@@ -9,18 +9,13 @@ export type PhotoItem =
 export default function usePhotoUploads() {
   const [items, setItems] = useState<PhotoItem[]>([]);
 
-  const isUploading = useMemo(
-    () => items.some((item) => item.status === 'uploading'),
-    [items]
+  const isUploading = items.some((item) => item.status === 'uploading');
+
+  const uploadedImages = items.flatMap((item) =>
+    item.status === 'uploaded' ? [item.image] : []
   );
 
-  const uploadedImages = useMemo(
-    () =>
-      items.flatMap((item) => (item.status === 'uploaded' ? [item.image] : [])),
-    [items]
-  );
-
-  const upload = useCallback(async (dataUrls: string[]) => {
+  const upload = async (dataUrls: string[]) => {
     const pending = dataUrls.map((dataUrl) => ({
       key: crypto.randomUUID(),
       status: 'uploading' as const,
@@ -51,13 +46,13 @@ export default function usePhotoUploads() {
     if (failed) {
       throw new Error('Failed to upload one or more images');
     }
-  }, []);
+  };
 
-  const removeAt = useCallback((index: number) => {
+  const removeAt = (index: number) => {
     setItems((prevState) => prevState.filter((_item, i) => i !== index));
-  }, []);
+  };
 
-  const reset = useCallback((images: Image[] = []) => {
+  const reset = (images: Image[] = []) => {
     setItems(
       images.map((image) => ({
         key: crypto.randomUUID(),
@@ -65,7 +60,7 @@ export default function usePhotoUploads() {
         image
       }))
     );
-  }, []);
+  };
 
   return { items, isUploading, uploadedImages, upload, removeAt, reset };
 }

--- a/src/hooks/usePushManager.ts
+++ b/src/hooks/usePushManager.ts
@@ -1,5 +1,5 @@
 import { getMessaging, getToken } from 'firebase/messaging';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { registerDevice } from '../actions/devices';
 import AuthContext from '../context/AuthContext';
 
@@ -10,16 +10,16 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
 
   const [registrationToken, setRegistrationToken] = useState(null);
 
-  const subscribe = useCallback(async () => {
+  const subscribe = async () => {
     const sub = await registration.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: process.env.NEXT_PUBLIC_VAPID_KEY
     });
 
     setSubscription(sub);
-  }, [registration]);
+  };
 
-  const unsubscribe = useCallback(async () => {
+  const unsubscribe = async () => {
     if (!subscription || isLoading) {
       return false;
     }
@@ -36,7 +36,7 @@ export function usePushManager(registration: ServiceWorkerRegistration | null) {
     setRegistrationToken(null);
 
     return true;
-  }, [subscription, isLoading]);
+  };
 
   useEffect(() => {
     if (authenticated || isLoading || !subscription) {


### PR DESCRIPTION
# Summary

Removes `useCallback` and `useMemo` from the files the React Compiler processes without a single bailout, now that #1113 turned the compiler back on. This retries what the closed #1109 attempted, rebuilt from scratch against current `master` rather than reviving that branch.

Moving effect-only functions into their effects made each effect state the data it reads, which in turn made several of them re-run where they previously did not — so the same pass hardens every Google Maps effect in `src` against a superseded run resolving last.

# Motivation

With the compiler on, manual memoization duplicates work the build already does, and its dependency arrays are a source of staleness bugs the compiler derives instead.

# Changes

- Re-ran the compiler over `src` with the `babel-plugin-react-compiler` logger: 166 functions compile, 47 bailouts. Only the 65 files with zero bailouts that contained manual memoization were touched; bailed-out files keep their hooks since nothing else would memoize them
- A codemod unwrapped `useCallback`/`useMemo` in those files; four multi-statement `useMemo` bodies were inlined by hand as plain expressions
- Functions that only an effect consumed moved inside it, which also lets each effect state its real data dependencies — this cleared every resulting `useExhaustiveDependencies` warning without suppressions
- Every `memo()` wrapper stays: uncompiled parents still create fresh element props, so the wrappers still earn their keep
- `usePushManager`&#39;s `subscribe`/`unsubscribe` lose their `useCallback`, but the hook compiles cleanly, so the compiler keeps their identity stable for the (bailed-out) `PushNotificationsCard` that lists them in a dependency array

## Async effect cleanup

Every effect in `src` that awaits `loader.importLibrary` and then writes now cancels on cleanup, and every Google Maps listener is removed:

| File | What a superseded run could do |
| --- | --- |
| `CurrentPositionMarker`, `ReviewMarker` | overwrite the newer position with older coordinates |
| `CustomMapControls`, `CoodinatesConverter`, `JourneyFab` | place a control from the previous breakpoint |
| `InfoWindow` | build a second window over the one already stored |
| `JourneyMap` | fit the viewport to a stale set of points |
| `PlaceAutocomplete` | install a second `Autocomplete` over the input, and — before this — leave a `place_changed` listener live so one selection ran several handlers |
| `DraggableMarker` | stack a `dragend` listener each time the handler identity changed |

`JourneyMap`, `JourneyFab` and `DraggableMarker` were not part of the memoization diff; they carried the same defect and are fixed here rather than left for later.

# Testing

- `pnpm biome ci ./src` passes with zero warnings
- `pnpm exec tsc --noEmit` passes
- `pnpm build` succeeds; the compiler re-check confirms none of the touched files gained a bailout — the count holds at 47, and `DraggableMarker` bails for the reason it always did
- A script walks every `useEffect` in `src` and reports any that awaits and then writes without a cancellation flag; it now reports none
- A browser crawled 20 routes against a local production build — no uncaught exceptions, console errors or error-boundary hits

Coverage limits: no signed-in pages, no Google Maps runtime, no interaction. Since map components dominate this diff, the preview deployment deserves a pass over the map pages with the console open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i1gaN8w1tmSTK358C9Qhe

---
_Generated by [Claude Code](https://claude.ai/code/session_018i1gaN8w1tmSTK358C9Qhe)_