### PR TITLE
refactor: keep map objects out of React state

### DIFF
--- a/src/components/journeys/CheckinNoteField.tsx
+++ b/src/components/journeys/CheckinNoteField.tsx
@@ -20,7 +20,16 @@ function CheckinNoteField({ checkin, onSave }: Props) {
   const [revision, setRevision] = useState(0);
 
   const stateRef = useRef({ checkin, value, dirty: false, onSave });
-  stateRef.current = { ...stateRef.current, checkin, value, onSave };
+
+  // flush runs from a timer, a pagehide listener and unmount, so it reads the
+  // latest values through the ref rather than being rebuilt on every keystroke
+  // and re-arming both listeners with it. dirty is left alone because the
+  // change handler owns it.
+  useEffect(() => {
+    stateRef.current.checkin = checkin;
+    stateRef.current.value = value;
+    stateRef.current.onSave = onSave;
+  });
 
   const flush = useCallback(() => {
     const {

--- a/src/components/journeys/CheckinNoteField.tsx
+++ b/src/components/journeys/CheckinNoteField.tsx
@@ -23,11 +23,11 @@ function CheckinNoteField({ checkin, onSave }: Props) {
 
   // flush runs from a timer, a pagehide listener and unmount, so it reads the
   // latest values through the ref rather than being rebuilt on every keystroke
-  // and re-arming both listeners with it. dirty is left alone because the
-  // change handler owns it.
+  // and re-arming both listeners with it. The draft is not synced here: pagehide
+  // can fire between the keystroke and this effect, and flush would then save
+  // the previous draft and clear dirty with it.
   useEffect(() => {
     stateRef.current.checkin = checkin;
-    stateRef.current.value = value;
     stateRef.current.onSave = onSave;
   });
 
@@ -76,6 +76,7 @@ function CheckinNoteField({ checkin, onSave }: Props) {
       placeholder={dictionary['checkin note placeholder']}
       onChange={(event) => {
         setValue(event.target.value);
+        stateRef.current.value = event.target.value;
         stateRef.current.dirty = true;
         setRevision((current) => current + 1);
       }}

--- a/src/components/maps/DraggableMarker.tsx
+++ b/src/components/maps/DraggableMarker.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useGoogleMap } from '../../hooks/useGoogleMap';
 
 type Props = {
@@ -12,8 +12,13 @@ export default memo(function DraggableMarker({
 }: Props) {
   const { googleMap, loader } = useGoogleMap();
 
-  const [markerView, setMarkerView] =
-    useState<google.maps.marker.AdvancedMarkerElement | null>(null);
+  // The marker is an imperative map object that the effects below write to, so
+  // it is held in a ref rather than in state; the flag is what lets them run
+  // once it exists.
+  const markerRef = useRef<google.maps.marker.AdvancedMarkerElement | null>(
+    null
+  );
+  const [ready, setReady] = useState(false);
 
   const handleDragEnd = useCallback(
     ({ latLng }: google.maps.MapMouseEvent) => {
@@ -29,47 +34,66 @@ export default memo(function DraggableMarker({
     [onLatLngChanged]
   );
 
-  const initMarker = useCallback(async () => {
-    const { AdvancedMarkerElement } = await loader.importLibrary('marker');
-
-    setMarkerView(
-      new AdvancedMarkerElement({
-        map: googleMap,
-        gmpDraggable: true,
-        zIndex: 2
-      })
-    );
-  }, [googleMap, loader]);
-
   useEffect(() => {
-    if (!markerView) {
+    if (!googleMap || !loader) {
       return;
     }
 
-    const listener = markerView.addListener('dragend', handleDragEnd);
+    let cancelled = false;
+
+    const initMarker = async () => {
+      const { AdvancedMarkerElement } = await loader.importLibrary('marker');
+
+      if (cancelled) {
+        return;
+      }
+
+      markerRef.current = new AdvancedMarkerElement({
+        map: googleMap,
+        gmpDraggable: true,
+        zIndex: 2
+      });
+
+      setReady(true);
+    };
+
+    initMarker();
+
+    return () => {
+      cancelled = true;
+
+      if (markerRef.current) {
+        markerRef.current.map = null;
+        markerRef.current = null;
+      }
+
+      setReady(false);
+    };
+  }, [googleMap, loader]);
+
+  useEffect(() => {
+    const marker = markerRef.current;
+
+    if (!ready || !marker) {
+      return;
+    }
+
+    const listener = marker.addListener('dragend', handleDragEnd);
 
     return () => {
       listener.remove();
     };
-  }, [markerView, handleDragEnd]);
+  }, [ready, handleDragEnd]);
 
   useEffect(() => {
-    if (!markerView && googleMap && loader) {
-      initMarker();
+    const marker = markerRef.current;
+
+    if (!ready || !marker || !defaultPosition) {
+      return;
     }
 
-    return () => {
-      if (markerView) {
-        markerView.map = null;
-      }
-    };
-  }, [markerView, googleMap, loader, initMarker]);
-
-  useEffect(() => {
-    if (markerView && defaultPosition) {
-      markerView.position = defaultPosition;
-    }
-  }, [markerView, defaultPosition]);
+    marker.position = defaultPosition;
+  }, [ready, defaultPosition]);
 
   return null;
 });

--- a/src/components/maps/MapControl.tsx
+++ b/src/components/maps/MapControl.tsx
@@ -29,15 +29,19 @@ export default memo(function MapControl({
     };
   }, [googleMap, controlPosition, container]);
 
-  // The width is set on the element the map positions, so it has to go on the
-  // container itself. Building a fresh one keeps the element out of state that
-  // is later written to.
   useEffect(() => {
-    const div = document.createElement('div');
-    div.style.width = fullWidth ? '100%' : 'auto';
+    if (!container) {
+      const div = document.createElement('div');
 
-    setContainer(div);
-  }, [fullWidth]);
+      setContainer(div);
+    }
+  }, [container]);
+
+  useEffect(() => {
+    if (container) {
+      container.style.width = fullWidth ? '100%' : 'auto';
+    }
+  }, [container, fullWidth]);
 
   return container && createPortal(children, container);
 });

--- a/src/components/maps/MapControl.tsx
+++ b/src/components/maps/MapControl.tsx
@@ -29,19 +29,15 @@ export default memo(function MapControl({
     };
   }, [googleMap, controlPosition, container]);
 
+  // The width is set on the element the map positions, so it has to go on the
+  // container itself. Building a fresh one keeps the element out of state that
+  // is later written to.
   useEffect(() => {
-    if (!container) {
-      const div = document.createElement('div');
+    const div = document.createElement('div');
+    div.style.width = fullWidth ? '100%' : 'auto';
 
-      setContainer(div);
-    }
-  }, [container]);
-
-  useEffect(() => {
-    if (container) {
-      container.style.width = fullWidth ? '100%' : 'auto';
-    }
-  }, [container, fullWidth]);
+    setContainer(div);
+  }, [fullWidth]);
 
   return container && createPortal(children, container);
 });

