### PR TITLE
refactor: let the compiler memoize useJourney

### DIFF
--- a/src/components/maps/MarkerView.tsx
+++ b/src/components/maps/MarkerView.tsx
@@ -36,9 +36,12 @@ export default memo(function MarkerView({
 
   // The marker holds this element, so the portal has to keep rendering into
   // the same one. A lazy initial state guarantees that; useMemo does not.
-  const [content] = useState<HTMLDivElement>(() =>
-    document.createElement('div')
-  );
+  const [content] = useState<HTMLDivElement>(() => {
+    const element = document.createElement('div');
+    element.style.cursor = 'pointer';
+
+    return element;
+  });
 
   const handleClick = useCallback(() => {
     if (!onClick) {
@@ -109,7 +112,6 @@ export default memo(function MarkerView({
     content.addEventListener('click', handleClick);
     content.addEventListener('mouseenter', handleMouseEnter);
     content.addEventListener('mouseleave', handleMouseLeave);
-    content.style.cursor = 'pointer';
 
     return () => {
       content.removeEventListener('click', handleClick);

--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -280,36 +280,33 @@ export default function useJourney({
     );
   }, []);
 
-  const attachCheckinImage = useCallback(
-    async (checkin: JourneyCheckin, image: Image) => {
-      const latest = findLatestCheckin(checkin);
+  const attachCheckinImage = async (checkin: JourneyCheckin, image: Image) => {
+    const latest = findLatestCheckin(checkin);
 
-      await mutateCheckin(checkin, {
-        image_ids: [...latest.images.map((existing) => existing.id), image.id]
-      });
-    },
-    [findLatestCheckin, mutateCheckin]
-  );
+    await mutateCheckin(checkin, {
+      image_ids: [...latest.images.map((existing) => existing.id), image.id]
+    });
+  };
 
-  const removeCheckinImage = useCallback(
-    (checkin: JourneyCheckin, imageId: number): Promise<boolean> => {
-      const latest = findLatestCheckin(checkin);
+  const removeCheckinImage = (
+    checkin: JourneyCheckin,
+    imageId: number
+  ): Promise<boolean> => {
+    const latest = findLatestCheckin(checkin);
 
-      return mutateCheckin(checkin, {
-        image_ids: latest.images
-          .filter((existing) => existing.id !== imageId)
-          .map((existing) => existing.id)
-      });
-    },
-    [findLatestCheckin, mutateCheckin]
-  );
+    return mutateCheckin(checkin, {
+      image_ids: latest.images
+        .filter((existing) => existing.id !== imageId)
+        .map((existing) => existing.id)
+    });
+  };
 
-  const updateCheckinNote = useCallback(
-    async (checkin: JourneyCheckin, note: string | null) => {
-      await mutateCheckin(checkin, { note });
-    },
-    [mutateCheckin]
-  );
+  const updateCheckinNote = async (
+    checkin: JourneyCheckin,
+    note: string | null
+  ) => {
+    await mutateCheckin(checkin, { note });
+  };
 
   const performCheckin = useCallback(
     async (review: Review) => {
@@ -637,11 +634,11 @@ export default function useJourney({
       });
     }, []);
 
-  const pause = useCallback(() => commitPaused(true), [commitPaused]);
+  const pause = () => commitPaused(true);
 
   // Asking here rather than letting the watch ask keeps a refused resume from
   // reporting success and bouncing straight back to paused.
-  const resume = useCallback(async (): Promise<boolean> => {
+  const resume = async (): Promise<boolean> => {
     const position = await requestPosition();
 
     if (!position) {
@@ -652,7 +649,7 @@ export default function useJourney({
     handlePosition(position);
 
     return true;
-  }, [requestPosition, commitPaused, handlePosition]);
+  };
 
   const ensureJourney = useCallback(async (): Promise<Journey | null> => {
     const current = journeyRef.current;
@@ -673,57 +670,47 @@ export default function useJourney({
     return data;
   }, [map.id, commitJourney, onError]);
 
-  const addMilestone = useCallback(
-    async (review: Review): Promise<boolean> => {
-      if (!authenticated || !uid) {
-        setSignInRequired(true);
-        return false;
-      }
+  const addMilestone = async (review: Review): Promise<boolean> => {
+    if (!authenticated || !uid) {
+      setSignInRequired(true);
+      return false;
+    }
 
-      const current = await ensureJourney();
+    const current = await ensureJourney();
 
-      if (!current) {
-        return false;
-      }
+    if (!current) {
+      return false;
+    }
 
-      if (
-        current.milestones.some((existing) => existing.review_id === review.id)
-      ) {
-        return true;
-      }
-
-      const { success, data, error } = await addMilestoneAction(
-        current.id,
-        review.id
-      );
-
-      if (!success || !data) {
-        onError(error);
-        return false;
-      }
-
-      const latest = journeyRef.current;
-
-      if (!latest || latest.id !== current.id) {
-        return false;
-      }
-
-      commitJourney({ ...latest, milestones: [...latest.milestones, data] });
+    if (
+      current.milestones.some((existing) => existing.review_id === review.id)
+    ) {
       return true;
-    },
-    [
-      authenticated,
-      uid,
-      setSignInRequired,
-      ensureJourney,
-      commitJourney,
-      onError
-    ]
-  );
+    }
+
+    const { success, data, error } = await addMilestoneAction(
+      current.id,
+      review.id
+    );
+
+    if (!success || !data) {
+      onError(error);
+      return false;
+    }
+
+    const latest = journeyRef.current;
+
+    if (!latest || latest.id !== current.id) {
+      return false;
+    }
+
+    commitJourney({ ...latest, milestones: [...latest.milestones, data] });
+    return true;
+  };
 
   // The permission prompt belongs to this tap rather than to the watch that
   // follows, so a refused journey never reaches the started state.
-  const start = useCallback(async (): Promise<boolean> => {
+  const start = async (): Promise<boolean> => {
     if (!uid) {
       return false;
     }
@@ -752,93 +739,75 @@ export default function useJourney({
 
     onError(error);
     return false;
-  }, [
-    uid,
-    requestPosition,
-    ensureJourney,
-    commitJourney,
-    commitPaused,
-    handlePosition,
-    onLocationError,
-    onError
-  ]);
+  };
 
-  const removeMilestone = useCallback(
-    async (milestone: Milestone) => {
-      const current = journeyRef.current;
+  const removeMilestone = async (milestone: Milestone) => {
+    const current = journeyRef.current;
 
-      if (!uid || !current) {
-        return;
-      }
+    if (!uid || !current) {
+      return;
+    }
 
-      const { success, error } = await removeMilestoneAction(
-        current.id,
-        milestone.id
-      );
+    const { success, error } = await removeMilestoneAction(
+      current.id,
+      milestone.id
+    );
 
-      if (!success) {
-        onError(error);
-        return;
-      }
+    if (!success) {
+      onError(error);
+      return;
+    }
 
-      const latest = journeyRef.current;
+    const latest = journeyRef.current;
 
-      if (!latest || latest.id !== current.id) {
-        return;
-      }
+    if (!latest || latest.id !== current.id) {
+      return;
+    }
 
-      const milestones = latest.milestones.filter(
-        (existing) => existing.id !== milestone.id
-      );
+    const milestones = latest.milestones.filter(
+      (existing) => existing.id !== milestone.id
+    );
 
-      if (
-        !latest.started_at &&
-        milestones.length < 1 &&
-        latest.checkins.length < 1
-      ) {
-        deleteJourney(latest.id);
-        commitJourney(null);
-        return;
-      }
+    if (
+      !latest.started_at &&
+      milestones.length < 1 &&
+      latest.checkins.length < 1
+    ) {
+      deleteJourney(latest.id);
+      commitJourney(null);
+      return;
+    }
 
-      commitJourney({ ...latest, milestones });
-    },
-    [uid, commitJourney, onError]
-  );
+    commitJourney({ ...latest, milestones });
+  };
 
-  const removeCheckin = useCallback(
-    async (target: JourneyCheckin) => {
-      const current = journeyRef.current;
+  const removeCheckin = async (target: JourneyCheckin) => {
+    const current = journeyRef.current;
 
-      if (!uid || !current) {
-        return;
-      }
+    if (!uid || !current) {
+      return;
+    }
 
-      const { success, error } = await removeCheckinAction(
-        current.id,
-        target.id
-      );
+    const { success, error } = await removeCheckinAction(current.id, target.id);
 
-      if (!success) {
-        onError(error);
-        return;
-      }
+    if (!success) {
+      onError(error);
+      return;
+    }
 
-      const latest = journeyRef.current;
+    const latest = journeyRef.current;
 
-      if (!latest || latest.id !== current.id) {
-        return;
-      }
+    if (!latest || latest.id !== current.id) {
+      return;
+    }
 
-      commitJourney({
-        ...latest,
-        checkins: latest.checkins.filter((checkin) => checkin.id !== target.id)
-      });
-    },
-    [uid, commitJourney, onError]
-  );
+    commitJourney({
+      ...latest,
+      checkins: latest.checkins.filter((checkin) => checkin.id !== target.id)
+    });
+  };
 
-  const end = useCallback(async (): Promise<FinishedJourney | null> => {
+  const end = async (): Promise<FinishedJourney | null> => {
     const current = journeyRef.current;
 
     if (!uid || !current) {
@@ -870,7 +839,7 @@ export default function useJourney({
     sampleIntervalRef.current = MOVING_SAMPLE_MIN_INTERVAL_MS;
 
     return { journey: data, trail: points };
-  }, [uid, commitJourney, onError]);
+  };
 
   return {
     journey,


### PR DESCRIPTION
# Summary

Drops ten `useCallback` wrappers from `useJourney` that only restate what the React Compiler already emits, and puts `MarkerView` back on the compiled list after a write to state crept back into it. Compiler coverage goes from 169 compiled functions and 44 bailouts to 170 and 43.

# Motivation

`52e6c60` removed the manual memoization the compiler had taken over, but only from the files it could compile at the time. Four files joined that set afterwards and kept their wrappers. This clears the ones that can be cleared.

`MarkerView` needs the second change first. `e4e80f8` moved the marker's listeners onto the content element and assigned `content.style.cursor` from that effect — but `content` is held in state, so writing to it is the same violation `119da0f` had already removed from this component, and the compiler stopped compiling it again:

```
MarkerView.tsx:112  This value cannot be modified
  `content` cannot be modified
```

The cursor never changes, so it belongs on the element where the element is built.

# Changes

- Build the marker's content element with its cursor already set, instead of assigning it from the listener effect
- Unwrap the ten `useCallback`s `useJourney` hands back to its callers: `start`, `end`, `pause`, `resume`, `addMilestone`, `removeMilestone`, `removeCheckin`, `attachCheckinImage`, `removeCheckinImage`, `updateCheckinNote`

The compiler caches each one on the same values the dependency array listed, so the identities hold exactly as before:

```js
if ($[51] !== commitPaused) {      // was useCallback(..., [commitPaused])
  t26 = () => commitPaused(true);
  $[51] = commitPaused;
  $[52] = t26;
} else {
  t26 = $[52];
}
const pause = t26;
```

# Why sixteen wrappers stay

Sixteen remain — eleven inside `useJourney`, plus `handleClick`/`handleMouseEnter`/`handleMouseLeave` in `MarkerView`, `handleDragEnd` in `DraggableMarker` and `flush` in `CheckinNoteField`. Every one of them appears in a dependency array written by hand, and `useExhaustiveDependencies` does not know the compiler exists: unwrapping the five in those three components produced six warnings telling us to wrap them in `useCallback` again.

Turning the rule off is not the answer, because the compiler does not repair dependency arrays. Compiling an effect whose array is missing a dependency leaves the array exactly as written:

```js
// source: useEffect(() => { ...step... }, [])
if ($[0] !== step) {          // the callback is memoized on step
  t1 = () => { ... };
}
if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
  t2 = [];                    // the dependency array is still empty
}
useEffect(t1, t2);
```

The stale closure survives. Since `b088059` retired ESLint, this rule is the only thing in the repository that catches a missing dependency, and its options (`hooks`, `stableResult`) offer no way to keep that check while dropping the demand for `useCallback`. Sixteen redundant wrappers are the cheaper of the two costs.

# Testing

- `pnpm biome ci ./src biome.json` passes with no errors and no warnings
- `pnpm exec tsc --noEmit` passes
- `pnpm build` succeeds
- Compiler coverage re-measured over all of `src`: 170 compiled, 43 bailouts, and `MarkerView` compiles again
- The emitted output for `useJourney` was read back to confirm each unwrapped callback is cached on the values its dependency array had listed

No runtime check covers the journey recording flow or the map. The build environment cannot reach Google's servers from a browser, so no marker is ever constructed here, and the journey callbacks need a signed-in session with geolocation. Worth exercising on a deployment: starting and ending a journey, pausing and resuming it, adding and removing a milestone, editing a check-in note and its images, and that markers still respond to click and hover.


---
_Generated by [Claude Code](https://claude.ai/code/session_018i1gaN8w1tmSTK358C9Qhe)_