--- a/src/components/maps/MarkerView.tsx
+++ b/src/components/maps/MarkerView.tsx
@@ -3,7 +3,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
-  useMemo,
+  useRef,
   useState
 } from 'react';
 import { createPortal } from 'react-dom';
@@ -25,12 +25,20 @@ export default memo(function MarkerView({
   onMouseLeave
 }: Props) {
   const { loader, googleMap } = useGoogleMap();
-  const [markerView, setMarkerView] =
-    useState<google.maps.marker.AdvancedMarkerElement | null>(null);
 
-  const content = useMemo<HTMLDivElement>(() => {
-    return document.createElement('div');
-  }, []);
+  // The marker is an imperative map object that the effects below write to, so
+  // it is held in a ref rather than in state; the flag is what lets them run
+  // once it exists.
+  const markerRef = useRef<google.maps.marker.AdvancedMarkerElement | null>(
+    null
+  );
+  const [ready, setReady] = useState(false);
+
+  // The marker holds this element, so the portal has to keep rendering into
+  // the same one. A lazy initial state guarantees that; useMemo does not.
+  const [content] = useState<HTMLDivElement>(() =>
+    document.createElement('div')
+  );
 
   const handleClick = useCallback(() => {
     if (!onClick) {
@@ -56,56 +64,75 @@ export default memo(function MarkerView({
     onMouseLeave();
   }, [onMouseLeave]);
 
-  const initMarker = useCallback(async () => {
-    const { AdvancedMarkerElement } = await loader.importLibrary('marker');
+  useEffect(() => {
+    if (!googleMap || !loader) {
+      return;
+    }
 
-    setMarkerView(
-      new AdvancedMarkerElement({
+    let cancelled = false;
+
+    const initMarker = async () => {
+      const { AdvancedMarkerElement } = await loader.importLibrary('marker');
+
+      if (cancelled) {
+        return;
+      }
+
+      const marker = new AdvancedMarkerElement({
         map: googleMap,
         content: content
-      })
-    );
-  }, [googleMap, content, loader]);
+      });
+
+      marker.element.style.cursor = 'pointer';
+      markerRef.current = marker;
+
+      setReady(true);
+    };
+
+    initMarker();
+
+    return () => {
+      cancelled = true;
+
+      if (markerRef.current) {
+        markerRef.current.map = null;
+        markerRef.current = null;
+      }
+
+      setReady(false);
+    };
+  }, [googleMap, loader, content]);
 
   useEffect(() => {
-    if (!markerView?.element) {
+    const element = markerRef.current?.element;
+
+    if (!ready || !element) {
       return;
     }
 
     // markerView.addListener でイベントを設定してしまうと
     // マーカー付近をタップしてのマップ移動操作を受け付けなくなってしまうため、
     // element に対して listener を設定する
-    markerView.element.addEventListener('click', handleClick);
-    markerView.element.addEventListener('mouseenter', handleMouseEnter);
-    markerView.element.addEventListener('mouseleave', handleMouseLeave);
-    markerView.element.style.cursor = 'pointer';
+    element.addEventListener('click', handleClick);
+    element.addEventListener('mouseenter', handleMouseEnter);
+    element.addEventListener('mouseleave', handleMouseLeave);
 
     return () => {
-      if (markerView?.element) {
-        markerView.element.removeEventListener('click', handleClick);
-        markerView.element.removeEventListener('mouseenter', handleMouseEnter);
-        markerView.element.removeEventListener('mouseleave', handleMouseLeave);
-      }
+      element.removeEventListener('click', handleClick);
+      element.removeEventListener('mouseenter', handleMouseEnter);
+      element.removeEventListener('mouseleave', handleMouseLeave);
     };
-  }, [markerView, handleClick, handleMouseEnter, handleMouseLeave]);
+  }, [ready, handleClick, handleMouseEnter, handleMouseLeave]);
 
   useEffect(() => {
-    if (!markerView && googleMap && loader) {
-      initMarker();
+    const marker = markerRef.current;
+
+    if (!ready || !marker || !position) {
+      return;
     }
 
-    return () => {
-      if (markerView) {
-        markerView.map = null;
-      }
-    };
-  }, [markerView, googleMap, loader, initMarker]);
-
-  useEffect(() => {
-    if (markerView && position) {
-      markerView.position = position;
-    }
-  }, [markerView, position]);
+    marker.position = position;
+  }, [ready, position]);
 
   return createPortal(children, content);
 });

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,10 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+// Layout effects run in the commit phase, so a value published from one is in
+// place before anything the browser schedules afterwards can read it — which a
+// passive effect cannot promise. There is no commit phase on the server, where
+// useLayoutEffect only warns, so the server falls back to useEffect.
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+export default useIsomorphicLayoutEffect;

--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -34,6 +34,7 @@ import {
   saveTrail
 } from '../utils/journeyTrailStorage';
 import { encodePath } from '../utils/polyline';
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
 const CHECKIN_RADIUS_METERS = 50;
 const PATH_MIN_DISTANCE_METERS = 10;
@@ -150,8 +151,10 @@ export default function useJourney({
 
   // The check-in path runs from geolocation callbacks rather than from a
   // render, so it reads the list through a ref instead of taking a dependency
-  // on it and re-registering the watch every time the list changes.
-  useEffect(() => {
+  // on it and re-registering the watch every time the list changes. A fix that
+  // arrived between the commit and a passive effect would read the previous
+  // list, so the write happens in the commit phase.
+  useIsomorphicLayoutEffect(() => {
     reviewsRef.current = reviews;
   }, [reviews]);
 

--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -147,7 +147,13 @@ export default function useJourney({
   const lastPositionAtRef = useRef<number | null>(null);
 
   const reviewsRef = useRef(reviews);
-  reviewsRef.current = reviews;
+
+  // The check-in path runs from geolocation callbacks rather than from a
+  // render, so it reads the list through a ref instead of taking a dependency
+  // on it and re-registering the watch every time the list changes.
+  useEffect(() => {
+    reviewsRef.current = reviews;
+  }, [reviews]);
 
   const pendingCheckinsRef = useRef(new Set<number>());
 


### PR DESCRIPTION
# Summary

Clears seven of the nine Rules of React violations the React Compiler was reporting: refs written during render, and Google Maps objects held in state and then written to. Compiler coverage goes from 166 compiled functions and 49 bailouts to 170 and 42.

# Motivation

The compiler was enabled without touching what it could not compile. Running `babel-plugin-react-compiler` over `src` with a logger sorts those bailouts into two groups: limitations in the compiler itself, and code that breaks the Rules of React. This PR takes the second group.

Nine bailouts fell into it — four `Cannot access refs during render`, five `This value cannot be modified`. Both patterns are wrong independently of the compiler. Writing a ref from the render body makes rendering non-repeatable, which React relies on being able to do. Writing to a value held in state means the stored object and what React believes it holds drift apart.

The remaining bailouts are the compiler's own gaps — 37 of them are `try`/`catch` forms it does not lower yet — and are left alone rather than having error handling reshaped to suit it.

# Changes

- `useJourney` and `CheckinNoteField` stop writing their latest-value refs from the render body. Both callbacks read those refs from somewhere the browser schedules — a timer, a `pagehide` listener, unmount, or a geolocation callback — so each write now lands where nothing can read past it: `CheckinNoteField` records the draft in the change handler that marks it dirty, and `useJourney` publishes its review list from the commit phase through a new `useIsomorphicLayoutEffect`.
- `MarkerView` and `DraggableMarker` hold the `AdvancedMarkerElement` in a ref rather than state, with a flag gating the effects that drive it. The marker also sets its cursor where it is created instead of from a later effect.
- `MarkerView` moves its portal element from `useMemo` to a lazy initial state. `useMemo` may drop its cache and return a second element, which the marker would not be holding — leaving the children rendering into a node that is no longer on the map.

# What this PR does not change

Two bailouts stay, both `This value cannot be modified`.

**`MapControl`** restyles its container element, which is held in state. Building a fresh container instead hands `createPortal` a different node, and React responds by remounting the portal children. `CustomMapControls` derives `fullWidth` from `useMediaQuery(theme.breakpoints.down('md'))`, so that would throw away whatever had been typed into the place search, along with the Google Autocomplete instance attached to that input, every time the breakpoint is crossed. Compiler coverage is not worth a search box that empties itself when a phone is rotated.

**`GoogleMaps`** assigns `loader.options.language`. The obvious fix — passing `language` to the constructor — is wrong here: `Loader` is a module-level singleton that throws when constructed again with different options.

```js
// @googlemaps/js-api-loader/dist/index.mjs:167
if (Loader.instance) {
  if (!isEqual(this.options, Loader.instance.options)) {
    throw new Error(`Loader must not be called again with different options. ...`);
  }
```

Constructing with the locale therefore throws on a client-side locale switch, and again on the server, where `GoogleMaps` renders for every request and the singleton is shared across them.

Separately, four files newly compile and still carry 26 manual `useCallback`/`useMemo` calls (`CheckinNoteField`, `DraggableMarker`, `MarkerView`, `useJourney`). Removing them belongs in its own change — `MarkerView` and `DraggableMarker` were just restructured, and stacking a memoization change onto the same functions would make a regression impossible to bisect.

# Testing

- `pnpm biome ci ./src biome.json` passes
- `pnpm exec tsc --noEmit` passes
- `pnpm build` succeeds
- Compiler coverage re-measured over all of `src`: 170 compiled, 42 bailouts, and no `Cannot access refs during render` remaining
- A browser crawled 21 routes against a local production build, watching for uncaught exceptions, non-network console errors and the error boundary. One early run reported 2 findings whose detail was lost to truncated output; five later runs, including one from a cold server start, reported none. They are unexplained rather than dismissed.

**The map itself is not covered by any of the above.** The build environment cannot reach Google's servers from a browser — every external HTTPS request resets, `example.com` included — so the Maps script never loads and no marker is ever constructed. The crawl only shows that the pages survive without the Maps API. These need checking on a deployment that can load it:

1. markers appear on a map detail page
2. marker click and hover both work
3. the draggable marker moves and reports its coordinates when creating a review
4. the map controls render, and the place search keeps its text across the `md` breakpoint