### PR TITLE
test: add node:test unit tests for utils

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -28,3 +28,6 @@ jobs:
       - name: Type check
         run: |
           pnpm typecheck
+      - name: Test
+        run: |
+          pnpm test

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,6 +1,5 @@
 name: Dev
 on:
-  workflow_dispatch:
   pull_request:
     types:
       - opened

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,5 +1,6 @@
 name: Dev
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - opened

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,8 @@
       },
       "correctness": {
         "useExhaustiveDependencies": "warn",
-        "useHookAtTopLevel": "error"
+        "useHookAtTopLevel": "error",
+        "useImportExtensions": "error"
       },
       "security": {
         "noDangerouslySetInnerHtml": "warn"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "next start",
     "lint": "biome ci ./src",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test \"src/**/*.test.ts\"",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test \"src/**/*.test.ts\"",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "deploy:dev": "opennextjs-cloudflare build --env dev && opennextjs-cloudflare deploy --env dev",
@@ -65,7 +65,6 @@
     "@types/react-dom": "^19.2.4",
     "babel-plugin-react-compiler": "^1.0.0",
     "serwist": "^9.2.1",
-    "tsx": "^4.23.12",
     "typescript": "^5.2.2",
     "wrangler": "^4.114.0"
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "next start",
     "lint": "biome ci ./src",
     "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "deploy:dev": "opennextjs-cloudflare build --env dev && opennextjs-cloudflare deploy --env dev",
@@ -64,6 +65,7 @@
     "@types/react-dom": "^19.2.4",
     "babel-plugin-react-compiler": "^1.0.0",
     "serwist": "^9.2.1",
+    "tsx": "^4.23.12",
     "typescript": "^5.2.2",
     "wrangler": "^4.114.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ importers:
       serwist:
         specifier: ^9.2.1
         version: 9.2.1(typescript@5.9.2)
-      tsx:
-        specifier: ^4.23.12
-        version: 4.23.12
       typescript:
         specifier: ^5.2.2
         version: 5.9.2
@@ -3552,11 +3549,6 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tsx@4.23.12:
-    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -7643,12 +7635,6 @@ snapshots:
   ts-tqdm@0.8.6: {}
 
   tslib@2.8.1: {}
-
-  tsx@4.23.12:
-    dependencies:
-      esbuild: 0.28.1
-    optionalDependencies:
-      fsevents: 2.3.3
 
   type-is@2.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       serwist:
         specifier: ^9.2.1
         version: 9.2.1(typescript@5.9.2)
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: ^5.2.2
         version: 5.9.2
@@ -3549,6 +3552,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -7635,6 +7643,12 @@ snapshots:
   ts-tqdm@0.8.6: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-is@2.1.0:
     dependencies:

--- a/src/actions/chapterLikes.ts
+++ b/src/actions/chapterLikes.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { apiFetch } from '../lib/api';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult = {
   success: boolean;

--- a/src/actions/chapters.ts
+++ b/src/actions/chapters.ts
@@ -1,8 +1,8 @@
 'use server';
 
 import type { SerializedEditorState } from 'lexical';
-import type { Chapter, MapFeatureCollection } from '../../types';
-import { apiFetch } from '../lib/api';
+import type { Chapter, MapFeatureCollection } from '../../types/index.ts';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult<T = null> = {
   success: boolean;

--- a/src/actions/coauthors.ts
+++ b/src/actions/coauthors.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import type { UserSearchResult } from '../../types';
-import { apiFetch } from '../lib/api';
+import type { UserSearchResult } from '../../types/index.ts';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult = {
   success: boolean;

--- a/src/actions/comments.ts
+++ b/src/actions/comments.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { apiFetch } from '../lib/api';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult = {
   success: boolean;

--- a/src/actions/devices.ts
+++ b/src/actions/devices.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { apiFetch } from '../lib/api';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult = {
   success: boolean;

--- a/src/actions/issues.ts
+++ b/src/actions/issues.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { apiFetch } from '../lib/api';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult = {
   success: boolean;

--- a/src/actions/journalBookmarks.ts
+++ b/src/actions/journalBookmarks.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { apiFetch } from '../lib/api';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult = {
   success: boolean;

--- a/src/actions/journals.ts
+++ b/src/actions/journals.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import type { Journal } from '../../types';
-import { apiFetch } from '../lib/api';
+import type { Journal } from '../../types/index.ts';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult<T = null> = {
   success: boolean;

--- a/src/actions/journeys.ts
+++ b/src/actions/journeys.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import type { Journey, JourneyCheckin, Milestone } from '../../types';
-import { apiFetch } from '../lib/api';
+import type { Journey, JourneyCheckin, Milestone } from '../../types/index.ts';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult<T = null> = {
   success: boolean;

--- a/src/actions/mapBookmarks.ts
+++ b/src/actions/mapBookmarks.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { apiFetch } from '../lib/api';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult = {
   success: boolean;

--- a/src/actions/maps.ts
+++ b/src/actions/maps.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import type { AppMap } from '../../types';
-import { apiFetch } from '../lib/api';
+import type { AppMap } from '../../types/index.ts';
+import { apiFetch } from '../lib/api.ts';
 
 type CreateMapParams = {
   name: string;

--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { apiFetch } from '../lib/api';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult = {
   success: boolean;

--- a/src/actions/reviewLikes.ts
+++ b/src/actions/reviewLikes.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { apiFetch } from '../lib/api';
+import { apiFetch } from '../lib/api.ts';
 
 type ActionResult = {
   success: boolean;

--- a/src/actions/reviews.ts
+++ b/src/actions/reviews.ts
@@ -1,9 +1,9 @@
 'use server';
 
-import type { Review } from '../../types';
-import { apiFetch } from '../lib/api';
-import { getTimelineReviews } from '../lib/reviews';
-import { getMyReviews, getUserReviews } from '../lib/users';
+import type { Review } from '../../types/index.ts';
+import { apiFetch } from '../lib/api.ts';
+import { getTimelineReviews } from '../lib/reviews.ts';
+import { getMyReviews, getUserReviews } from '../lib/users.ts';
 
 export async function fetchMoreTimelineReviews(
   nextTimestamp: string

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import type { Profile } from '../../types';
-import { apiFetch } from '../lib/api';
+import type { Profile } from '../../types/index.ts';
+import { apiFetch } from '../lib/api.ts';
 
 type UpdateProfileParams = {
   name: string;

--- a/src/app/[lang]/(contained)/(home)/page.tsx
+++ b/src/app/[lang]/(contained)/(home)/page.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from 'next';
-import Timeline from '../../../../components/home/Timeline';
-import TrendingReviews from '../../../../components/home/TrendingReviews';
-import { getServerAuthState } from '../../../../lib/auth';
-import { getPopularReviews, getTimelineReviews } from '../../../../lib/reviews';
-import { getDictionary } from '../../../../utils/getDictionary';
-import { localePath } from '../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
+import Timeline from '../../../../components/home/Timeline.tsx';
+import TrendingReviews from '../../../../components/home/TrendingReviews.tsx';
+import { getServerAuthState } from '../../../../lib/auth.ts';
+import {
+  getPopularReviews,
+  getTimelineReviews
+} from '../../../../lib/reviews.ts';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
+import { localePath } from '../../../../utils/locales.ts';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/assets/page.tsx
+++ b/src/app/[lang]/(contained)/assets/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
-import AssetGenerator from '../../../../components/assets/AssetGenerator';
-import { getDictionary } from '../../../../utils/getDictionary';
-import { localePath } from '../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
+import AssetGenerator from '../../../../components/assets/AssetGenerator.tsx';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
+import { localePath } from '../../../../utils/locales.ts';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/bookmarks/page.tsx
+++ b/src/app/[lang]/(contained)/bookmarks/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import BookmarksView from '../../../../components/bookmarks/BookmarksView';
-import { getServerAuthState } from '../../../../lib/auth';
+import BookmarksView from '../../../../components/bookmarks/BookmarksView.tsx';
+import { getServerAuthState } from '../../../../lib/auth.ts';
 import {
   getBookmarkedJournals,
   getBookmarkedMaps
-} from '../../../../lib/users';
-import { getDictionary } from '../../../../utils/getDictionary';
+} from '../../../../lib/users.ts';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/chapters/[chapterId]/edit/page.tsx
+++ b/src/app/[lang]/(contained)/chapters/[chapterId]/edit/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import ChapterEditor from '../../../../../../components/chapters/ChapterEditor';
-import { getServerAuthState } from '../../../../../../lib/auth';
-import { getChapter, getUserChapters } from '../../../../../../lib/chapters';
-import { getMyJourney } from '../../../../../../lib/journeys';
-import { getMap, getMapReviews } from '../../../../../../lib/maps';
-import { getUserJournal } from '../../../../../../lib/users';
-import { getDictionary } from '../../../../../../utils/getDictionary';
+import ChapterEditor from '../../../../../../components/chapters/ChapterEditor.tsx';
+import { getServerAuthState } from '../../../../../../lib/auth.ts';
+import { getChapter, getUserChapters } from '../../../../../../lib/chapters.ts';
+import { getMyJourney } from '../../../../../../lib/journeys.ts';
+import { getMap, getMapReviews } from '../../../../../../lib/maps.ts';
+import { getUserJournal } from '../../../../../../lib/users.ts';
+import { getDictionary } from '../../../../../../utils/getDictionary.ts';
 
 type Props = {
   params: Promise<{ lang: string; chapterId: string }>;

--- a/src/app/[lang]/(contained)/chapters/[chapterId]/loading.tsx
+++ b/src/app/[lang]/(contained)/chapters/[chapterId]/loading.tsx
@@ -1,5 +1,5 @@
 import { Box, Divider, Paper, Skeleton } from '@mui/material';
-import { coverAspectRatio } from '../../../../../components/chapters/constants';
+import { coverAspectRatio } from '../../../../../components/chapters/constants.ts';
 
 const ENTRY_COUNT = 3;
 

--- a/src/app/[lang]/(contained)/chapters/[chapterId]/page.tsx
+++ b/src/app/[lang]/(contained)/chapters/[chapterId]/page.tsx
@@ -1,13 +1,16 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import ChapterReadView from '../../../../../components/chapters/ChapterReadView';
-import { getServerAuthState } from '../../../../../lib/auth';
-import { getChapter, getUserChapters } from '../../../../../lib/chapters';
-import { getMap } from '../../../../../lib/maps';
-import { getUserJournal } from '../../../../../lib/users';
-import { getDictionary } from '../../../../../utils/getDictionary';
-import { localePath } from '../../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../../utils/metadata';
+import ChapterReadView from '../../../../../components/chapters/ChapterReadView.tsx';
+import { getServerAuthState } from '../../../../../lib/auth.ts';
+import { getChapter, getUserChapters } from '../../../../../lib/chapters.ts';
+import { getMap } from '../../../../../lib/maps.ts';
+import { getUserJournal } from '../../../../../lib/users.ts';
+import { getDictionary } from '../../../../../utils/getDictionary.ts';
+import { localePath } from '../../../../../utils/locales.ts';
+import {
+  buildAlternates,
+  defaultOgImage
+} from '../../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string; chapterId: string }>;

--- a/src/app/[lang]/(contained)/coauthorship_invitations/page.tsx
+++ b/src/app/[lang]/(contained)/coauthorship_invitations/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
-import CoauthorshipInvitationList from '../../../../components/coauthors/CoauthorshipInvitationList';
-import { getCoauthorshipInvitations } from '../../../../lib/coauthorshipInvitations';
-import { getDictionary } from '../../../../utils/getDictionary';
-import { buildAlternates } from '../../../../utils/metadata';
+import CoauthorshipInvitationList from '../../../../components/coauthors/CoauthorshipInvitationList.tsx';
+import { getCoauthorshipInvitations } from '../../../../lib/coauthorshipInvitations.ts';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
+import { buildAlternates } from '../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/discover/page.tsx
+++ b/src/app/[lang]/(contained)/discover/page.tsx
@@ -1,18 +1,18 @@
 import { Explore, FiberNew, Whatshot } from '@mui/icons-material';
 import { Box, Divider, Stack, Typography } from '@mui/material';
 import type { Metadata } from 'next';
-import PickUpMap from '../../../../components/discover/PickUpMap';
-import MapGridList from '../../../../components/maps/MapGridList';
-import ReviewGridList from '../../../../components/reviews/ReviewGridList';
+import PickUpMap from '../../../../components/discover/PickUpMap.tsx';
+import MapGridList from '../../../../components/maps/MapGridList.tsx';
+import ReviewGridList from '../../../../components/reviews/ReviewGridList.tsx';
 import {
   getActiveMaps,
   getFeaturedMap,
   getRecentMaps
-} from '../../../../lib/maps';
-import { getRecentReviews } from '../../../../lib/reviews';
-import { getDictionary } from '../../../../utils/getDictionary';
-import { localePath } from '../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
+} from '../../../../lib/maps.ts';
+import { getRecentReviews } from '../../../../lib/reviews.ts';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
+import { localePath } from '../../../../utils/locales.ts';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/journeys/[journeyId]/page.tsx
+++ b/src/app/[lang]/(contained)/journeys/[journeyId]/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import JourneyDetailView from '../../../../../components/journeys/JourneyDetailView';
-import { getServerAuthState } from '../../../../../lib/auth';
-import { getChapter } from '../../../../../lib/chapters';
-import { getMyJourney } from '../../../../../lib/journeys';
-import { getMap, getMapReviews } from '../../../../../lib/maps';
-import { getDictionary } from '../../../../../utils/getDictionary';
+import JourneyDetailView from '../../../../../components/journeys/JourneyDetailView.tsx';
+import { getServerAuthState } from '../../../../../lib/auth.ts';
+import { getChapter } from '../../../../../lib/chapters.ts';
+import { getMyJourney } from '../../../../../lib/journeys.ts';
+import { getMap, getMapReviews } from '../../../../../lib/maps.ts';
+import { getDictionary } from '../../../../../utils/getDictionary.ts';
 
 type Props = {
   params: Promise<{ lang: string; journeyId: string }>;

--- a/src/app/[lang]/(contained)/journeys/page.tsx
+++ b/src/app/[lang]/(contained)/journeys/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import UserJourneys from '../../../../components/profiles/UserJourneys';
-import { getServerAuthState } from '../../../../lib/auth';
-import { getMyJourneys } from '../../../../lib/journeys';
-import { getDictionary } from '../../../../utils/getDictionary';
+import UserJourneys from '../../../../components/profiles/UserJourneys.tsx';
+import { getServerAuthState } from '../../../../lib/auth.ts';
+import { getMyJourneys } from '../../../../lib/journeys.ts';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/layout.tsx
+++ b/src/app/[lang]/(contained)/layout.tsx
@@ -1,9 +1,9 @@
 import { Container, Grid } from '@mui/material';
 import type { ReactNode } from 'react';
-import BottomNav from '../../../components/layouts/BottomNav';
-import Sidebar from '../../../components/layouts/Sidebar';
-import { getServerAuthState } from '../../../lib/auth';
-import { getPopularMaps, getRecommendMaps } from '../../../lib/maps';
+import BottomNav from '../../../components/layouts/BottomNav.tsx';
+import Sidebar from '../../../components/layouts/Sidebar.tsx';
+import { getServerAuthState } from '../../../lib/auth.ts';
+import { getPopularMaps, getRecommendMaps } from '../../../lib/maps.ts';
 
 type Props = {
   children: ReactNode;

--- a/src/app/[lang]/(contained)/maps/[mapId]/reports/[reviewId]/page.tsx
+++ b/src/app/[lang]/(contained)/maps/[mapId]/reports/[reviewId]/page.tsx
@@ -1,15 +1,15 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
-import ReviewDetail from '../../../../../../../components/reviews/ReviewDetail';
-import { getServerAuthState } from '../../../../../../../lib/auth';
-import { getReview } from '../../../../../../../lib/reviews';
-import { getDictionary } from '../../../../../../../utils/getDictionary';
-import { localePath } from '../../../../../../../utils/locales';
+import ReviewDetail from '../../../../../../../components/reviews/ReviewDetail.tsx';
+import { getServerAuthState } from '../../../../../../../lib/auth.ts';
+import { getReview } from '../../../../../../../lib/reviews.ts';
+import { getDictionary } from '../../../../../../../utils/getDictionary.ts';
+import { localePath } from '../../../../../../../utils/locales.ts';
 import {
   buildAlternates,
   defaultOgImage
-} from '../../../../../../../utils/metadata';
+} from '../../../../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string; mapId: string; reviewId: string }>;

--- a/src/app/[lang]/(contained)/notifications/page.tsx
+++ b/src/app/[lang]/(contained)/notifications/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
-import NotificationsFeed from '../../../../components/notifications/NotificationsFeed';
-import { getNotifications } from '../../../../lib/users';
-import { getDictionary } from '../../../../utils/getDictionary';
-import { localePath } from '../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
+import NotificationsFeed from '../../../../components/notifications/NotificationsFeed.tsx';
+import { getNotifications } from '../../../../lib/users.ts';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
+import { localePath } from '../../../../utils/locales.ts';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/privacy/page.tsx
+++ b/src/app/[lang]/(contained)/privacy/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
-import MarkdownContent from '../../../../components/common/MarkdownContent';
-import { getDictionary } from '../../../../utils/getDictionary';
-import { getLegalDocument } from '../../../../utils/getLegalDocument';
-import { localePath } from '../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
+import MarkdownContent from '../../../../components/common/MarkdownContent.tsx';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
+import { getLegalDocument } from '../../../../utils/getLegalDocument.ts';
+import { localePath } from '../../../../utils/locales.ts';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/settings/page.tsx
+++ b/src/app/[lang]/(contained)/settings/page.tsx
@@ -1,12 +1,12 @@
 import { Stack } from '@mui/material';
 import type { Metadata } from 'next';
-import AccountEmailCard from '../../../../components/settings/AccountEmailCard';
-import DeleteAccountCard from '../../../../components/settings/DeleteAccountCard';
-import ProvidersCard from '../../../../components/settings/ProvidersCard';
-import PushNotificationsCard from '../../../../components/settings/PushNotificationsCard';
-import { getDictionary } from '../../../../utils/getDictionary';
-import { localePath } from '../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
+import AccountEmailCard from '../../../../components/settings/AccountEmailCard.tsx';
+import DeleteAccountCard from '../../../../components/settings/DeleteAccountCard.tsx';
+import ProvidersCard from '../../../../components/settings/ProvidersCard.tsx';
+import PushNotificationsCard from '../../../../components/settings/PushNotificationsCard.tsx';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
+import { localePath } from '../../../../utils/locales.ts';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/terms/page.tsx
+++ b/src/app/[lang]/(contained)/terms/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
-import MarkdownContent from '../../../../components/common/MarkdownContent';
-import { getDictionary } from '../../../../utils/getDictionary';
-import { getLegalDocument } from '../../../../utils/getLegalDocument';
-import { localePath } from '../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../utils/metadata';
+import MarkdownContent from '../../../../components/common/MarkdownContent.tsx';
+import { getDictionary } from '../../../../utils/getDictionary.ts';
+import { getLegalDocument } from '../../../../utils/getLegalDocument.ts';
+import { localePath } from '../../../../utils/locales.ts';
+import { buildAlternates, defaultOgImage } from '../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string }>;

--- a/src/app/[lang]/(contained)/users/[userId]/page.tsx
+++ b/src/app/[lang]/(contained)/users/[userId]/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import UserProfile from '../../../../../components/profiles/UserProfile';
-import { getServerAuthState } from '../../../../../lib/auth';
-import { getMyChapters, getUserChapters } from '../../../../../lib/chapters';
+import UserProfile from '../../../../../components/profiles/UserProfile.tsx';
+import { getServerAuthState } from '../../../../../lib/auth.ts';
+import { getMyChapters, getUserChapters } from '../../../../../lib/chapters.ts';
 import {
   getMyJournal,
   getMyMaps,
@@ -11,10 +11,13 @@ import {
   getUserJournal,
   getUserMaps,
   getUserReviews
-} from '../../../../../lib/users';
-import { getDictionary } from '../../../../../utils/getDictionary';
-import { localePath } from '../../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../../utils/metadata';
+} from '../../../../../lib/users.ts';
+import { getDictionary } from '../../../../../utils/getDictionary.ts';
+import { localePath } from '../../../../../utils/locales.ts';
+import {
+  buildAlternates,
+  defaultOgImage
+} from '../../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string; userId: string }>;

--- a/src/app/[lang]/AccountProviders.tsx
+++ b/src/app/[lang]/AccountProviders.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { type ReactNode, use } from 'react';
-import type { Notification, Profile } from '../../../types';
-import NotificationsContext from '../../context/NotificationsContext';
-import ProfileContext from '../../context/ProfileContext';
+import type { Notification, Profile } from '../../../types/index.ts';
+import NotificationsContext from '../../context/NotificationsContext.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
 
 type Props = {
   profilePromise: Promise<Profile | null>;

--- a/src/app/[lang]/Providers.tsx
+++ b/src/app/[lang]/Providers.tsx
@@ -21,14 +21,14 @@ import {
   useMemo,
   useState
 } from 'react';
-import type { Notification, Profile } from '../../../types';
-import AuthProvider from '../../components/auth/AuthProvider';
-import FootprintsLoader from '../../components/common/FootprintsLoader';
-import ServiceWorkerContext from '../../context/ServiceWorkerContext';
-import useDictionary from '../../hooks/useDictionary';
-import { usePushManager } from '../../hooks/usePushManager';
-import AccountProviders from './AccountProviders';
-import AnalyticsTracker from './AnalyticsTracker';
+import type { Notification, Profile } from '../../../types/index.ts';
+import AuthProvider from '../../components/auth/AuthProvider.tsx';
+import FootprintsLoader from '../../components/common/FootprintsLoader.tsx';
+import ServiceWorkerContext from '../../context/ServiceWorkerContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { usePushManager } from '../../hooks/usePushManager.ts';
+import AccountProviders from './AccountProviders.tsx';
+import AnalyticsTracker from './AnalyticsTracker.tsx';
 
 const globalStyles = css`
   .pac-container {

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -2,15 +2,15 @@ import { Box } from '@mui/material';
 import type { Metadata, Viewport } from 'next';
 import { Cinzel, Lobster, Shippori_Mincho } from 'next/font/google';
 import type { ReactNode } from 'react';
-import type { Notification, Profile } from '../../../types';
-import MiniDrawer from '../../components/layouts/MiniDrawer';
-import MobileAppBar from '../../components/layouts/MobileAppBar';
-import ShellProvider from '../../components/layouts/ShellProvider';
-import { getServerAuthState } from '../../lib/auth';
-import { getMyProfile, getNotifications } from '../../lib/users';
-import { getDictionary } from '../../utils/getDictionary';
-import { defaultOgImage, SITE_ORIGIN } from '../../utils/metadata';
-import Providers from './Providers';
+import type { Notification, Profile } from '../../../types/index.ts';
+import MiniDrawer from '../../components/layouts/MiniDrawer.tsx';
+import MobileAppBar from '../../components/layouts/MobileAppBar.tsx';
+import ShellProvider from '../../components/layouts/ShellProvider.tsx';
+import { getServerAuthState } from '../../lib/auth.ts';
+import { getMyProfile, getNotifications } from '../../lib/users.ts';
+import { getDictionary } from '../../utils/getDictionary.ts';
+import { defaultOgImage, SITE_ORIGIN } from '../../utils/metadata.ts';
+import Providers from './Providers.tsx';
 
 const lobster = Lobster({
   subsets: ['latin'],

--- a/src/app/[lang]/login/page.tsx
+++ b/src/app/[lang]/login/page.tsx
@@ -9,11 +9,11 @@ import {
   Typography
 } from '@mui/material';
 import type { Metadata } from 'next';
-import LoginCard from '../../../components/auth/LoginCard';
-import Footer from '../../../components/layouts/Footer';
-import { getDictionary } from '../../../utils/getDictionary';
-import { localePath } from '../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../utils/metadata';
+import LoginCard from '../../../components/auth/LoginCard.tsx';
+import Footer from '../../../components/layouts/Footer.tsx';
+import { getDictionary } from '../../../utils/getDictionary.ts';
+import { localePath } from '../../../utils/locales.ts';
+import { buildAlternates, defaultOgImage } from '../../../utils/metadata.ts';
 
 const HERO_IMAGE_URL =
   'https://storage.googleapis.com/qoodish.appspot.com/assets/qoodish-lp-carousel-1-2019-05-06.jpg';

--- a/src/app/[lang]/maps/[mapId]/(detail)/loading.tsx
+++ b/src/app/[lang]/maps/[mapId]/(detail)/loading.tsx
@@ -7,7 +7,7 @@ import {
   Divider,
   Skeleton
 } from '@mui/material';
-import { drawerBleeding } from '../../../../../components/maps/constants';
+import { drawerBleeding } from '../../../../../components/maps/constants.ts';
 
 const summaryCardWidth = 360;
 

--- a/src/app/[lang]/maps/[mapId]/(detail)/page.tsx
+++ b/src/app/[lang]/maps/[mapId]/(detail)/page.tsx
@@ -1,19 +1,22 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
-import MapDetailView from '../../../../../components/maps/MapDetailView';
-import { getServerAuthState } from '../../../../../lib/auth';
-import { getMyJourney, getMyJourneys } from '../../../../../lib/journeys';
+import MapDetailView from '../../../../../components/maps/MapDetailView.tsx';
+import { getServerAuthState } from '../../../../../lib/auth.ts';
+import { getMyJourney, getMyJourneys } from '../../../../../lib/journeys.ts';
 import {
   getMap,
   getMapChapters,
   getMapCoauthors,
   getMapReviews
-} from '../../../../../lib/maps';
-import { getMyProfile } from '../../../../../lib/users';
-import { getDictionary } from '../../../../../utils/getDictionary';
-import { localePath } from '../../../../../utils/locales';
-import { buildAlternates, defaultOgImage } from '../../../../../utils/metadata';
+} from '../../../../../lib/maps.ts';
+import { getMyProfile } from '../../../../../lib/users.ts';
+import { getDictionary } from '../../../../../utils/getDictionary.ts';
+import { localePath } from '../../../../../utils/locales.ts';
+import {
+  buildAlternates,
+  defaultOgImage
+} from '../../../../../utils/metadata.ts';
 
 type Props = {
   params: Promise<{ lang: string; mapId: string }>;

--- a/src/app/[lang]/not-found.tsx
+++ b/src/app/[lang]/not-found.tsx
@@ -4,7 +4,7 @@ import { KeyboardArrowLeft } from '@mui/icons-material';
 import { Alert, AlertTitle, Button, Container, Grid } from '@mui/material';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 export default function NotFound() {
   const dictionary = useDictionary();

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,9 @@
 import type { MetadataRoute } from 'next';
-import { getRecentChapters } from '../lib/chapters';
-import { getActiveMaps, getPopularMaps, getRecentMaps } from '../lib/maps';
-import { getPopularReviews, getRecentReviews } from '../lib/reviews';
-import { DEFAULT_LOCALE, LOCALES, localePath } from '../utils/locales';
-import { SITE_ORIGIN } from '../utils/metadata';
+import { getRecentChapters } from '../lib/chapters.ts';
+import { getActiveMaps, getPopularMaps, getRecentMaps } from '../lib/maps.ts';
+import { getPopularReviews, getRecentReviews } from '../lib/reviews.ts';
+import { DEFAULT_LOCALE, LOCALES, localePath } from '../utils/locales.ts';
+import { SITE_ORIGIN } from '../utils/metadata.ts';
 
 export const revalidate = 3600;
 

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -9,8 +9,8 @@ import {
   useRef,
   useState
 } from 'react';
-import AuthContext from '../../context/AuthContext';
-import useEmailLinkHandler from '../../hooks/useEmailLinkHandler';
+import AuthContext from '../../context/AuthContext.ts';
+import useEmailLinkHandler from '../../hooks/useEmailLinkHandler.ts';
 
 type Props = {
   children: ReactNode;

--- a/src/components/auth/LoginCard.tsx
+++ b/src/components/auth/LoginCard.tsx
@@ -11,9 +11,9 @@ import {
 } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import { memo } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import SignInButtons from './SignInButtons';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import SignInButtons from './SignInButtons.tsx';
 
 export default memo(function LoginCard() {
   const dictionary = useDictionary();

--- a/src/components/auth/SignInButtons.tsx
+++ b/src/components/auth/SignInButtons.tsx
@@ -1,8 +1,8 @@
 import { Divider, Stack } from '@mui/material';
 import { memo } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import SignInWithEmailLinkButton from './SignInWithEmailLinkButton';
-import SignInWithGoogleButton from './SignInWithGoogleButton';
+import useDictionary from '../../hooks/useDictionary.ts';
+import SignInWithEmailLinkButton from './SignInWithEmailLinkButton.tsx';
+import SignInWithGoogleButton from './SignInWithGoogleButton.tsx';
 
 type Props = {
   onSignInSuccess: () => void;

--- a/src/components/auth/SignInRequiredDialog.tsx
+++ b/src/components/auth/SignInRequiredDialog.tsx
@@ -1,10 +1,10 @@
 import { Container, Typography } from '@mui/material';
 import { memo, useContext } from 'react';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import BottomSheet from '../common/BottomSheet';
-import Logo from '../layouts/Logo';
-import SignInButtons from './SignInButtons';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import BottomSheet from '../common/BottomSheet.tsx';
+import Logo from '../layouts/Logo.tsx';
+import SignInButtons from './SignInButtons.tsx';
 
 function SignInRequiredDialog() {
   const dictionary = useDictionary();

--- a/src/components/auth/SignInWithEmailLinkButton.tsx
+++ b/src/components/auth/SignInWithEmailLinkButton.tsx
@@ -3,8 +3,8 @@ import { getAnalytics, logEvent } from 'firebase/analytics';
 import { getAuth, sendSignInLinkToEmail } from 'firebase/auth';
 import { useParams } from 'next/navigation';
 import { type FormEvent, memo, useCallback, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import EmailField from '../common/EmailField';
+import useDictionary from '../../hooks/useDictionary.ts';
+import EmailField from '../common/EmailField.tsx';
 
 function SignInWithEmailLinkButton() {
   const { lang } = useParams<{ lang: string }>();

--- a/src/components/auth/SignInWithGoogleButton.tsx
+++ b/src/components/auth/SignInWithGoogleButton.tsx
@@ -1,7 +1,7 @@
 import { SvgIcon } from '@mui/material';
 import { GoogleAuthProvider } from 'firebase/auth';
 import { memo } from 'react';
-import SignInWithProviderButton from './SignInWithProviderButton';
+import SignInWithProviderButton from './SignInWithProviderButton.tsx';
 
 type Props = {
   onSignInSuccess: () => void;

--- a/src/components/auth/SignInWithProviderButton.tsx
+++ b/src/components/auth/SignInWithProviderButton.tsx
@@ -9,7 +9,7 @@ import {
 import { useParams } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { memo, type ReactNode, useCallback, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   provider: GoogleAuthProvider;

--- a/src/components/bookmarks/BookmarkedJournalList.tsx
+++ b/src/components/bookmarks/BookmarkedJournalList.tsx
@@ -12,9 +12,9 @@ import {
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { memo } from 'react';
-import type { Journal } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import NoContents from '../common/NoContents';
+import type { Journal } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import NoContents from '../common/NoContents.tsx';
 
 type Props = {
   journals: Journal[];

--- a/src/components/bookmarks/BookmarksView.tsx
+++ b/src/components/bookmarks/BookmarksView.tsx
@@ -3,10 +3,10 @@
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Card, Tab } from '@mui/material';
 import { memo, type SyntheticEvent, useState } from 'react';
-import type { AppMap, Journal } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import UserBookmarks from '../profiles/UserBookmarks';
-import BookmarkedJournalList from './BookmarkedJournalList';
+import type { AppMap, Journal } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import UserBookmarks from '../profiles/UserBookmarks.tsx';
+import BookmarkedJournalList from './BookmarkedJournalList.tsx';
 
 type Props = {
   maps: AppMap[];

--- a/src/components/chapters/ChapterActions.tsx
+++ b/src/components/chapters/ChapterActions.tsx
@@ -11,10 +11,10 @@ import {
   useState,
   useTransition
 } from 'react';
-import type { Chapter } from '../../../types';
-import { likeChapter, unlikeChapter } from '../../actions/chapterLikes';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
+import type { Chapter } from '../../../types/index.ts';
+import { likeChapter, unlikeChapter } from '../../actions/chapterLikes.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   chapter: Chapter;

--- a/src/components/chapters/ChapterAuthorCard.tsx
+++ b/src/components/chapters/ChapterAuthorCard.tsx
@@ -3,10 +3,10 @@
 import { Box, Divider, Link as MuiLink, Typography } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { Author, Journal } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import ProfileAvatar from '../common/ProfileAvatar';
-import JournalBookmarkButton from '../profiles/JournalBookmarkButton';
+import type { Author, Journal } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import ProfileAvatar from '../common/ProfileAvatar.tsx';
+import JournalBookmarkButton from '../profiles/JournalBookmarkButton.tsx';
 
 type Props = {
   author: Author;

--- a/src/components/chapters/ChapterAuthorHeader.tsx
+++ b/src/components/chapters/ChapterAuthorHeader.tsx
@@ -3,8 +3,8 @@
 import { Box, Link as MuiLink, Typography } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { Author } from '../../../types';
-import ProfileAvatar from '../common/ProfileAvatar';
+import type { Author } from '../../../types/index.ts';
+import ProfileAvatar from '../common/ProfileAvatar.tsx';
 
 type Props = {
   author: Author | null;

--- a/src/components/chapters/ChapterContentEditor.tsx
+++ b/src/components/chapters/ChapterContentEditor.tsx
@@ -19,9 +19,9 @@ import type {
   SerializedEditorState
 } from 'lexical';
 import { memo, type RefObject } from 'react';
-import ChapterFloatingToolbar from './ChapterFloatingToolbar';
-import ChapterSlashMenu from './ChapterSlashMenu';
-import ChapterToolbar from './ChapterToolbar';
+import ChapterFloatingToolbar from './ChapterFloatingToolbar.tsx';
+import ChapterSlashMenu from './ChapterSlashMenu.tsx';
+import ChapterToolbar from './ChapterToolbar.tsx';
 import {
   chapterAutoLinkMatchers,
   chapterContentStyles,
@@ -29,8 +29,8 @@ import {
   chapterNodes,
   chapterTheme,
   validateUrl
-} from './chapterEditorConfig';
-import EmptyBlockPlaceholderPlugin from './EmptyBlockPlaceholderPlugin';
+} from './chapterEditorConfig.ts';
+import EmptyBlockPlaceholderPlugin from './EmptyBlockPlaceholderPlugin.tsx';
 
 type Props = {
   initialContent: SerializedEditorState;

--- a/src/components/chapters/ChapterContentReader.tsx
+++ b/src/components/chapters/ChapterContentReader.tsx
@@ -15,7 +15,7 @@ import {
   chapterNodes,
   chapterTheme,
   validateUrl
-} from './chapterEditorConfig';
+} from './chapterEditorConfig.ts';
 
 type Props = {
   content: SerializedEditorState;

--- a/src/components/chapters/ChapterCover.tsx
+++ b/src/components/chapters/ChapterCover.tsx
@@ -17,11 +17,11 @@ import {
   useEffect,
   useState
 } from 'react';
-import type { ImageVariants } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import fileToDataUrl from '../../utils/fileToDataUrl';
-import uploadImage from '../../utils/uploadImage';
-import { coverAspectRatio } from './constants';
+import type { ImageVariants } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import fileToDataUrl from '../../utils/fileToDataUrl.ts';
+import uploadImage from '../../utils/uploadImage.ts';
+import { coverAspectRatio } from './constants.ts';
 
 type Props = {
   image: ImageVariants | null;

--- a/src/components/chapters/ChapterEditor.tsx
+++ b/src/components/chapters/ChapterEditor.tsx
@@ -30,26 +30,32 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { useRef, useState } from 'react';
-import type { AppMap, Chapter, Journal, Journey, Review } from '../../../types';
-import useChapter from '../../hooks/useChapter';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalDateTime from '../../hooks/useLocalDateTime';
-import { isContentEmpty } from '../../utils/chapterContent';
+import type {
+  AppMap,
+  Chapter,
+  Journal,
+  Journey,
+  Review
+} from '../../../types/index.ts';
+import useChapter from '../../hooks/useChapter.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalDateTime from '../../hooks/useLocalDateTime.ts';
+import { isContentEmpty } from '../../utils/chapterContent.ts';
 import {
   createMapFeatures,
   featureSpots,
   spotFeature
-} from '../../utils/mapFeatures';
-import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog';
-import ConfirmDialog from '../common/ConfirmDialog';
-import SpotPickerDialog from '../journeys/SpotPickerDialog';
-import ChapterAuthorCard from './ChapterAuthorCard';
-import ChapterAuthorHeader from './ChapterAuthorHeader';
-import ChapterContentEditor from './ChapterContentEditor';
-import ChapterCover from './ChapterCover';
-import ChapterMapCard from './ChapterMapCard';
-import MapLinkChip from './MapLinkChip';
-import { $replaceChapterContent } from './replaceChapterContent';
+} from '../../utils/mapFeatures.ts';
+import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog.tsx';
+import ConfirmDialog from '../common/ConfirmDialog.tsx';
+import SpotPickerDialog from '../journeys/SpotPickerDialog.tsx';
+import ChapterAuthorCard from './ChapterAuthorCard.tsx';
+import ChapterAuthorHeader from './ChapterAuthorHeader.tsx';
+import ChapterContentEditor from './ChapterContentEditor.tsx';
+import ChapterCover from './ChapterCover.tsx';
+import ChapterMapCard from './ChapterMapCard.tsx';
+import MapLinkChip from './MapLinkChip.tsx';
+import { $replaceChapterContent } from './replaceChapterContent.ts';
 
 const LONG_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
   year: 'numeric',

--- a/src/components/chapters/ChapterFloatingToolbar.tsx
+++ b/src/components/chapters/ChapterFloatingToolbar.tsx
@@ -34,7 +34,7 @@ import {
   useRef,
   useState
 } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 function FormatButton({
   label,

--- a/src/components/chapters/ChapterMapCard.tsx
+++ b/src/components/chapters/ChapterMapCard.tsx
@@ -10,9 +10,9 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { memo, type ReactNode } from 'react';
-import type { AppMap, JourneyPathPoint, Spot } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import JourneyMap from '../journeys/JourneyMap';
+import type { AppMap, JourneyPathPoint, Spot } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import JourneyMap from '../journeys/JourneyMap.tsx';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/chapters/ChapterReadView.tsx
+++ b/src/components/chapters/ChapterReadView.tsx
@@ -16,19 +16,19 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { useState } from 'react';
-import type { AppMap, Chapter, Journal } from '../../../types';
-import { deleteChapter } from '../../actions/chapters';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalDateTime from '../../hooks/useLocalDateTime';
-import { featureSpots } from '../../utils/mapFeatures';
-import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog';
-import ChapterActions from './ChapterActions';
-import ChapterAuthorCard from './ChapterAuthorCard';
-import ChapterAuthorHeader from './ChapterAuthorHeader';
-import ChapterContentReader from './ChapterContentReader';
-import ChapterCover from './ChapterCover';
-import ChapterMapCard from './ChapterMapCard';
-import MapLinkChip from './MapLinkChip';
+import type { AppMap, Chapter, Journal } from '../../../types/index.ts';
+import { deleteChapter } from '../../actions/chapters.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalDateTime from '../../hooks/useLocalDateTime.ts';
+import { featureSpots } from '../../utils/mapFeatures.ts';
+import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog.tsx';
+import ChapterActions from './ChapterActions.tsx';
+import ChapterAuthorCard from './ChapterAuthorCard.tsx';
+import ChapterAuthorHeader from './ChapterAuthorHeader.tsx';
+import ChapterContentReader from './ChapterContentReader.tsx';
+import ChapterCover from './ChapterCover.tsx';
+import ChapterMapCard from './ChapterMapCard.tsx';
+import MapLinkChip from './MapLinkChip.tsx';
 
 const LONG_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
   year: 'numeric',

--- a/src/components/chapters/ChapterSlashMenu.tsx
+++ b/src/components/chapters/ChapterSlashMenu.tsx
@@ -16,7 +16,7 @@ import {
 import type { TextNode } from 'lexical';
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { type BlockAction, useBlockActions } from './chapterBlockActions';
+import { type BlockAction, useBlockActions } from './chapterBlockActions.tsx';
 
 class BlockOption extends MenuOption {
   action: BlockAction;

--- a/src/components/chapters/ChapterToolbar.tsx
+++ b/src/components/chapters/ChapterToolbar.tsx
@@ -50,8 +50,8 @@ import {
   useRef,
   useState
 } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import { type BlockAction, useBlockActions } from './chapterBlockActions';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { type BlockAction, useBlockActions } from './chapterBlockActions.tsx';
 
 function ToolButton({
   label,

--- a/src/components/chapters/ImageNode.tsx
+++ b/src/components/chapters/ImageNode.tsx
@@ -8,8 +8,8 @@ import {
   createSerializedImage,
   IMAGE_NODE_TYPE,
   type SerializedImageNode
-} from '../../utils/chapterContent';
-import useBlockSelection from './useBlockSelection';
+} from '../../utils/chapterContent.ts';
+import useBlockSelection from './useBlockSelection.ts';
 
 type ImageViewProps = {
   nodeKey: NodeKey;

--- a/src/components/chapters/MapLinkChip.tsx
+++ b/src/components/chapters/MapLinkChip.tsx
@@ -4,8 +4,8 @@ import { Map as MapIcon } from '@mui/icons-material';
 import { Avatar, Chip } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { AppMap } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
+import type { AppMap } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/chapters/chapterBlockActions.tsx
+++ b/src/components/chapters/chapterBlockActions.tsx
@@ -27,7 +27,7 @@ import {
   type LexicalEditor
 } from 'lexical';
 import type { ReactNode } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 export type BlockAction = {
   key: string;

--- a/src/components/chapters/chapterEditorConfig.ts
+++ b/src/components/chapters/chapterEditorConfig.ts
@@ -25,7 +25,7 @@ import {
 import { HeadingNode, QuoteNode } from '@lexical/rich-text';
 import type { Theme } from '@mui/material';
 import type { EditorThemeClasses, Klass, LexicalNode } from 'lexical';
-import { ImageNode } from './ImageNode';
+import { ImageNode } from './ImageNode.tsx';
 
 export const chapterNodes: Klass<LexicalNode>[] = [
   ImageNode,

--- a/src/components/chapters/replaceChapterContent.ts
+++ b/src/components/chapters/replaceChapterContent.ts
@@ -1,8 +1,8 @@
 import { $createHeadingNode } from '@lexical/rich-text';
 import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical';
-import type { Journey } from '../../../types';
-import { chapterSections } from '../../utils/chapterContent';
-import { $createImageNode } from './ImageNode';
+import type { Journey } from '../../../types/index.ts';
+import { chapterSections } from '../../utils/chapterContent.ts';
+import { $createImageNode } from './ImageNode.tsx';
 
 // Rebuilds the document from the journey in place. Running inside editor.update
 // (rather than remounting the editor) keeps the change on the history stack, so

--- a/src/components/coauthors/CoauthorshipInvitationList.tsx
+++ b/src/components/coauthors/CoauthorshipInvitationList.tsx
@@ -12,13 +12,13 @@ import {
 import { useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { memo, useState, useTransition } from 'react';
-import type { CoauthorshipInvitation } from '../../../types';
+import type { CoauthorshipInvitation } from '../../../types/index.ts';
 import {
   acceptCoauthorshipInvitation,
   declineCoauthorshipInvitation
-} from '../../actions/coauthors';
-import useDictionary from '../../hooks/useDictionary';
-import NoContents from '../common/NoContents';
+} from '../../actions/coauthors.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import NoContents from '../common/NoContents.tsx';
 
 type Props = {
   invitations: CoauthorshipInvitation[];

--- a/src/components/common/AddPhotoButton.tsx
+++ b/src/components/common/AddPhotoButton.tsx
@@ -1,7 +1,7 @@
 import { AddAPhoto } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
 import { type ChangeEvent, memo, useEffect, useId, useState } from 'react';
-import fileToDataUrl from '../../utils/fileToDataUrl';
+import fileToDataUrl from '../../utils/fileToDataUrl.ts';
 
 type Props = {
   onChange: (dataUrls: string[]) => void;

--- a/src/components/common/AppDialog.tsx
+++ b/src/components/common/AppDialog.tsx
@@ -24,8 +24,8 @@ import {
   type ReactNode,
   useId
 } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import SlideUpTransition from './SlideUpTransition';
+import useDictionary from '../../hooks/useDictionary.ts';
+import SlideUpTransition from './SlideUpTransition.tsx';
 
 // In full screen the form has to fill the dialog's height, or the content
 // cannot grow and the action row is not pinned to the bottom.

--- a/src/components/common/AuthorAvatar.tsx
+++ b/src/components/common/AuthorAvatar.tsx
@@ -1,8 +1,8 @@
 import { Avatar, Link as MuiLink, type SxProps } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { Author } from '../../../types';
-import useLocalePath from '../../hooks/useLocalePath';
+import type { Author } from '../../../types/index.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
 
 type Props = {
   author: Author;

--- a/src/components/common/AutocompleteListItem.tsx
+++ b/src/components/common/AutocompleteListItem.tsx
@@ -8,7 +8,7 @@ import {
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
 import { memo, type ReactNode } from 'react';
-import type { AutocompleteOption } from '../../../types';
+import type { AutocompleteOption } from '../../../types/index.ts';
 
 type Props = {
   option: AutocompleteOption;

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -2,7 +2,7 @@
 
 import { Box, SwipeableDrawer, type SwipeableDrawerProps } from '@mui/material';
 import { memo, type ReactNode } from 'react';
-import DrawerPuller from './DrawerPuller';
+import DrawerPuller from './DrawerPuller.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/common/ConfirmDeleteDialog.tsx
+++ b/src/components/common/ConfirmDeleteDialog.tsx
@@ -2,8 +2,8 @@
 
 import { Checkbox, DialogContentText, FormControlLabel } from '@mui/material';
 import { memo, useCallback, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog from './AppDialog';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog from './AppDialog.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -2,8 +2,8 @@
 
 import { type ButtonProps, DialogContentText } from '@mui/material';
 import { memo, useCallback, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog from './AppDialog';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog from './AppDialog.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/common/EmailField.tsx
+++ b/src/components/common/EmailField.tsx
@@ -1,6 +1,6 @@
 import { TextField } from '@mui/material';
 import { memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   value: string;

--- a/src/components/common/FootprintsLoader.tsx
+++ b/src/components/common/FootprintsLoader.tsx
@@ -3,7 +3,7 @@
 import { keyframes } from '@emotion/react';
 import { Box } from '@mui/material';
 import { memo } from 'react';
-import { FOOTPRINT_PATH_RIGHT } from '../../utils/journeyTrailIcons';
+import { FOOTPRINT_PATH_RIGHT } from '../../utils/journeyTrailIcons.ts';
 
 const VIEW_SIZE = 400;
 const STEP_COUNT = 10;

--- a/src/components/common/IssueDialog.tsx
+++ b/src/components/common/IssueDialog.tsx
@@ -14,9 +14,9 @@ import {
   useId,
   useState
 } from 'react';
-import { createIssue } from '../../actions/issues';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog from './AppDialog';
+import { createIssue } from '../../actions/issues.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog from './AppDialog.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/common/LoadingStatus.tsx
+++ b/src/components/common/LoadingStatus.tsx
@@ -2,7 +2,7 @@
 
 import { Box } from '@mui/material';
 import { memo } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   loading: boolean;

--- a/src/components/common/PhotoPreviewList.tsx
+++ b/src/components/common/PhotoPreviewList.tsx
@@ -12,7 +12,7 @@ import {
   useTheme
 } from '@mui/material';
 import { memo } from 'react';
-import type { PhotoItem } from '../../hooks/usePhotoUploads';
+import type { PhotoItem } from '../../hooks/usePhotoUploads.ts';
 
 type Props = {
   items: PhotoItem[];

--- a/src/components/common/ProfileAvatar.tsx
+++ b/src/components/common/ProfileAvatar.tsx
@@ -1,7 +1,7 @@
 import { AccountCircle } from '@mui/icons-material';
 import { Avatar } from '@mui/material';
 import { memo } from 'react';
-import type { ImageVariants } from '../../../types';
+import type { ImageVariants } from '../../../types/index.ts';
 
 type Props = {
   profile?: { name: string; image: ImageVariants | null } | null;

--- a/src/components/common/WalkingFootprints.tsx
+++ b/src/components/common/WalkingFootprints.tsx
@@ -3,7 +3,7 @@
 import { keyframes } from '@emotion/react';
 import { Box } from '@mui/material';
 import { memo } from 'react';
-import { FOOTPRINT_PATH_RIGHT } from '../../utils/journeyTrailIcons';
+import { FOOTPRINT_PATH_RIGHT } from '../../utils/journeyTrailIcons.ts';
 
 const STEP_DELAY = 0.18;
 

--- a/src/components/discover/PickUpMap.tsx
+++ b/src/components/discover/PickUpMap.tsx
@@ -13,8 +13,8 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { AppMap } from '../../../types';
-import useLocalePath from '../../hooks/useLocalePath';
+import type { AppMap } from '../../../types/index.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/home/Timeline.tsx
+++ b/src/components/home/Timeline.tsx
@@ -3,14 +3,14 @@
 import { Reviews } from '@mui/icons-material';
 import { Box, Button, Stack } from '@mui/material';
 import { memo, useState, useTransition } from 'react';
-import type { Review } from '../../../types';
-import { fetchMoreTimelineReviews } from '../../actions/reviews';
-import useDictionary from '../../hooks/useDictionary';
-import IssueDialog from '../common/IssueDialog';
-import LoadingStatus from '../common/LoadingStatus';
-import NoContents from '../common/NoContents';
-import TimelineReviewCard from './TimelineReviewCard';
-import TimelineReviewCardSkeleton from './TimelineReviewCardSkeleton';
+import type { Review } from '../../../types/index.ts';
+import { fetchMoreTimelineReviews } from '../../actions/reviews.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import IssueDialog from '../common/IssueDialog.tsx';
+import LoadingStatus from '../common/LoadingStatus.tsx';
+import NoContents from '../common/NoContents.tsx';
+import TimelineReviewCard from './TimelineReviewCard.tsx';
+import TimelineReviewCardSkeleton from './TimelineReviewCardSkeleton.tsx';
 
 type Props = {
   initialReviews: Review[];

--- a/src/components/home/TimelineReviewCard.tsx
+++ b/src/components/home/TimelineReviewCard.tsx
@@ -8,12 +8,12 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { Review } from '../../../types';
-import useLocalePath from '../../hooks/useLocalePath';
-import LikeReviewButton from '../reviews/LikeReviewButton';
-import ReviewCardHeader from '../reviews/ReviewCardHeader';
-import ReviewImageList from '../reviews/ReviewImageList';
-import ReviewMenuButton from '../reviews/ReviewMenuButton';
+import type { Review } from '../../../types/index.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import LikeReviewButton from '../reviews/LikeReviewButton.tsx';
+import ReviewCardHeader from '../reviews/ReviewCardHeader.tsx';
+import ReviewImageList from '../reviews/ReviewImageList.tsx';
+import ReviewMenuButton from '../reviews/ReviewMenuButton.tsx';
 
 type Props = {
   review: Review;

--- a/src/components/home/TrendingReviews.tsx
+++ b/src/components/home/TrendingReviews.tsx
@@ -4,11 +4,11 @@ import { Reviews } from '@mui/icons-material';
 import { Box, Button, Stack, Typography } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { Review } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import NoContents from '../common/NoContents';
-import TimelineReviewCard from './TimelineReviewCard';
+import type { Review } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import NoContents from '../common/NoContents.tsx';
+import TimelineReviewCard from './TimelineReviewCard.tsx';
 
 type Props = {
   reviews: Review[];

--- a/src/components/journeys/CheckinImageStrip.tsx
+++ b/src/components/journeys/CheckinImageStrip.tsx
@@ -13,10 +13,10 @@ import {
 } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
 import { type ChangeEvent, memo, useCallback, useId, useState } from 'react';
-import type { Image, JourneyCheckin } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import fileToDataUrl from '../../utils/fileToDataUrl';
-import uploadImage from '../../utils/uploadImage';
+import type { Image, JourneyCheckin } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import fileToDataUrl from '../../utils/fileToDataUrl.ts';
+import uploadImage from '../../utils/uploadImage.ts';
 
 const IMAGE_SIZE = 96;
 

--- a/src/components/journeys/CheckinNoteField.tsx
+++ b/src/components/journeys/CheckinNoteField.tsx
@@ -2,8 +2,8 @@
 
 import { TextField } from '@mui/material';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import type { JourneyCheckin } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
+import type { JourneyCheckin } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 const AUTOSAVE_DELAY = 800;
 const NOTE_MAX_LENGTH = 500;

--- a/src/components/journeys/EndJourneyDialog.tsx
+++ b/src/components/journeys/EndJourneyDialog.tsx
@@ -1,8 +1,8 @@
 import { Check, HistoryEdu, LocationOff } from '@mui/icons-material';
 import { List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
 import { memo, useCallback, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog from '../common/AppDialog';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog from '../common/AppDialog.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/journeys/JourneyDetailView.tsx
+++ b/src/components/journeys/JourneyDetailView.tsx
@@ -55,34 +55,34 @@ import type {
   Journey,
   JourneyCheckin,
   Review
-} from '../../../types';
-import { createChapter } from '../../actions/chapters';
+} from '../../../types/index.ts';
+import { createChapter } from '../../actions/chapters.ts';
 import {
   addCheckin,
   deleteJourney,
   finishJourney,
   removeCheckin,
   updateCheckin
-} from '../../actions/journeys';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
+} from '../../actions/journeys.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 import useLocalDateTime, {
   LOCAL_DATE_TIME_PLACEHOLDER
-} from '../../hooks/useLocalDateTime';
-import { createChapterContent } from '../../utils/chapterContent';
-import { trailDistanceMeters } from '../../utils/geo';
-import { deletePaused } from '../../utils/journeyPauseStorage';
-import { deleteTrail, loadTrail } from '../../utils/journeyTrailStorage';
-import { createMapFeatures } from '../../utils/mapFeatures';
-import { decodePath, encodePath } from '../../utils/polyline';
-import MapLinkChip from '../chapters/MapLinkChip';
-import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog';
-import NoContents from '../common/NoContents';
-import CheckinImageStrip from './CheckinImageStrip';
-import CheckinNoteField from './CheckinNoteField';
-import EndJourneyDialog from './EndJourneyDialog';
-import JourneyMap from './JourneyMap';
-import SpotPickerDialog from './SpotPickerDialog';
+} from '../../hooks/useLocalDateTime.ts';
+import { createChapterContent } from '../../utils/chapterContent.ts';
+import { trailDistanceMeters } from '../../utils/geo.ts';
+import { deletePaused } from '../../utils/journeyPauseStorage.ts';
+import { deleteTrail, loadTrail } from '../../utils/journeyTrailStorage.ts';
+import { createMapFeatures } from '../../utils/mapFeatures.ts';
+import { decodePath, encodePath } from '../../utils/polyline.ts';
+import MapLinkChip from '../chapters/MapLinkChip.tsx';
+import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog.tsx';
+import NoContents from '../common/NoContents.tsx';
+import CheckinImageStrip from './CheckinImageStrip.tsx';
+import CheckinNoteField from './CheckinNoteField.tsx';
+import EndJourneyDialog from './EndJourneyDialog.tsx';
+import JourneyMap from './JourneyMap.tsx';
+import SpotPickerDialog from './SpotPickerDialog.tsx';
 
 const DAY_OPTIONS: Intl.DateTimeFormatOptions = {
   year: 'numeric',

--- a/src/components/journeys/JourneyFab.tsx
+++ b/src/components/journeys/JourneyFab.tsx
@@ -1,12 +1,12 @@
 import { DirectionsWalk, Pause } from '@mui/icons-material';
 import { Box, Fab } from '@mui/material';
 import { memo, useContext, useEffect, useState } from 'react';
-import type { Journey } from '../../../types';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
-import WalkingFootprints from '../common/WalkingFootprints';
-import MapControl from '../maps/MapControl';
+import type { Journey } from '../../../types/index.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
+import WalkingFootprints from '../common/WalkingFootprints.tsx';
+import MapControl from '../maps/MapControl.tsx';
 
 type Props = {
   disabled: boolean;

--- a/src/components/journeys/JourneyMap.tsx
+++ b/src/components/journeys/JourneyMap.tsx
@@ -3,11 +3,11 @@
 import { Flag, Place } from '@mui/icons-material';
 import { Tooltip } from '@mui/material';
 import { memo, useEffect, useRef, useState } from 'react';
-import type { JourneyPathPoint, Spot } from '../../../types';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
-import { footprintIcons } from '../../utils/journeyTrailIcons';
-import GoogleMaps from '../maps/GoogleMaps';
-import MarkerView from '../maps/MarkerView';
+import type { JourneyPathPoint, Spot } from '../../../types/index.ts';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
+import { footprintIcons } from '../../utils/journeyTrailIcons.ts';
+import GoogleMaps from '../maps/GoogleMaps.tsx';
+import MarkerView from '../maps/MarkerView.tsx';
 
 // A flag in the primary color marks a milestone still to reach, the same way
 // ReviewMarker badges one on the map screen.

--- a/src/components/journeys/JourneyOverlay.tsx
+++ b/src/components/journeys/JourneyOverlay.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useRef, useState } from 'react';
-import type { JourneyPathPoint } from '../../../types';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
-import { footprintIcons } from '../../utils/journeyTrailIcons';
+import type { JourneyPathPoint } from '../../../types/index.ts';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
+import { footprintIcons } from '../../utils/journeyTrailIcons.ts';
 
 type Props = {
   position: GeolocationPosition | null;

--- a/src/components/journeys/JourneyProgressSheet.tsx
+++ b/src/components/journeys/JourneyProgressSheet.tsx
@@ -32,12 +32,12 @@ import type {
   Milestone,
   Review,
   Spot
-} from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalDateTime from '../../hooks/useLocalDateTime';
-import BottomSheet from '../common/BottomSheet';
-import CheckinImageStrip from './CheckinImageStrip';
-import CheckinNoteField from './CheckinNoteField';
+} from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalDateTime from '../../hooks/useLocalDateTime.ts';
+import BottomSheet from '../common/BottomSheet.tsx';
+import CheckinImageStrip from './CheckinImageStrip.tsx';
+import CheckinNoteField from './CheckinNoteField.tsx';
 
 const TIME_OPTIONS: Intl.DateTimeFormatOptions = {
   hour: '2-digit',

--- a/src/components/journeys/SpotPickerDialog.tsx
+++ b/src/components/journeys/SpotPickerDialog.tsx
@@ -8,10 +8,10 @@ import {
   ListItemText
 } from '@mui/material';
 import { memo } from 'react';
-import type { Review } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog from '../common/AppDialog';
-import NoContents from '../common/NoContents';
+import type { Review } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog from '../common/AppDialog.tsx';
+import NoContents from '../common/NoContents.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/journeys/StartJourneyDialog.tsx
+++ b/src/components/journeys/StartJourneyDialog.tsx
@@ -3,8 +3,8 @@
 import { AddLocationAlt, HistoryEdu, MyLocation } from '@mui/icons-material';
 import { List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
 import { memo, useCallback, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog from '../common/AppDialog';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog from '../common/AppDialog.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/layouts/AccountMenuButton.tsx
+++ b/src/components/layouts/AccountMenuButton.tsx
@@ -11,11 +11,11 @@ import { getAuth, signOut } from 'firebase/auth';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { memo, useContext, useRef, useState } from 'react';
-import AuthContext from '../../context/AuthContext';
-import ProfileContext from '../../context/ProfileContext';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import ProfileAvatar from '../common/ProfileAvatar';
+import AuthContext from '../../context/AuthContext.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import ProfileAvatar from '../common/ProfileAvatar.tsx';
 
 export default memo(function AccountMenuButton() {
   const { authenticated } = useContext(AuthContext);

--- a/src/components/layouts/BottomNav.tsx
+++ b/src/components/layouts/BottomNav.tsx
@@ -16,11 +16,11 @@ import {
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { memo, useContext, useEffect, useState } from 'react';
-import AuthContext from '../../context/AuthContext';
-import ProfileContext from '../../context/ProfileContext';
-import ShellContext from '../../context/ShellContext';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
+import AuthContext from '../../context/AuthContext.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import ShellContext from '../../context/ShellContext.tsx';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
 
 export default memo(function BottomNav() {
   const { authenticated } = useContext(AuthContext);

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -11,8 +11,8 @@ import {
 import { amber } from '@mui/material/colors';
 import Link from 'next/link';
 import { memo } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
 
 export default memo(function Footer() {
   const dictionary = useDictionary();

--- a/src/components/layouts/MiniDrawer.tsx
+++ b/src/components/layouts/MiniDrawer.tsx
@@ -30,15 +30,15 @@ import {
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { memo, useContext, useRef, useState } from 'react';
-import AuthContext from '../../context/AuthContext';
-import NotificationsContext from '../../context/NotificationsContext';
-import ProfileContext from '../../context/ProfileContext';
-import ShellContext from '../../context/ShellContext';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import NotificationList from '../notifications/NotificationList';
-import AccountMenuButton from './AccountMenuButton';
-import LogoAvatar from './LogoAvatar';
+import AuthContext from '../../context/AuthContext.ts';
+import NotificationsContext from '../../context/NotificationsContext.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import ShellContext from '../../context/ShellContext.tsx';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import NotificationList from '../notifications/NotificationList.tsx';
+import AccountMenuButton from './AccountMenuButton.tsx';
+import LogoAvatar from './LogoAvatar.tsx';
 
 export default memo(function MiniDrawer() {
   const { openSearch, openCreateMap } = useContext(ShellContext);

--- a/src/components/layouts/MobileAppBar.tsx
+++ b/src/components/layouts/MobileAppBar.tsx
@@ -13,15 +13,15 @@ import {
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { memo, useContext, useState } from 'react';
-import AuthContext from '../../context/AuthContext';
-import NotificationsContext from '../../context/NotificationsContext';
-import ProfileContext from '../../context/ProfileContext';
-import ShellContext from '../../context/ShellContext';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import ProfileAvatar from '../common/ProfileAvatar';
-import Logo from './Logo';
-import MobileDrawer from './MobileDrawer';
+import AuthContext from '../../context/AuthContext.ts';
+import NotificationsContext from '../../context/NotificationsContext.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import ShellContext from '../../context/ShellContext.tsx';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import ProfileAvatar from '../common/ProfileAvatar.tsx';
+import Logo from './Logo.tsx';
+import MobileDrawer from './MobileDrawer.tsx';
 
 function MobileAppBarContent() {
   const { openSearch, openCreateMap, appBarHidden } = useContext(ShellContext);

--- a/src/components/layouts/MobileDrawer.tsx
+++ b/src/components/layouts/MobileDrawer.tsx
@@ -29,12 +29,12 @@ import { getAuth, signOut } from 'firebase/auth';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { memo, useContext } from 'react';
-import AuthContext from '../../context/AuthContext';
-import ProfileContext from '../../context/ProfileContext';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import ProfileAvatar from '../common/ProfileAvatar';
-import Logo from './Logo';
+import AuthContext from '../../context/AuthContext.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import ProfileAvatar from '../common/ProfileAvatar.tsx';
+import Logo from './Logo.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/layouts/RecommendMaps.tsx
+++ b/src/components/layouts/RecommendMaps.tsx
@@ -1,10 +1,10 @@
 import { Box, Button, Typography } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { AppMap } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import MapGridList from '../maps/MapGridList';
+import type { AppMap } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import MapGridList from '../maps/MapGridList.tsx';
 
 type Props = {
   maps?: AppMap[];

--- a/src/components/layouts/SearchDialog.tsx
+++ b/src/components/layouts/SearchDialog.tsx
@@ -16,13 +16,13 @@ import {
 } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import { memo, useDeferredValue, useState } from 'react';
-import type { AppMap } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import { useMapSearch } from '../../hooks/useMapSearch';
-import AutocompleteListItem from '../common/AutocompleteListItem';
-import NoContents from '../common/NoContents';
-import SlideUpTransition from '../common/SlideUpTransition';
+import type { AppMap } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import { useMapSearch } from '../../hooks/useMapSearch.ts';
+import AutocompleteListItem from '../common/AutocompleteListItem.tsx';
+import NoContents from '../common/NoContents.tsx';
+import SlideUpTransition from '../common/SlideUpTransition.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/layouts/ShellProvider.tsx
+++ b/src/components/layouts/ShellProvider.tsx
@@ -2,13 +2,13 @@
 
 import { useRouter } from 'next/navigation';
 import { type ReactNode, useContext, useState } from 'react';
-import type { AppMap } from '../../../types';
-import AuthContext from '../../context/AuthContext';
-import ShellContext from '../../context/ShellContext';
-import useLocalePath from '../../hooks/useLocalePath';
-import SignInRequiredDialog from '../auth/SignInRequiredDialog';
-import CreateMapDialog from '../maps/CreateMapDialog';
-import SearchDialog from './SearchDialog';
+import type { AppMap } from '../../../types/index.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import ShellContext from '../../context/ShellContext.tsx';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import SignInRequiredDialog from '../auth/SignInRequiredDialog.tsx';
+import CreateMapDialog from '../maps/CreateMapDialog.tsx';
+import SearchDialog from './SearchDialog.tsx';
 
 type Props = {
   children: ReactNode;

--- a/src/components/layouts/Sidebar.tsx
+++ b/src/components/layouts/Sidebar.tsx
@@ -10,11 +10,11 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { AppMap } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import RecommendMaps from './RecommendMaps';
-import TrendingMaps from './TrendingMaps';
+import type { AppMap } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import RecommendMaps from './RecommendMaps.tsx';
+import TrendingMaps from './TrendingMaps.tsx';
 
 type Props = {
   popularMaps?: AppMap[];

--- a/src/components/layouts/TrendingMaps.tsx
+++ b/src/components/layouts/TrendingMaps.tsx
@@ -11,10 +11,10 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { AppMap } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import SkeletonTrendingList from './SkeletonTrendingList';
+import type { AppMap } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import SkeletonTrendingList from './SkeletonTrendingList.tsx';
 
 type Props = {
   maps?: AppMap[];

--- a/src/components/maps/BookmarkButton.tsx
+++ b/src/components/maps/BookmarkButton.tsx
@@ -2,10 +2,10 @@ import { BookmarkBorder } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
 import { memo, useCallback, useContext, useState, useTransition } from 'react';
-import type { AppMap } from '../../../types';
-import { bookmarkMap } from '../../actions/mapBookmarks';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
+import type { AppMap } from '../../../types/index.ts';
+import { bookmarkMap } from '../../actions/mapBookmarks.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/maps/CoauthorInviteDialog.tsx
+++ b/src/components/maps/CoauthorInviteDialog.tsx
@@ -17,10 +17,10 @@ import {
   useState,
   useTransition
 } from 'react';
-import type { AppMap, UserSearchResult } from '../../../types';
-import { inviteCoauthor, searchUsers } from '../../actions/coauthors';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog from '../common/AppDialog';
+import type { AppMap, UserSearchResult } from '../../../types/index.ts';
+import { inviteCoauthor, searchUsers } from '../../actions/coauthors.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog from '../common/AppDialog.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/maps/Coauthors.tsx
+++ b/src/components/maps/Coauthors.tsx
@@ -2,8 +2,8 @@
 
 import { Avatar, AvatarGroup, ButtonBase } from '@mui/material';
 import { memo, useState } from 'react';
-import type { AppMap, Coauthor, Profile } from '../../../types';
-import CoauthorsDialog from './CoauthorsDialog';
+import type { AppMap, Coauthor, Profile } from '../../../types/index.ts';
+import CoauthorsDialog from './CoauthorsDialog.tsx';
 
 type Props = {
   coauthors: Coauthor[];

--- a/src/components/maps/CoauthorsDialog.tsx
+++ b/src/components/maps/CoauthorsDialog.tsx
@@ -15,11 +15,11 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { memo, useState } from 'react';
-import type { AppMap, Coauthor } from '../../../types';
-import { removeCoauthor } from '../../actions/coauthors';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog from '../common/AppDialog';
-import ConfirmDialog from '../common/ConfirmDialog';
+import type { AppMap, Coauthor } from '../../../types/index.ts';
+import { removeCoauthor } from '../../actions/coauthors.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog from '../common/AppDialog.tsx';
+import ConfirmDialog from '../common/ConfirmDialog.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/maps/CoodinatesConverter.tsx
+++ b/src/components/maps/CoodinatesConverter.tsx
@@ -1,10 +1,10 @@
 import { Box, Paper } from '@mui/material';
 import { memo, useEffect, useRef, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
-import DraggableMarker from './DraggableMarker';
-import MapControl from './MapControl';
-import PlaceAutocomplete from './PlaceAutocomplete';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
+import DraggableMarker from './DraggableMarker.tsx';
+import MapControl from './MapControl.tsx';
+import PlaceAutocomplete from './PlaceAutocomplete.tsx';
 
 type Props = {
   onChange: (center: google.maps.LatLngLiteral) => void;

--- a/src/components/maps/CreateMapDialog.tsx
+++ b/src/components/maps/CreateMapDialog.tsx
@@ -14,16 +14,16 @@ import {
   useState,
   useTransition
 } from 'react';
-import type { AppMap } from '../../../types';
-import { createMap } from '../../actions/maps';
-import useDictionary from '../../hooks/useDictionary';
-import usePhotoUploads from '../../hooks/usePhotoUploads';
-import AddPhotoButton from '../common/AddPhotoButton';
-import AppDialog from '../common/AppDialog';
-import MapDescriptionForm from './MapDescriptionForm';
-import MapNameForm from './MapNameForm';
-import MapOptions from './MapOptions';
-import PositionForm from './PositionForm';
+import type { AppMap } from '../../../types/index.ts';
+import { createMap } from '../../actions/maps.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import usePhotoUploads from '../../hooks/usePhotoUploads.ts';
+import AddPhotoButton from '../common/AddPhotoButton.tsx';
+import AppDialog from '../common/AppDialog.tsx';
+import MapDescriptionForm from './MapDescriptionForm.tsx';
+import MapNameForm from './MapNameForm.tsx';
+import MapOptions from './MapOptions.tsx';
+import PositionForm from './PositionForm.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/maps/CurrentPositionButton.tsx
+++ b/src/components/maps/CurrentPositionButton.tsx
@@ -1,7 +1,7 @@
 import { MyLocation } from '@mui/icons-material';
 import { Box, CircularProgress, Fab } from '@mui/material';
 import { memo, useState } from 'react';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
 
 function CurrentPositionButton() {
   const { googleMap, setCurrentPosition } = useGoogleMap();

--- a/src/components/maps/CurrentPositionMarker.tsx
+++ b/src/components/maps/CurrentPositionMarker.tsx
@@ -17,11 +17,11 @@ import {
   Typography
 } from '@mui/material';
 import { memo, useEffect, useRef, useState } from 'react';
-import type { Profile } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
-import ProfileAvatar from '../common/ProfileAvatar';
-import MarkerView from './MarkerView';
+import type { Profile } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
+import ProfileAvatar from '../common/ProfileAvatar.tsx';
+import MarkerView from './MarkerView.tsx';
 
 const StyledBadge = styled(Badge)(({ theme }) => ({
   '& .MuiBadge-badge': {

--- a/src/components/maps/CustomMapControls.tsx
+++ b/src/components/maps/CustomMapControls.tsx
@@ -1,10 +1,10 @@
 import { Box, Paper, Stack, useMediaQuery, useTheme } from '@mui/material';
 import { memo, useEffect, useRef, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
-import CurrentPositionButton from './CurrentPositionButton';
-import MapControl from './MapControl';
-import PlaceAutocomplete from './PlaceAutocomplete';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
+import CurrentPositionButton from './CurrentPositionButton.tsx';
+import MapControl from './MapControl.tsx';
+import PlaceAutocomplete from './PlaceAutocomplete.tsx';
 
 type Props = {
   onPlaceChange: (place: google.maps.places.Place) => void;

--- a/src/components/maps/CustomOverlays.tsx
+++ b/src/components/maps/CustomOverlays.tsx
@@ -8,16 +8,16 @@ import {
   useRef,
   useState
 } from 'react';
-import type { AppMap, Review } from '../../../types';
-import ProfileContext from '../../context/ProfileContext';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
-import CreateReviewDialog from '../reviews/CreateReviewDialog';
-import CurrentPositionMarker from './CurrentPositionMarker';
-import CustomMapControls from './CustomMapControls';
-import PlaceInfoWindow from './PlaceInfoWindow';
-import PositionInfoWindow from './PositionInfoWindow';
-import ReviewMarker from './ReviewMarker';
-import ReviewPopover from './ReviewPopover';
+import type { AppMap, Review } from '../../../types/index.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
+import CreateReviewDialog from '../reviews/CreateReviewDialog.tsx';
+import CurrentPositionMarker from './CurrentPositionMarker.tsx';
+import CustomMapControls from './CustomMapControls.tsx';
+import PlaceInfoWindow from './PlaceInfoWindow.tsx';
+import PositionInfoWindow from './PositionInfoWindow.tsx';
+import ReviewMarker from './ReviewMarker.tsx';
+import ReviewPopover from './ReviewPopover.tsx';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/maps/DeleteMapDialog.tsx
+++ b/src/components/maps/DeleteMapDialog.tsx
@@ -1,9 +1,9 @@
 import { enqueueSnackbar } from 'notistack';
 import { memo, useCallback } from 'react';
-import type { AppMap } from '../../../types';
-import { deleteMap } from '../../actions/maps';
-import useDictionary from '../../hooks/useDictionary';
-import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog';
+import type { AppMap } from '../../../types/index.ts';
+import { deleteMap } from '../../actions/maps.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog.tsx';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/maps/DraggableMarker.tsx
+++ b/src/components/maps/DraggableMarker.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
 
 type Props = {
   defaultPosition?: google.maps.LatLng | google.maps.LatLngLiteral | null;

--- a/src/components/maps/EditMapDialog.tsx
+++ b/src/components/maps/EditMapDialog.tsx
@@ -14,16 +14,16 @@ import {
   useState,
   useTransition
 } from 'react';
-import type { AppMap } from '../../../types';
-import { updateMap } from '../../actions/maps';
-import useDictionary from '../../hooks/useDictionary';
-import usePhotoUploads from '../../hooks/usePhotoUploads';
-import AddPhotoButton from '../common/AddPhotoButton';
-import AppDialog from '../common/AppDialog';
-import MapDescriptionForm from './MapDescriptionForm';
-import MapNameForm from './MapNameForm';
-import MapOptions from './MapOptions';
-import PositionForm from './PositionForm';
+import type { AppMap } from '../../../types/index.ts';
+import { updateMap } from '../../actions/maps.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import usePhotoUploads from '../../hooks/usePhotoUploads.ts';
+import AddPhotoButton from '../common/AddPhotoButton.tsx';
+import AppDialog from '../common/AppDialog.tsx';
+import MapDescriptionForm from './MapDescriptionForm.tsx';
+import MapNameForm from './MapNameForm.tsx';
+import MapOptions from './MapOptions.tsx';
+import PositionForm from './PositionForm.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/maps/GoogleMaps.tsx
+++ b/src/components/maps/GoogleMaps.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState
 } from 'react';
-import GoogleMapsContext from '../../context/GoogleMapsContext';
+import GoogleMapsContext from '../../context/GoogleMapsContext.ts';
 
 type Props = {
   mapId: string;

--- a/src/components/maps/InfoWindow.tsx
+++ b/src/components/maps/InfoWindow.tsx
@@ -1,6 +1,6 @@
 import { memo, type ReactNode, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
 
 type Props = {
   children: ReactNode;

--- a/src/components/maps/MapAutocompleteOption.tsx
+++ b/src/components/maps/MapAutocompleteOption.tsx
@@ -3,7 +3,7 @@ import { Grid, Typography } from '@mui/material';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
 import { memo } from 'react';
-import type { AppMap } from '../../../types';
+import type { AppMap } from '../../../types/index.ts';
 
 type Props = {
   option: AppMap;

--- a/src/components/maps/MapCardHeader.tsx
+++ b/src/components/maps/MapCardHeader.tsx
@@ -9,9 +9,9 @@ import { enUS, ja } from 'date-fns/locale';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { memo, type ReactNode } from 'react';
-import type { AppMap } from '../../../types';
-import useLocalePath from '../../hooks/useLocalePath';
-import AuthorAvatar from '../common/AuthorAvatar';
+import type { AppMap } from '../../../types/index.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import AuthorAvatar from '../common/AuthorAvatar.tsx';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/maps/MapChapterList.tsx
+++ b/src/components/maps/MapChapterList.tsx
@@ -10,11 +10,11 @@ import {
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { memo } from 'react';
-import type { Chapter } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalDateTime from '../../hooks/useLocalDateTime';
-import AuthorAvatar from '../common/AuthorAvatar';
-import NoContents from '../common/NoContents';
+import type { Chapter } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalDateTime from '../../hooks/useLocalDateTime.ts';
+import AuthorAvatar from '../common/AuthorAvatar.tsx';
+import NoContents from '../common/NoContents.tsx';
 
 const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
   year: 'numeric',

--- a/src/components/maps/MapControl.tsx
+++ b/src/components/maps/MapControl.tsx
@@ -1,6 +1,6 @@
 import { memo, type ReactNode, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
 
 type Props = {
   children: ReactNode;

--- a/src/components/maps/MapDescriptionForm.tsx
+++ b/src/components/maps/MapDescriptionForm.tsx
@@ -1,6 +1,6 @@
 import { TextField } from '@mui/material';
 import { type ChangeEvent, memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 const MAX_LENGTH = 200;
 

--- a/src/components/maps/MapDetailTabs.tsx
+++ b/src/components/maps/MapDetailTabs.tsx
@@ -2,10 +2,10 @@ import { HistoryEdu, Place } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Tab } from '@mui/material';
 import { memo, type SyntheticEvent, useState } from 'react';
-import type { Chapter, Review } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import MapChapterList from './MapChapterList';
-import MapReviewList from './MapReviewList';
+import type { Chapter, Review } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import MapChapterList from './MapChapterList.tsx';
+import MapReviewList from './MapReviewList.tsx';
 
 type Props = {
   reviews: Review[];

--- a/src/components/maps/MapDetailView.tsx
+++ b/src/components/maps/MapDetailView.tsx
@@ -11,23 +11,23 @@ import type {
   Journey,
   Profile,
   Review
-} from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import useJourney, { type PauseReason } from '../../hooks/useJourney';
-import IssueDialog from '../common/IssueDialog';
-import EndJourneyDialog from '../journeys/EndJourneyDialog';
-import JourneyFab from '../journeys/JourneyFab';
-import JourneyOverlay from '../journeys/JourneyOverlay';
-import JourneyProgressSheet from '../journeys/JourneyProgressSheet';
-import StartJourneyDialog from '../journeys/StartJourneyDialog';
-import CustomOverlays from './CustomOverlays';
-import { drawerBleeding } from './constants';
-import DeleteMapDialog from './DeleteMapDialog';
-import EditMapDialog from './EditMapDialog';
-import GoogleMaps from './GoogleMaps';
-import MapSummaryCard from './MapSummaryCard';
-import MobileMapDrawer from './MobileMapDrawer';
-import ReviewDrawer from './ReviewDrawer';
+} from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useJourney, { type PauseReason } from '../../hooks/useJourney.ts';
+import IssueDialog from '../common/IssueDialog.tsx';
+import EndJourneyDialog from '../journeys/EndJourneyDialog.tsx';
+import JourneyFab from '../journeys/JourneyFab.tsx';
+import JourneyOverlay from '../journeys/JourneyOverlay.tsx';
+import JourneyProgressSheet from '../journeys/JourneyProgressSheet.tsx';
+import StartJourneyDialog from '../journeys/StartJourneyDialog.tsx';
+import CustomOverlays from './CustomOverlays.tsx';
+import { drawerBleeding } from './constants.ts';
+import DeleteMapDialog from './DeleteMapDialog.tsx';
+import EditMapDialog from './EditMapDialog.tsx';
+import GoogleMaps from './GoogleMaps.tsx';
+import MapSummaryCard from './MapSummaryCard.tsx';
+import MobileMapDrawer from './MobileMapDrawer.tsx';
+import ReviewDrawer from './ReviewDrawer.tsx';
 
 const summaryCardHeight = 360;
 

--- a/src/components/maps/MapGridList.tsx
+++ b/src/components/maps/MapGridList.tsx
@@ -15,9 +15,9 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { AppMap } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
+import type { AppMap } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
 
 type Props = {
   maps: AppMap[];

--- a/src/components/maps/MapMenuButton.tsx
+++ b/src/components/maps/MapMenuButton.tsx
@@ -17,12 +17,12 @@ import {
 import { useParams } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { memo, useContext, useRef, useState } from 'react';
-import type { AppMap, Profile } from '../../../types';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import { localePath } from '../../utils/locales';
-import { SITE_ORIGIN } from '../../utils/metadata';
-import CoauthorInviteDialog from './CoauthorInviteDialog';
+import type { AppMap, Profile } from '../../../types/index.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { localePath } from '../../utils/locales.ts';
+import { SITE_ORIGIN } from '../../utils/metadata.ts';
+import CoauthorInviteDialog from './CoauthorInviteDialog.tsx';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/maps/MapNameForm.tsx
+++ b/src/components/maps/MapNameForm.tsx
@@ -1,6 +1,6 @@
 import { TextField } from '@mui/material';
 import { type ChangeEvent, memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 const MAX_LENGTH = 30;
 

--- a/src/components/maps/MapOptions.tsx
+++ b/src/components/maps/MapOptions.tsx
@@ -6,8 +6,8 @@ import {
   Switch
 } from '@mui/material';
 import { type ChangeEvent, memo, useEffect, useState } from 'react';
-import type { AppMap } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
+import type { AppMap } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type MapOptions = {
   isPrivate: boolean;

--- a/src/components/maps/MapReviewList.tsx
+++ b/src/components/maps/MapReviewList.tsx
@@ -9,10 +9,10 @@ import {
 } from '@mui/material';
 import { usePathname, useRouter } from 'next/navigation';
 import { memo } from 'react';
-import type { Review } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import AuthorAvatar from '../common/AuthorAvatar';
-import NoContents from '../common/NoContents';
+import type { Review } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AuthorAvatar from '../common/AuthorAvatar.tsx';
+import NoContents from '../common/NoContents.tsx';
 
 type Props = {
   reviews: Review[];

--- a/src/components/maps/MapSummaryCard.tsx
+++ b/src/components/maps/MapSummaryCard.tsx
@@ -16,15 +16,15 @@ import type {
   Coauthor,
   Profile,
   Review
-} from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import BookmarkButton from './BookmarkButton';
-import Coauthors from './Coauthors';
-import MapCardHeader from './MapCardHeader';
-import MapDetailTabs from './MapDetailTabs';
-import MapMenuButton from './MapMenuButton';
-import PrivateMapChip from './PrivateMapChip';
-import RemoveBookmarkButton from './RemoveBookmarkButton';
+} from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import BookmarkButton from './BookmarkButton.tsx';
+import Coauthors from './Coauthors.tsx';
+import MapCardHeader from './MapCardHeader.tsx';
+import MapDetailTabs from './MapDetailTabs.tsx';
+import MapMenuButton from './MapMenuButton.tsx';
+import PrivateMapChip from './PrivateMapChip.tsx';
+import RemoveBookmarkButton from './RemoveBookmarkButton.tsx';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/maps/MarkerView.tsx
+++ b/src/components/maps/MarkerView.tsx
@@ -7,7 +7,7 @@ import {
   useState
 } from 'react';
 import { createPortal } from 'react-dom';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
 
 type Props = {
   children: ReactNode;

--- a/src/components/maps/MobileMapDrawer.tsx
+++ b/src/components/maps/MobileMapDrawer.tsx
@@ -14,18 +14,18 @@ import type {
   Coauthor,
   Profile,
   Review
-} from '../../../types';
-import ShellContext from '../../context/ShellContext';
-import useDictionary from '../../hooks/useDictionary';
-import BookmarkButton from './BookmarkButton';
-import Coauthors from './Coauthors';
-import { drawerBleeding } from './constants';
-import MapCardHeader from './MapCardHeader';
-import MapDetailTabs from './MapDetailTabs';
-import MapMenuButton from './MapMenuButton';
-import MobileMiniMapHeader from './MobileMiniMapHeader';
-import PrivateMapChip from './PrivateMapChip';
-import RemoveBookmarkButton from './RemoveBookmarkButton';
+} from '../../../types/index.ts';
+import ShellContext from '../../context/ShellContext.tsx';
+import useDictionary from '../../hooks/useDictionary.ts';
+import BookmarkButton from './BookmarkButton.tsx';
+import Coauthors from './Coauthors.tsx';
+import { drawerBleeding } from './constants.ts';
+import MapCardHeader from './MapCardHeader.tsx';
+import MapDetailTabs from './MapDetailTabs.tsx';
+import MapMenuButton from './MapMenuButton.tsx';
+import MobileMiniMapHeader from './MobileMiniMapHeader.tsx';
+import PrivateMapChip from './PrivateMapChip.tsx';
+import RemoveBookmarkButton from './RemoveBookmarkButton.tsx';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/maps/MobileMiniMapHeader.tsx
+++ b/src/components/maps/MobileMiniMapHeader.tsx
@@ -1,9 +1,9 @@
 import { Lock } from '@mui/icons-material';
 import { Avatar, CardHeader, Skeleton, type SxProps } from '@mui/material';
 import { memo, type ReactNode } from 'react';
-import type { AppMap, Review } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import DrawerPuller from '../common/DrawerPuller';
+import type { AppMap, Review } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import DrawerPuller from '../common/DrawerPuller.tsx';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/maps/PlaceInfoWindow.tsx
+++ b/src/components/maps/PlaceInfoWindow.tsx
@@ -1,8 +1,8 @@
 import { Add } from '@mui/icons-material';
 import { Box, Button, Typography } from '@mui/material';
 import { memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import InfoWindow from './InfoWindow';
+import useDictionary from '../../hooks/useDictionary.ts';
+import InfoWindow from './InfoWindow.tsx';
 
 type Props = {
   disableCreateReview: boolean;

--- a/src/components/maps/PositionForm.tsx
+++ b/src/components/maps/PositionForm.tsx
@@ -1,10 +1,10 @@
 import { Done, Edit } from '@mui/icons-material';
 import { Box, Button, Chip, Stack } from '@mui/material';
 import { memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import CoodinatesConverter from './CoodinatesConverter';
-import GoogleMaps from './GoogleMaps';
-import StaticMap from './StaticMap';
+import useDictionary from '../../hooks/useDictionary.ts';
+import CoodinatesConverter from './CoodinatesConverter.tsx';
+import GoogleMaps from './GoogleMaps.tsx';
+import StaticMap from './StaticMap.tsx';
 
 type Props = {
   onChange: (position: google.maps.LatLngLiteral) => void;

--- a/src/components/maps/PositionInfoWindow.tsx
+++ b/src/components/maps/PositionInfoWindow.tsx
@@ -8,8 +8,8 @@ import {
   ListItemText
 } from '@mui/material';
 import { memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import InfoWindow from './InfoWindow';
+import useDictionary from '../../hooks/useDictionary.ts';
+import InfoWindow from './InfoWindow.tsx';
 
 type Props = {
   disableCreateReview: boolean;

--- a/src/components/maps/PrivateMapChip.tsx
+++ b/src/components/maps/PrivateMapChip.tsx
@@ -1,7 +1,7 @@
 import { Lock } from '@mui/icons-material';
 import { Chip, Typography } from '@mui/material';
 import { memo } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 function PrivateMapChip() {
   const dictionary = useDictionary();

--- a/src/components/maps/RemoveBookmarkButton.tsx
+++ b/src/components/maps/RemoveBookmarkButton.tsx
@@ -9,10 +9,10 @@ import {
   useState,
   useTransition
 } from 'react';
-import type { AppMap, Profile } from '../../../types';
-import { removeBookmark } from '../../actions/mapBookmarks';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
+import type { AppMap, Profile } from '../../../types/index.ts';
+import { removeBookmark } from '../../actions/mapBookmarks.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   map: AppMap | null;

--- a/src/components/maps/ReviewDrawer.tsx
+++ b/src/components/maps/ReviewDrawer.tsx
@@ -11,17 +11,17 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { memo, useCallback, useContext, useState } from 'react';
-import type { Review } from '../../../types';
-import ProfileContext from '../../context/ProfileContext';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import BottomSheet from '../common/BottomSheet';
-import IssueDialog from '../common/IssueDialog';
-import DeleteReviewDialog from '../reviews/DeleteReviewDialog';
-import EditReviewDialog from '../reviews/EditReviewDialog';
-import LikeReviewButton from '../reviews/LikeReviewButton';
-import ReviewCardHeader from '../reviews/ReviewCardHeader';
-import ReviewMenuButton from '../reviews/ReviewMenuButton';
+import type { Review } from '../../../types/index.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import BottomSheet from '../common/BottomSheet.tsx';
+import IssueDialog from '../common/IssueDialog.tsx';
+import DeleteReviewDialog from '../reviews/DeleteReviewDialog.tsx';
+import EditReviewDialog from '../reviews/EditReviewDialog.tsx';
+import LikeReviewButton from '../reviews/LikeReviewButton.tsx';
+import ReviewCardHeader from '../reviews/ReviewCardHeader.tsx';
+import ReviewMenuButton from '../reviews/ReviewMenuButton.tsx';
 
 type MilestoneAction = {
   selected: boolean;

--- a/src/components/maps/ReviewMarker.tsx
+++ b/src/components/maps/ReviewMarker.tsx
@@ -14,10 +14,10 @@ import {
   useRef,
   useState
 } from 'react';
-import type { Review } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import { useGoogleMap } from '../../hooks/useGoogleMap';
-import MarkerView from './MarkerView';
+import type { Review } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
+import MarkerView from './MarkerView.tsx';
 
 type Props = {
   review: Review;

--- a/src/components/maps/ReviewPopover.tsx
+++ b/src/components/maps/ReviewPopover.tsx
@@ -9,19 +9,19 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { memo, useContext, useState } from 'react';
-import type { Review } from '../../../types';
-import ReviewCardHeader from '../reviews/ReviewCardHeader';
-import ReviewMenuButton from '../reviews/ReviewMenuButton';
+import type { Review } from '../../../types/index.ts';
+import ReviewCardHeader from '../reviews/ReviewCardHeader.tsx';
+import ReviewMenuButton from '../reviews/ReviewMenuButton.tsx';
 import 'swiper/css';
 import 'swiper/css/pagination';
 import { Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import ProfileContext from '../../context/ProfileContext';
-import useLocalePath from '../../hooks/useLocalePath';
-import IssueDialog from '../common/IssueDialog';
-import DeleteReviewDialog from '../reviews/DeleteReviewDialog';
-import EditReviewDialog from '../reviews/EditReviewDialog';
-import LikeReviewButton from '../reviews/LikeReviewButton';
+import ProfileContext from '../../context/ProfileContext.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import IssueDialog from '../common/IssueDialog.tsx';
+import DeleteReviewDialog from '../reviews/DeleteReviewDialog.tsx';
+import EditReviewDialog from '../reviews/EditReviewDialog.tsx';
+import LikeReviewButton from '../reviews/LikeReviewButton.tsx';
 
 type Props = {
   currentReview: Review | null;

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -14,14 +14,14 @@ import { enUS, ja } from 'date-fns/locale';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { memo, useContext, useEffect, useRef, useState } from 'react';
-import type { Notification } from '../../../types';
-import { markNotificationAsRead } from '../../actions/notifications';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import { LOCAL_DATE_TIME_PLACEHOLDER } from '../../hooks/useLocalDateTime';
-import sleep from '../../utils/sleep';
-import AuthorAvatar from '../common/AuthorAvatar';
-import NoContents from '../common/NoContents';
+import type { Notification } from '../../../types/index.ts';
+import { markNotificationAsRead } from '../../actions/notifications.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { LOCAL_DATE_TIME_PLACEHOLDER } from '../../hooks/useLocalDateTime.ts';
+import sleep from '../../utils/sleep.ts';
+import AuthorAvatar from '../common/AuthorAvatar.tsx';
+import NoContents from '../common/NoContents.tsx';
 
 type Props = {
   notifications: Notification[];

--- a/src/components/notifications/NotificationsFeed.tsx
+++ b/src/components/notifications/NotificationsFeed.tsx
@@ -1,8 +1,8 @@
 'use client';
 import { List } from '@mui/material';
 import { useRouter } from 'next/navigation';
-import type { Notification } from '../../../types';
-import NotificationList from './NotificationList';
+import type { Notification } from '../../../types/index.ts';
+import NotificationList from './NotificationList.tsx';
 
 type Props = {
   notifications: Notification[];

--- a/src/components/profiles/BiographyForm.tsx
+++ b/src/components/profiles/BiographyForm.tsx
@@ -1,6 +1,6 @@
 import { TextField } from '@mui/material';
 import { type ChangeEvent, memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 const MAX_LENGTH = 160;
 

--- a/src/components/profiles/EditProfileDialog.tsx
+++ b/src/components/profiles/EditProfileDialog.tsx
@@ -14,16 +14,16 @@ import {
   useState,
   useTransition
 } from 'react';
-import type { Journal, Profile } from '../../../types';
-import { updateJournal } from '../../actions/journals';
-import { updateProfile } from '../../actions/users';
-import useDictionary from '../../hooks/useDictionary';
-import usePhotoUploads from '../../hooks/usePhotoUploads';
-import AddPhotoButton from '../common/AddPhotoButton';
-import AppDialog from '../common/AppDialog';
-import BiographyForm from './BiographyForm';
-import JournalTitleForm from './JournalTitleForm';
-import ProfileNameForm from './ProfileNameForm';
+import type { Journal, Profile } from '../../../types/index.ts';
+import { updateJournal } from '../../actions/journals.ts';
+import { updateProfile } from '../../actions/users.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import usePhotoUploads from '../../hooks/usePhotoUploads.ts';
+import AddPhotoButton from '../common/AddPhotoButton.tsx';
+import AppDialog from '../common/AppDialog.tsx';
+import BiographyForm from './BiographyForm.tsx';
+import JournalTitleForm from './JournalTitleForm.tsx';
+import ProfileNameForm from './ProfileNameForm.tsx';
 
 type Props = {
   currentProfile: Profile | null;

--- a/src/components/profiles/JournalBookmarkButton.tsx
+++ b/src/components/profiles/JournalBookmarkButton.tsx
@@ -4,13 +4,13 @@ import { Bookmark, BookmarkBorder } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
 import { memo, useCallback, useContext, useState, useTransition } from 'react';
-import type { Journal } from '../../../types';
+import type { Journal } from '../../../types/index.ts';
 import {
   bookmarkJournal,
   removeJournalBookmark
-} from '../../actions/journalBookmarks';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
+} from '../../actions/journalBookmarks.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   journal: Journal;

--- a/src/components/profiles/JournalTitleForm.tsx
+++ b/src/components/profiles/JournalTitleForm.tsx
@@ -1,6 +1,6 @@
 import { TextField } from '@mui/material';
 import { type ChangeEvent, memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 const MAX_LENGTH = 50;
 

--- a/src/components/profiles/ProfileNameForm.tsx
+++ b/src/components/profiles/ProfileNameForm.tsx
@@ -1,6 +1,6 @@
 import { TextField } from '@mui/material';
 import { type ChangeEvent, memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 const MAX_LENGTH = 30;
 

--- a/src/components/profiles/UserBookmarks.tsx
+++ b/src/components/profiles/UserBookmarks.tsx
@@ -1,9 +1,9 @@
 import { Bookmarks } from '@mui/icons-material';
 import { memo } from 'react';
-import type { AppMap } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import NoContents from '../common/NoContents';
-import MapGridList from '../maps/MapGridList';
+import type { AppMap } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import NoContents from '../common/NoContents.tsx';
+import MapGridList from '../maps/MapGridList.tsx';
 
 type Props = {
   maps: AppMap[];

--- a/src/components/profiles/UserChapters.tsx
+++ b/src/components/profiles/UserChapters.tsx
@@ -19,12 +19,12 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { type MouseEvent, memo, useState } from 'react';
-import type { Chapter } from '../../../types';
-import { deleteChapter } from '../../actions/chapters';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalDateTime from '../../hooks/useLocalDateTime';
-import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog';
-import NoContents from '../common/NoContents';
+import type { Chapter } from '../../../types/index.ts';
+import { deleteChapter } from '../../actions/chapters.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalDateTime from '../../hooks/useLocalDateTime.ts';
+import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog.tsx';
+import NoContents from '../common/NoContents.tsx';
 
 const THUMBNAIL_SIZE = { xs: 80, sm: 100 };
 

--- a/src/components/profiles/UserJourneys.tsx
+++ b/src/components/profiles/UserJourneys.tsx
@@ -18,12 +18,12 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { type MouseEvent, memo, useState } from 'react';
-import type { JourneySummary } from '../../../types';
-import { deleteJourney } from '../../actions/journeys';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalDateTime from '../../hooks/useLocalDateTime';
-import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog';
-import NoContents from '../common/NoContents';
+import type { JourneySummary } from '../../../types/index.ts';
+import { deleteJourney } from '../../actions/journeys.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalDateTime from '../../hooks/useLocalDateTime.ts';
+import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog.tsx';
+import NoContents from '../common/NoContents.tsx';
 
 const DATE_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
   year: 'numeric',

--- a/src/components/profiles/UserMaps.tsx
+++ b/src/components/profiles/UserMaps.tsx
@@ -1,9 +1,9 @@
 import { Map as MapIcon } from '@mui/icons-material';
 import { memo } from 'react';
-import type { AppMap } from '../../../types';
-import useDictionary from '../../hooks/useDictionary';
-import NoContents from '../common/NoContents';
-import MapGridList from '../maps/MapGridList';
+import type { AppMap } from '../../../types/index.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import NoContents from '../common/NoContents.tsx';
+import MapGridList from '../maps/MapGridList.tsx';
 
 type Props = {
   maps: AppMap[];

--- a/src/components/profiles/UserProfile.tsx
+++ b/src/components/profiles/UserProfile.tsx
@@ -19,15 +19,21 @@ import {
   useContext,
   useState
 } from 'react';
-import type { AppMap, Chapter, Journal, Profile, Review } from '../../../types';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import ProfileAvatar from '../common/ProfileAvatar';
-import EditProfileDialog from './EditProfileDialog';
-import JournalBookmarkButton from './JournalBookmarkButton';
-import UserChapters from './UserChapters';
-import UserMaps from './UserMaps';
-import UserReviews from './UserReviews';
+import type {
+  AppMap,
+  Chapter,
+  Journal,
+  Profile,
+  Review
+} from '../../../types/index.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import ProfileAvatar from '../common/ProfileAvatar.tsx';
+import EditProfileDialog from './EditProfileDialog.tsx';
+import JournalBookmarkButton from './JournalBookmarkButton.tsx';
+import UserChapters from './UserChapters.tsx';
+import UserMaps from './UserMaps.tsx';
+import UserReviews from './UserReviews.tsx';
 
 type Props = {
   profile: Profile;

--- a/src/components/profiles/UserReviews.tsx
+++ b/src/components/profiles/UserReviews.tsx
@@ -1,15 +1,15 @@
 import { Reviews } from '@mui/icons-material';
 import { Button, Stack } from '@mui/material';
 import { memo, useState, useTransition } from 'react';
-import type { Review } from '../../../types';
+import type { Review } from '../../../types/index.ts';
 import {
   fetchMoreMyReviews,
   fetchMoreUserReviews
-} from '../../actions/reviews';
-import useDictionary from '../../hooks/useDictionary';
-import LoadingStatus from '../common/LoadingStatus';
-import NoContents from '../common/NoContents';
-import ReviewGridList from '../reviews/ReviewGridList';
+} from '../../actions/reviews.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import LoadingStatus from '../common/LoadingStatus.tsx';
+import NoContents from '../common/NoContents.tsx';
+import ReviewGridList from '../reviews/ReviewGridList.tsx';
 
 type Props = {
   userId: number;

--- a/src/components/reviews/CommentMenuButton.tsx
+++ b/src/components/reviews/CommentMenuButton.tsx
@@ -7,9 +7,9 @@ import {
   MenuItem
 } from '@mui/material';
 import { memo, useContext, useRef, useState } from 'react';
-import type { Comment, Profile } from '../../../types';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
+import type { Comment, Profile } from '../../../types/index.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   comment: Comment;

--- a/src/components/reviews/CreateReviewDialog.tsx
+++ b/src/components/reviews/CreateReviewDialog.tsx
@@ -8,16 +8,16 @@ import {
   useState,
   useTransition
 } from 'react';
-import type { AppMap } from '../../../types';
-import { createReview } from '../../actions/reviews';
-import useDictionary from '../../hooks/useDictionary';
-import usePhotoUploads from '../../hooks/usePhotoUploads';
-import AddPhotoButton from '../common/AddPhotoButton';
-import AppDialog from '../common/AppDialog';
-import PhotoPreviewList from '../common/PhotoPreviewList';
-import PositionForm from '../maps/PositionForm';
-import ReviewDescriptionForm from './ReviewDescriptionForm';
-import ReviewNameForm from './ReviewNameForm';
+import type { AppMap } from '../../../types/index.ts';
+import { createReview } from '../../actions/reviews.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import usePhotoUploads from '../../hooks/usePhotoUploads.ts';
+import AddPhotoButton from '../common/AddPhotoButton.tsx';
+import AppDialog from '../common/AppDialog.tsx';
+import PhotoPreviewList from '../common/PhotoPreviewList.tsx';
+import PositionForm from '../maps/PositionForm.tsx';
+import ReviewDescriptionForm from './ReviewDescriptionForm.tsx';
+import ReviewNameForm from './ReviewNameForm.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/reviews/DeleteCommentDialog.tsx
+++ b/src/components/reviews/DeleteCommentDialog.tsx
@@ -1,9 +1,9 @@
 import { enqueueSnackbar } from 'notistack';
 import { memo, useCallback } from 'react';
-import type { Comment } from '../../../types';
-import { deleteComment } from '../../actions/comments';
-import useDictionary from '../../hooks/useDictionary';
-import ConfirmDialog from '../common/ConfirmDialog';
+import type { Comment } from '../../../types/index.ts';
+import { deleteComment } from '../../actions/comments.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import ConfirmDialog from '../common/ConfirmDialog.tsx';
 
 type Props = {
   comment: Comment | null;

--- a/src/components/reviews/DeleteReviewDialog.tsx
+++ b/src/components/reviews/DeleteReviewDialog.tsx
@@ -1,9 +1,9 @@
 import { enqueueSnackbar } from 'notistack';
 import { memo, useCallback } from 'react';
-import type { Review } from '../../../types';
-import { deleteReview } from '../../actions/reviews';
-import useDictionary from '../../hooks/useDictionary';
-import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog';
+import type { Review } from '../../../types/index.ts';
+import { deleteReview } from '../../actions/reviews.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog.tsx';
 
 type Props = {
   review: Review | null;

--- a/src/components/reviews/EditReviewDialog.tsx
+++ b/src/components/reviews/EditReviewDialog.tsx
@@ -8,16 +8,16 @@ import {
   useState,
   useTransition
 } from 'react';
-import type { Review } from '../../../types';
-import { updateReview } from '../../actions/reviews';
-import useDictionary from '../../hooks/useDictionary';
-import usePhotoUploads from '../../hooks/usePhotoUploads';
-import AddPhotoButton from '../common/AddPhotoButton';
-import AppDialog from '../common/AppDialog';
-import PhotoPreviewList from '../common/PhotoPreviewList';
-import PositionForm from '../maps/PositionForm';
-import ReviewDescriptionForm from './ReviewDescriptionForm';
-import ReviewNameForm from './ReviewNameForm';
+import type { Review } from '../../../types/index.ts';
+import { updateReview } from '../../actions/reviews.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import usePhotoUploads from '../../hooks/usePhotoUploads.ts';
+import AddPhotoButton from '../common/AddPhotoButton.tsx';
+import AppDialog from '../common/AppDialog.tsx';
+import PhotoPreviewList from '../common/PhotoPreviewList.tsx';
+import PositionForm from '../maps/PositionForm.tsx';
+import ReviewDescriptionForm from './ReviewDescriptionForm.tsx';
+import ReviewNameForm from './ReviewNameForm.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/reviews/LikeReviewButton.tsx
+++ b/src/components/reviews/LikeReviewButton.tsx
@@ -9,10 +9,10 @@ import {
   useState,
   useTransition
 } from 'react';
-import type { Review } from '../../../types';
-import { likeReview, unlikeReview } from '../../actions/reviewLikes';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
+import type { Review } from '../../../types/index.ts';
+import { likeReview, unlikeReview } from '../../actions/reviewLikes.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 type Props = {
   review: Review;

--- a/src/components/reviews/PosterAvatar.tsx
+++ b/src/components/reviews/PosterAvatar.tsx
@@ -1,8 +1,8 @@
 import { Person } from '@mui/icons-material';
 import { Avatar } from '@mui/material';
 import { memo, useContext } from 'react';
-import AuthContext from '../../context/AuthContext';
-import ProfileContext from '../../context/ProfileContext';
+import AuthContext from '../../context/AuthContext.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
 
 export default memo(function PosterAvatar() {
   const { authenticated } = useContext(AuthContext);

--- a/src/components/reviews/ReviewCardActions.tsx
+++ b/src/components/reviews/ReviewCardActions.tsx
@@ -1,12 +1,12 @@
 import { Box, Button, CardActions, Stack, TextField } from '@mui/material';
 import { enqueueSnackbar } from 'notistack';
 import { memo, useCallback, useContext, useState, useTransition } from 'react';
-import type { Review } from '../../../types';
-import { createComment } from '../../actions/comments';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import LikeReviewButton from './LikeReviewButton';
-import PosterAvatar from './PosterAvatar';
+import type { Review } from '../../../types/index.ts';
+import { createComment } from '../../actions/comments.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import LikeReviewButton from './LikeReviewButton.tsx';
+import PosterAvatar from './PosterAvatar.tsx';
 
 type Props = {
   review: Review;

--- a/src/components/reviews/ReviewCardHeader.tsx
+++ b/src/components/reviews/ReviewCardHeader.tsx
@@ -10,9 +10,9 @@ import { enUS, ja } from 'date-fns/locale';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { memo, type ReactNode } from 'react';
-import type { Review } from '../../../types';
-import useLocalePath from '../../hooks/useLocalePath';
-import AuthorAvatar from '../common/AuthorAvatar';
+import type { Review } from '../../../types/index.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import AuthorAvatar from '../common/AuthorAvatar.tsx';
 
 type Props = {
   review: Review | null;

--- a/src/components/reviews/ReviewComments.tsx
+++ b/src/components/reviews/ReviewComments.tsx
@@ -13,13 +13,13 @@ import { enUS, ja } from 'date-fns/locale';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { memo, useContext, useState } from 'react';
-import type { Comment } from '../../../types';
-import ProfileContext from '../../context/ProfileContext';
-import useLocalePath from '../../hooks/useLocalePath';
-import AuthorAvatar from '../common/AuthorAvatar';
-import IssueDialog from '../common/IssueDialog';
-import CommentMenuButton from './CommentMenuButton';
-import DeleteCommentDialog from './DeleteCommentDialog';
+import type { Comment } from '../../../types/index.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import AuthorAvatar from '../common/AuthorAvatar.tsx';
+import IssueDialog from '../common/IssueDialog.tsx';
+import CommentMenuButton from './CommentMenuButton.tsx';
+import DeleteCommentDialog from './DeleteCommentDialog.tsx';
 
 type Props = {
   comments: Comment[];

--- a/src/components/reviews/ReviewDescriptionForm.tsx
+++ b/src/components/reviews/ReviewDescriptionForm.tsx
@@ -1,6 +1,6 @@
 import { TextField } from '@mui/material';
 import { type ChangeEvent, memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 const MAX_LENGTH = 500;
 

--- a/src/components/reviews/ReviewDetail.tsx
+++ b/src/components/reviews/ReviewDetail.tsx
@@ -5,17 +5,17 @@ import { Box, Button, Card, CardContent, Typography } from '@mui/material';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useContext, useState } from 'react';
-import type { Review } from '../../../types';
-import ProfileContext from '../../context/ProfileContext';
-import useDictionary from '../../hooks/useDictionary';
-import IssueDialog from '../common/IssueDialog';
-import DeleteReviewDialog from './DeleteReviewDialog';
-import EditReviewDialog from './EditReviewDialog';
-import ReviewCardActions from './ReviewCardActions';
-import ReviewCardHeader from './ReviewCardHeader';
-import ReviewComments from './ReviewComments';
-import ReviewImageList from './ReviewImageList';
-import ReviewMenuButton from './ReviewMenuButton';
+import type { Review } from '../../../types/index.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import IssueDialog from '../common/IssueDialog.tsx';
+import DeleteReviewDialog from './DeleteReviewDialog.tsx';
+import EditReviewDialog from './EditReviewDialog.tsx';
+import ReviewCardActions from './ReviewCardActions.tsx';
+import ReviewCardHeader from './ReviewCardHeader.tsx';
+import ReviewComments from './ReviewComments.tsx';
+import ReviewImageList from './ReviewImageList.tsx';
+import ReviewMenuButton from './ReviewMenuButton.tsx';
 
 type Props = {
   review: Review;

--- a/src/components/reviews/ReviewGridList.tsx
+++ b/src/components/reviews/ReviewGridList.tsx
@@ -13,8 +13,8 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import { memo } from 'react';
-import type { Review } from '../../../types';
-import useLocalePath from '../../hooks/useLocalePath';
+import type { Review } from '../../../types/index.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
 
 type Props = {
   reviews: Review[];

--- a/src/components/reviews/ReviewImageList.tsx
+++ b/src/components/reviews/ReviewImageList.tsx
@@ -6,7 +6,7 @@ import {
   ImageListItem
 } from '@mui/material';
 import { memo } from 'react';
-import type { Review } from '../../../types';
+import type { Review } from '../../../types/index.ts';
 
 type Props = {
   review: Review;

--- a/src/components/reviews/ReviewMenuButton.tsx
+++ b/src/components/reviews/ReviewMenuButton.tsx
@@ -17,11 +17,11 @@ import {
 import { useParams, useRouter } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { memo, useContext, useRef, useState } from 'react';
-import type { Profile, Review } from '../../../types';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import { localePath } from '../../utils/locales';
-import { SITE_ORIGIN } from '../../utils/metadata';
+import type { Profile, Review } from '../../../types/index.ts';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { localePath } from '../../utils/locales.ts';
+import { SITE_ORIGIN } from '../../utils/metadata.ts';
 
 type Props = {
   review: Review | null;

--- a/src/components/reviews/ReviewNameForm.tsx
+++ b/src/components/reviews/ReviewNameForm.tsx
@@ -1,6 +1,6 @@
 import { TextField } from '@mui/material';
 import { type ChangeEvent, memo, useEffect, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
+import useDictionary from '../../hooks/useDictionary.ts';
 
 const MAX_LENGTH = 30;
 

--- a/src/components/settings/AccountEmailCard.tsx
+++ b/src/components/settings/AccountEmailCard.tsx
@@ -11,9 +11,9 @@ import {
 } from '@mui/material';
 import { getAuth } from 'firebase/auth';
 import { memo, useContext, useState } from 'react';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import ChangeEmailDialog from './ChangeEmailDialog';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import ChangeEmailDialog from './ChangeEmailDialog.tsx';
 
 function AccountEmailCard() {
   const dictionary = useDictionary();

--- a/src/components/settings/ChangeEmailDialog.tsx
+++ b/src/components/settings/ChangeEmailDialog.tsx
@@ -9,10 +9,10 @@ import {
 } from 'firebase/auth';
 import { useParams } from 'next/navigation';
 import { memo, useCallback, useContext, useMemo, useState } from 'react';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog, { type ConfirmAction } from '../common/AppDialog';
-import EmailField from '../common/EmailField';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog, { type ConfirmAction } from '../common/AppDialog.tsx';
+import EmailField from '../common/EmailField.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/settings/DeleteAccountCard.tsx
+++ b/src/components/settings/DeleteAccountCard.tsx
@@ -10,10 +10,10 @@ import {
 import { getAuth, signOut } from 'firebase/auth';
 import { useRouter } from 'next/navigation';
 import { memo, useContext, useState } from 'react';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import useLocalePath from '../../hooks/useLocalePath';
-import DeleteAccountDialog from './DeleteAccountDialog';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocalePath from '../../hooks/useLocalePath.ts';
+import DeleteAccountDialog from './DeleteAccountDialog.tsx';
 
 function DeleteAccountCard() {
   const dictionary = useDictionary();

--- a/src/components/settings/DeleteAccountDialog.tsx
+++ b/src/components/settings/DeleteAccountDialog.tsx
@@ -1,8 +1,8 @@
 import { enqueueSnackbar } from 'notistack';
 import { memo, useCallback } from 'react';
-import { deleteAccount } from '../../actions/users';
-import useDictionary from '../../hooks/useDictionary';
-import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog';
+import { deleteAccount } from '../../actions/users.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import ConfirmDeleteDialog from '../common/ConfirmDeleteDialog.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/settings/LinkEmailDialog.tsx
+++ b/src/components/settings/LinkEmailDialog.tsx
@@ -2,9 +2,9 @@ import { Alert, DialogContentText } from '@mui/material';
 import { type AuthError, getAuth, sendSignInLinkToEmail } from 'firebase/auth';
 import { useParams } from 'next/navigation';
 import { memo, useCallback, useState } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import AppDialog from '../common/AppDialog';
-import EmailField from '../common/EmailField';
+import useDictionary from '../../hooks/useDictionary.ts';
+import AppDialog from '../common/AppDialog.tsx';
+import EmailField from '../common/EmailField.tsx';
 
 type Props = {
   open: boolean;

--- a/src/components/settings/ProvidersCard.tsx
+++ b/src/components/settings/ProvidersCard.tsx
@@ -33,10 +33,10 @@ import {
   useMemo,
   useState
 } from 'react';
-import AuthContext from '../../context/AuthContext';
-import useDictionary from '../../hooks/useDictionary';
-import LinkEmailDialog from './LinkEmailDialog';
-import UnlinkProviderDialog from './UnlinkProviderDialog';
+import AuthContext from '../../context/AuthContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import LinkEmailDialog from './LinkEmailDialog.tsx';
+import UnlinkProviderDialog from './UnlinkProviderDialog.tsx';
 
 function ProvidersCard() {
   const dictionary = useDictionary();

--- a/src/components/settings/PushNotificationsCard.tsx
+++ b/src/components/settings/PushNotificationsCard.tsx
@@ -22,11 +22,11 @@ import {
   useEffect,
   useState
 } from 'react';
-import { updatePreferences } from '../../actions/users';
-import ProfileContext from '../../context/ProfileContext';
-import ServiceWorkerContext from '../../context/ServiceWorkerContext';
-import useDictionary from '../../hooks/useDictionary';
-import { usePushManager } from '../../hooks/usePushManager';
+import { updatePreferences } from '../../actions/users.ts';
+import ProfileContext from '../../context/ProfileContext.ts';
+import ServiceWorkerContext from '../../context/ServiceWorkerContext.ts';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { usePushManager } from '../../hooks/usePushManager.ts';
 
 function PushNotificationsCard() {
   const dictionary = useDictionary();

--- a/src/components/settings/UnlinkProviderDialog.tsx
+++ b/src/components/settings/UnlinkProviderDialog.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import ConfirmDialog from '../common/ConfirmDialog';
+import useDictionary from '../../hooks/useDictionary.ts';
+import ConfirmDialog from '../common/ConfirmDialog.tsx';
 
 type Props = {
   open: boolean;

--- a/src/context/NotificationsContext.ts
+++ b/src/context/NotificationsContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import type { Notification } from '../../types';
+import type { Notification } from '../../types/index.ts';
 
 const NotificationsContext = createContext<Notification[]>([]);
 

--- a/src/context/ProfileContext.ts
+++ b/src/context/ProfileContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import type { Profile } from '../../types';
+import type { Profile } from '../../types/index.ts';
 
 const ProfileContext = createContext<Profile | null>(null);
 

--- a/src/hooks/useChapter.ts
+++ b/src/hooks/useChapter.ts
@@ -9,9 +9,9 @@ import {
   useRef,
   useState
 } from 'react';
-import type { Chapter, MapFeatureCollection } from '../../types';
-import { deleteChapter, updateChapter } from '../actions/chapters';
-import useDictionary from './useDictionary';
+import type { Chapter, MapFeatureCollection } from '../../types/index.ts';
+import { deleteChapter, updateChapter } from '../actions/chapters.ts';
+import useDictionary from './useDictionary.ts';
 
 const AUTOSAVE_DELAY = 800;
 

--- a/src/hooks/useEmailLinkHandler.ts
+++ b/src/hooks/useEmailLinkHandler.ts
@@ -14,7 +14,7 @@ import {
 import { useParams } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import { useEffect, useRef } from 'react';
-import useDictionary from './useDictionary';
+import useDictionary from './useDictionary.ts';
 
 type Dictionary = { [key: string]: string };
 

--- a/src/hooks/useGoogleMap.ts
+++ b/src/hooks/useGoogleMap.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import GoogleMapsContext from '../context/GoogleMapsContext';
+import GoogleMapsContext from '../context/GoogleMapsContext.ts';
 
 export function useGoogleMap() {
   return useContext(GoogleMapsContext);

--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -29,12 +29,19 @@ import {
   updateCheckin
 } from '../actions/journeys';
 import AuthContext from '../context/AuthContext';
-import { distanceInMeters } from '../utils/geo';
 import {
   deletePaused,
   loadPaused,
   savePaused
 } from '../utils/journeyPauseStorage';
+import {
+  MOVING_SAMPLE_MIN_INTERVAL_MS,
+  nextHighAccuracy,
+  type PreviousFix,
+  type StationaryAnchor,
+  type TrackingFix,
+  trackPosition
+} from '../utils/journeyTracking';
 import {
   deleteTrail,
   loadTrail,
@@ -42,16 +49,7 @@ import {
 } from '../utils/journeyTrailStorage';
 import { encodePath } from '../utils/polyline';
 
-const CHECKIN_RADIUS_METERS = 50;
-const PATH_MIN_DISTANCE_METERS = 10;
 const CHECKIN_VIBRATION_MS = 30;
-
-// A coarse fix can report a spot as reachable from far outside the check-in
-// radius, so anything less certain than this is only used to draw the trail.
-const CHECKIN_MAX_ACCURACY_METERS = 100;
-
-const ACCURACY_UPGRADE_RADIUS_METERS = 300;
-const ACCURACY_DOWNGRADE_RADIUS_METERS = 500;
 
 const INACTIVITY_PAUSE_MS = 8 * 60 * 60 * 1000;
 const INACTIVITY_CHECK_INTERVAL_MS = 10 * 60 * 1000;
@@ -67,38 +65,8 @@ const LOW_ACCURACY_OPTIONS: PositionOptions = {
   maximumAge: 60000
 };
 
-// The Geolocation API offers no interval or distance filter, so a registered
-// watch keeps the positioning hardware powered the whole time. Away from any
-// unvisited spot the journey samples on a timer instead, and the hardware can
-// power down between fixes.
-const MOVING_SAMPLE_MIN_INTERVAL_MS = 15000;
-const MOVING_SAMPLE_MAX_INTERVAL_MS = 2 * 60 * 1000;
-
-// Headroom over the observed speed, so that speeding up between two samples
-// cannot carry the traveller into the continuous-watch zone unseen.
-const SPEED_HEADROOM = 2;
-const MIN_ASSUMED_SPEED_MPS = 1.5;
-
-// Positioning jitter alone can move a fix this far while the device rests.
-const STATIONARY_RADIUS_METERS = 30;
-const STATIONARY_AFTER_MS = 3 * 60 * 1000;
-const STATIONARY_SAMPLE_BASE_INTERVAL_MS = 30000;
-const STATIONARY_BACKOFF_MAX_STEPS = 4;
-
-// Near a spot a stale fix could miss a departure that heads straight into
-// the check-in radius, so the backoff stays tighter there.
-const STATIONARY_SAMPLE_MAX_NEAR_MS = 60000;
-const STATIONARY_SAMPLE_MAX_FAR_MS = 5 * 60 * 1000;
-
 // A fix that never resolves would otherwise stall the sampling loop.
 const SAMPLE_TIMEOUT_MS = 30000;
-
-type StationaryAnchor = {
-  latitude: number;
-  longitude: number;
-  accuracy: number;
-  since: number;
-};
 
 export type PauseReason = 'permission' | 'inactivity';
 
@@ -145,11 +113,7 @@ export default function useJourney({
   const [stationary, setStationary] = useState(false);
   const stationaryRef = useRef(false);
   const anchorRef = useRef<StationaryAnchor | null>(null);
-  const lastFixRef = useRef<{
-    latitude: number;
-    longitude: number;
-    timestamp: number;
-  } | null>(null);
+  const lastFixRef = useRef<PreviousFix | null>(null);
   const sampleIntervalRef = useRef(MOVING_SAMPLE_MIN_INTERVAL_MS);
   const lastPositionAtRef = useRef<number | null>(null);
 
@@ -349,132 +313,52 @@ export default function useJourney({
 
     lastPositionAtRef.current = position.timestamp;
 
-    const here = {
+    const fix: TrackingFix = {
       latitude: position.coords.latitude,
-      longitude: position.coords.longitude
+      longitude: position.coords.longitude,
+      accuracy: position.coords.accuracy,
+      speed: position.coords.speed,
+      timestamp: position.timestamp
     };
-
-    const previousFix = lastFixRef.current;
-    lastFixRef.current = { ...here, timestamp: position.timestamp };
-
-    const { accuracy } = position.coords;
-    const precise = accuracy <= CHECKIN_MAX_ACCURACY_METERS;
-    const anchor = anchorRef.current;
-
-    const applyStationary = (next: boolean) => {
-      stationaryRef.current = next;
-      setStationary(next);
-    };
-
-    if (
-      anchor &&
-      distanceInMeters(here, anchor) >
-        Math.max(STATIONARY_RADIUS_METERS, accuracy, anchor.accuracy)
-    ) {
-      // The fix's error circle excludes the anchor, so this is genuine
-      // movement even when the fix itself is coarse.
-      anchorRef.current = precise
-        ? { ...here, accuracy, since: position.timestamp }
-        : null;
-      applyStationary(false);
-    } else if (!anchor) {
-      // Only a precise fix may open an anchor: a coarse one would widen the
-      // stillness radius so far that a stroll would read as rest.
-      if (precise) {
-        anchorRef.current = { ...here, accuracy, since: position.timestamp };
-      }
-      applyStationary(false);
-    } else if (precise) {
-      applyStationary(position.timestamp - anchor.since >= STATIONARY_AFTER_MS);
-    }
-
-    const lastPoint = trailRef.current.at(-1);
-
-    // A coarse fix drifts on its own, so the threshold follows the reported
-    // accuracy to keep those jumps out of the trail.
-    const minDistance = Math.max(
-      PATH_MIN_DISTANCE_METERS,
-      position.coords.accuracy
-    );
-
-    if (!lastPoint || distanceInMeters(here, lastPoint) >= minDistance) {
-      commitTrail([...trailRef.current, here]);
-    }
 
     const visitedIds = new Set(
       current.checkins.map((checkin) => checkin.review_id)
     );
 
-    const remaining = reviews.filter((review) => !visitedIds.has(review.id));
-
-    const nearest = remaining.reduce(
-      (shortest, review) => Math.min(shortest, distanceInMeters(here, review)),
-      Number.POSITIVE_INFINITY
+    const decision = trackPosition(
+      {
+        anchor: anchorRef.current,
+        stationary: stationaryRef.current,
+        previousFix: lastFixRef.current,
+        lastTrailPoint: trailRef.current.at(-1) ?? null
+      },
+      fix,
+      reviews.filter((review) => !visitedIds.has(review.id))
     );
+
+    lastFixRef.current = {
+      latitude: fix.latitude,
+      longitude: fix.longitude,
+      timestamp: fix.timestamp
+    };
+
+    anchorRef.current = decision.anchor;
+    stationaryRef.current = decision.stationary;
+    setStationary(decision.stationary);
+    sampleIntervalRef.current = decision.sampleIntervalMs;
+
+    if (decision.extendTrail) {
+      commitTrail([
+        ...trailRef.current,
+        { latitude: fix.latitude, longitude: fix.longitude }
+      ]);
+    }
 
     setHighAccuracy((enabled) =>
-      enabled
-        ? nearest <= ACCURACY_DOWNGRADE_RADIUS_METERS
-        : nearest <= ACCURACY_UPGRADE_RADIUS_METERS
+      nextHighAccuracy(enabled, decision.nearestMeters)
     );
 
-    const currentAnchor = anchorRef.current;
-
-    if (stationaryRef.current && currentAnchor) {
-      const steps = Math.min(
-        STATIONARY_BACKOFF_MAX_STEPS,
-        Math.floor(
-          (position.timestamp - currentAnchor.since) / STATIONARY_AFTER_MS
-        )
-      );
-
-      const cap =
-        nearest <= ACCURACY_DOWNGRADE_RADIUS_METERS
-          ? STATIONARY_SAMPLE_MAX_NEAR_MS
-          : STATIONARY_SAMPLE_MAX_FAR_MS;
-
-      sampleIntervalRef.current = Math.min(
-        cap,
-        STATIONARY_SAMPLE_BASE_INTERVAL_MS * 2 ** steps
-      );
-    } else {
-      let observedSpeed = position.coords.speed ?? Number.NaN;
-
-      if (!Number.isFinite(observedSpeed) || observedSpeed < 0) {
-        observedSpeed =
-          previousFix && position.timestamp > previousFix.timestamp
-            ? distanceInMeters(here, previousFix) /
-              ((position.timestamp - previousFix.timestamp) / 1000)
-            : 0;
-      }
-
-      const speed = Math.max(
-        MIN_ASSUMED_SPEED_MPS,
-        observedSpeed * SPEED_HEADROOM
-      );
-
-      // The next sample only has to land before the traveller could reach
-      // the continuous-watch zone around the nearest unvisited spot.
-      const travelMs =
-        ((nearest - ACCURACY_UPGRADE_RADIUS_METERS) / speed) * 1000;
-
-      sampleIntervalRef.current = Math.min(
-        MOVING_SAMPLE_MAX_INTERVAL_MS,
-        Math.max(MOVING_SAMPLE_MIN_INTERVAL_MS, travelMs)
-      );
-    }
-
-    if (position.coords.accuracy > CHECKIN_MAX_ACCURACY_METERS) {
-      return;
-    }
-
-    const reached = remaining.filter(
-      (review) =>
-        !pendingCheckinsRef.current.has(review.id) &&
-        distanceInMeters(here, review) <= CHECKIN_RADIUS_METERS
-    );
-
-    for (const review of reached) {
+    for (const review of decision.reached) {
       performCheckin(review);
     }
   };

--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -16,7 +16,7 @@ import type {
   JourneyPathPoint,
   Milestone,
   Review
-} from '../../types';
+} from '../../types/index.ts';
 import {
   addCheckin,
   addMilestone as addMilestoneAction,
@@ -27,13 +27,13 @@ import {
   removeMilestone as removeMilestoneAction,
   startJourney,
   updateCheckin
-} from '../actions/journeys';
-import AuthContext from '../context/AuthContext';
+} from '../actions/journeys.ts';
+import AuthContext from '../context/AuthContext.ts';
 import {
   deletePaused,
   loadPaused,
   savePaused
-} from '../utils/journeyPauseStorage';
+} from '../utils/journeyPauseStorage.ts';
 import {
   MOVING_SAMPLE_MIN_INTERVAL_MS,
   nextHighAccuracy,
@@ -41,13 +41,13 @@ import {
   type StationaryAnchor,
   type TrackingFix,
   trackPosition
-} from '../utils/journeyTracking';
+} from '../utils/journeyTracking.ts';
 import {
   deleteTrail,
   loadTrail,
   saveTrail
-} from '../utils/journeyTrailStorage';
-import { encodePath } from '../utils/polyline';
+} from '../utils/journeyTrailStorage.ts';
+import { encodePath } from '../utils/polyline.ts';
 
 const CHECKIN_VIBRATION_MS = 30;
 

--- a/src/hooks/useLocalePath.ts
+++ b/src/hooks/useLocalePath.ts
@@ -1,6 +1,6 @@
 'use client';
 import { useParams } from 'next/navigation';
-import { localePath } from '../utils/locales';
+import { localePath } from '../utils/locales.ts';
 
 /**
  * Builds an in-app href carrying the active locale prefix. Locale-less hrefs

--- a/src/hooks/useMapSearch.ts
+++ b/src/hooks/useMapSearch.ts
@@ -1,6 +1,6 @@
 import debounce from 'lodash.debounce';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { AppMap } from '../../types';
+import type { AppMap } from '../../types/index.ts';
 
 export function useMapSearch(input: string | null | undefined) {
   const [options, setOptions] = useState<AppMap[]>([]);

--- a/src/hooks/usePhotoUploads.ts
+++ b/src/hooks/usePhotoUploads.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import type { Image } from '../../types';
-import uploadImage from '../utils/uploadImage';
+import type { Image } from '../../types/index.ts';
+import uploadImage from '../utils/uploadImage.ts';
 
 export type PhotoItem =
   | { key: string; status: 'uploading'; previewUrl: string }

--- a/src/hooks/usePlaceDetails.ts
+++ b/src/hooks/usePlaceDetails.ts
@@ -1,6 +1,6 @@
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { useGoogleMap } from './useGoogleMap';
+import { useGoogleMap } from './useGoogleMap.ts';
 
 const placeCache = new Map<string, google.maps.places.Place>();
 

--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -1,7 +1,7 @@
 import debounce from 'lodash.debounce';
 import { useParams } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useGoogleMap } from './useGoogleMap';
+import { useGoogleMap } from './useGoogleMap.ts';
 
 const PLACE_FIELDS = [
   'id',

--- a/src/hooks/usePushManager.ts
+++ b/src/hooks/usePushManager.ts
@@ -1,7 +1,7 @@
 import { getMessaging, getToken } from 'firebase/messaging';
 import { useContext, useEffect, useState } from 'react';
-import { registerDevice } from '../actions/devices';
-import AuthContext from '../context/AuthContext';
+import { registerDevice } from '../actions/devices.ts';
+import AuthContext from '../context/AuthContext.ts';
 
 export function usePushManager(registration: ServiceWorkerRegistration | null) {
   const [subscription, setSubscription] = useState<PushSubscription>(null);

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,225 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  apiFetch,
+  apiFetchOrThrow,
+  assertApiAvailable,
+  performApiFetch
+} from './api';
+
+process.env.API_ENDPOINT = 'https://api.example.com';
+
+type FetchArgs = [input: string | URL | Request, init?: RequestInit];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe('performApiFetch', () => {
+  it('sends an authenticated request with a bearer token', async (t) => {
+    const fetchMock = t.mock.method(globalThis, 'fetch', async () =>
+      jsonResponse({ id: 1 })
+    );
+
+    const result = await performApiFetch('/maps', {
+      token: 'token-1',
+      acceptLanguage: 'ja'
+    });
+
+    const [url, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
+    const requestHeaders = init?.headers as Record<string, string>;
+
+    assert.equal(url, 'https://api.example.com/maps');
+    assert.equal(requestHeaders.Authorization, 'Bearer token-1');
+    assert.equal(requestHeaders['Accept-Language'], 'ja');
+    assert.deepEqual(result, { data: { id: 1 }, error: null, status: 200 });
+  });
+
+  it('falls back to the guest API without a token', async (t) => {
+    const fetchMock = t.mock.method(globalThis, 'fetch', async () =>
+      jsonResponse([])
+    );
+
+    await performApiFetch('/maps', { token: null, acceptLanguage: 'en' });
+
+    const [url, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
+    const requestHeaders = init?.headers as Record<string, string>;
+
+    assert.equal(url, 'https://api.example.com/guest/maps');
+    assert.equal('Authorization' in requestHeaders, false);
+  });
+
+  it('passes caller headers through alongside the defaults', async (t) => {
+    const fetchMock = t.mock.method(globalThis, 'fetch', async () =>
+      jsonResponse({})
+    );
+
+    await performApiFetch('/maps', {
+      token: 'token-1',
+      acceptLanguage: 'en',
+      headers: { 'X-Requested-With': 'test' }
+    });
+
+    const [, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
+    const requestHeaders = init?.headers as Record<string, string>;
+
+    assert.equal(requestHeaders['x-requested-with'], 'test');
+    assert.equal(requestHeaders.Accept, 'application/json');
+  });
+
+  it('surfaces the backend error detail', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () =>
+      jsonResponse({ detail: 'Name is required' }, 422)
+    );
+
+    const result = await performApiFetch('/maps', {
+      token: 'token-1',
+      acceptLanguage: 'en'
+    });
+
+    assert.deepEqual(result, {
+      data: null,
+      error: 'Name is required',
+      status: 422
+    });
+  });
+
+  it('falls back to a status message for a non-JSON error body', async (t) => {
+    t.mock.method(
+      globalThis,
+      'fetch',
+      async () => new Response('oops', { status: 500 })
+    );
+
+    const result = await performApiFetch('/maps', {
+      token: 'token-1',
+      acceptLanguage: 'en'
+    });
+
+    assert.deepEqual(result, {
+      data: null,
+      error: 'Request failed with status 500',
+      status: 500
+    });
+  });
+
+  it('treats 204 as success without a body', async (t) => {
+    t.mock.method(
+      globalThis,
+      'fetch',
+      async () => new Response(null, { status: 204 })
+    );
+
+    const result = await performApiFetch('/maps/1', {
+      token: 'token-1',
+      acceptLanguage: 'en',
+      method: 'DELETE'
+    });
+
+    assert.deepEqual(result, { data: null, error: null, status: 204 });
+  });
+
+  it('reports a timeout distinctly from other failures', async (t) => {
+    t.mock.method(console, 'error', () => {});
+    t.mock.method(globalThis, 'fetch', async () => {
+      throw new DOMException('The operation timed out', 'TimeoutError');
+    });
+
+    const result = await performApiFetch('/maps', {
+      token: null,
+      acceptLanguage: 'en'
+    });
+
+    assert.deepEqual(result, {
+      data: null,
+      error: 'Request timed out',
+      status: 0
+    });
+  });
+
+  it('reports unreachable backends as a network error', async (t) => {
+    t.mock.method(console, 'error', () => {});
+    t.mock.method(globalThis, 'fetch', async () => {
+      throw new TypeError('fetch failed');
+    });
+
+    const result = await performApiFetch('/maps', {
+      token: null,
+      acceptLanguage: 'en'
+    });
+
+    assert.deepEqual(result, { data: null, error: 'Network error', status: 0 });
+  });
+
+  it('prefers a caller-provided abort signal', async (t) => {
+    const fetchMock = t.mock.method(globalThis, 'fetch', async () =>
+      jsonResponse({})
+    );
+
+    const controller = new AbortController();
+
+    await performApiFetch('/maps', {
+      token: null,
+      acceptLanguage: 'en',
+      signal: controller.signal
+    });
+
+    const [, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
+
+    assert.equal(init?.signal, controller.signal);
+  });
+});
+
+// The guest + explicit-lang path is the only one that needs no Next.js
+// request scope, which makes it the seam where apiFetch itself is testable.
+describe('apiFetch', () => {
+  it('resolves a guest request with an explicit language', async (t) => {
+    const fetchMock = t.mock.method(globalThis, 'fetch', async () =>
+      jsonResponse([])
+    );
+
+    const result = await apiFetch('/maps', { guest: true, lang: 'ja' });
+
+    const [url, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
+    const requestHeaders = init?.headers as Record<string, string>;
+
+    assert.equal(url, 'https://api.example.com/guest/maps');
+    assert.equal(requestHeaders['Accept-Language'], 'ja');
+    assert.deepEqual(result, { data: [], error: null, status: 200 });
+  });
+});
+
+describe('apiFetchOrThrow', () => {
+  it('returns the payload on success', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () => jsonResponse({ id: 7 }));
+
+    assert.deepEqual(
+      await apiFetchOrThrow('/maps/7', { guest: true, lang: 'en' }),
+      { id: 7 }
+    );
+  });
+
+  it('throws the backend error detail', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () =>
+      jsonResponse({ detail: 'Not found' }, 404)
+    );
+
+    await assert.rejects(
+      apiFetchOrThrow('/maps/7', { guest: true, lang: 'en' }),
+      /Not found/
+    );
+  });
+});
+
+describe('assertApiAvailable', () => {
+  it('accepts responses the caller can interpret', () => {
+    assert.doesNotThrow(() => assertApiAvailable(200, '/maps/1'));
+    assert.doesNotThrow(() => assertApiAvailable(404, '/maps/1'));
+  });
+
+  it('rejects unreachable and failing backends', () => {
+    assert.throws(() => assertApiAvailable(0, '/maps/1'));
+    assert.throws(() => assertApiAvailable(500, '/maps/1'));
+    assert.throws(() => assertApiAvailable(503, '/maps/1'));
+  });
+});

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -5,7 +5,7 @@ import {
   apiFetchOrThrow,
   assertApiAvailable,
   performApiFetch
-} from './api';
+} from './api.ts';
 
 process.env.API_ENDPOINT = 'https://api.example.com';
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,6 +7,19 @@ type ApiFetchOptions = RequestInit & {
   next?: { revalidate?: number | false; tags?: string[] };
 };
 
+type PerformApiFetchOptions = RequestInit & {
+  token: string | null;
+  acceptLanguage: string;
+  timeoutMs?: number;
+  next?: { revalidate?: number | false; tags?: string[] };
+};
+
+export type ApiResult<T> = {
+  data: T | null;
+  error: string | null;
+  status: number;
+};
+
 const DEFAULT_TIMEOUT_MS = 15000;
 
 async function getAuthToken(): Promise<string | null> {
@@ -23,16 +36,15 @@ async function getAcceptLanguage(lang?: string): Promise<string> {
   return headerStore.get('accept-language')?.split(',')[0] ?? 'en';
 }
 
-export async function apiFetch<T>(
+// The transport half of apiFetch: everything below the request-context
+// lookups, so it stays callable outside a Next.js request scope.
+export async function performApiFetch<T>(
   path: string,
-  options: ApiFetchOptions = {}
-): Promise<{ data: T | null; error: string | null; status: number }> {
-  const { guest, lang, timeoutMs, next, ...fetchOptions } = options;
+  options: PerformApiFetchOptions
+): Promise<ApiResult<T>> {
+  const { token, acceptLanguage, timeoutMs, next, ...fetchOptions } = options;
 
-  const token = guest ? null : await getAuthToken();
-  const acceptLanguage = await getAcceptLanguage(lang);
-
-  const apiPath = !guest && token ? path : `/guest${path}`;
+  const apiPath = token ? path : `/guest${path}`;
 
   const requestHeaders: Record<string, string> = {
     Accept: 'application/json',
@@ -40,7 +52,7 @@ export async function apiFetch<T>(
     'Content-Type': 'application/json'
   };
 
-  if (token && !guest) {
+  if (token) {
     requestHeaders.Authorization = `Bearer ${token}`;
   }
 
@@ -81,6 +93,18 @@ export async function apiFetch<T>(
       status: 0
     };
   }
+}
+
+export async function apiFetch<T>(
+  path: string,
+  options: ApiFetchOptions = {}
+): Promise<ApiResult<T>> {
+  const { guest, lang, ...fetchOptions } = options;
+
+  const token = guest ? null : await getAuthToken();
+  const acceptLanguage = await getAcceptLanguage(lang);
+
+  return performApiFetch<T>(path, { ...fetchOptions, token, acceptLanguage });
 }
 
 export async function apiFetchOrThrow<T>(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,3 @@
-import { cookies, headers } from 'next/headers';
-
 type ApiFetchOptions = RequestInit & {
   guest?: boolean;
   lang?: string;
@@ -22,7 +20,10 @@ export type ApiResult<T> = {
 
 const DEFAULT_TIMEOUT_MS = 15000;
 
+// Imported lazily: `next` ships no exports map, so a static specifier fails
+// Node's strict ESM resolution when this module runs under the test runner.
 async function getAuthToken(): Promise<string | null> {
+  const { cookies } = await import('next/headers');
   const cookieStore = await cookies();
   return cookieStore.get('__session')?.value ?? null;
 }
@@ -32,6 +33,7 @@ async function getAcceptLanguage(lang?: string): Promise<string> {
     return lang;
   }
 
+  const { headers } = await import('next/headers');
   const headerStore = await headers();
   return headerStore.get('accept-language')?.split(',')[0] ?? 'en';
 }

--- a/src/lib/chapters.ts
+++ b/src/lib/chapters.ts
@@ -1,5 +1,5 @@
-import type { Chapter } from '../../types';
-import { apiFetch, assertApiAvailable } from './api';
+import type { Chapter } from '../../types/index.ts';
+import { apiFetch, assertApiAvailable } from './api.ts';
 
 export async function getChapter(
   chapterId: string | number,

--- a/src/lib/coauthorshipInvitations.ts
+++ b/src/lib/coauthorshipInvitations.ts
@@ -1,5 +1,5 @@
-import type { CoauthorshipInvitation } from '../../types';
-import { apiFetch } from './api';
+import type { CoauthorshipInvitation } from '../../types/index.ts';
+import { apiFetch } from './api.ts';
 
 export async function getCoauthorshipInvitations(
   lang: string

--- a/src/lib/journeys.ts
+++ b/src/lib/journeys.ts
@@ -1,5 +1,5 @@
-import type { Journey, JourneySummary } from '../../types';
-import { apiFetch } from './api';
+import type { Journey, JourneySummary } from '../../types/index.ts';
+import { apiFetch } from './api.ts';
 
 export async function getMyJourneys(
   lang: string,

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -1,5 +1,5 @@
-import type { AppMap, Chapter, Coauthor, Review } from '../../types';
-import { apiFetch, assertApiAvailable } from './api';
+import type { AppMap, Chapter, Coauthor, Review } from '../../types/index.ts';
+import { apiFetch, assertApiAvailable } from './api.ts';
 
 export async function getMap(
   mapId: string,

--- a/src/lib/reviews.ts
+++ b/src/lib/reviews.ts
@@ -1,5 +1,5 @@
-import type { Review } from '../../types';
-import { apiFetch, assertApiAvailable } from './api';
+import type { Review } from '../../types/index.ts';
+import { apiFetch, assertApiAvailable } from './api.ts';
 
 export async function getReview(
   reviewId: string,

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -4,8 +4,8 @@ import type {
   Notification,
   Profile,
   Review
-} from '../../types';
-import { apiFetch, assertApiAvailable } from './api';
+} from '../../types/index.ts';
+import { apiFetch, assertApiAvailable } from './api.ts';
 
 export async function getProfile(
   userId: string,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import {
   type NextRequest,
   NextResponse
 } from 'next/server';
-import { DEFAULT_LOCALE, LOCALES, type Locale } from './utils/locales';
+import { DEFAULT_LOCALE, LOCALES, type Locale } from './utils/locales.ts';
 
 const WARMUP_INTERVAL_MS = 60000;
 

--- a/src/utils/chapterContent.test.ts
+++ b/src/utils/chapterContent.test.ts
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { SerializedEditorState } from 'lexical';
+import type { Image, Journey, JourneyCheckin } from '../../types';
+import {
+  chapterSections,
+  createChapterContent,
+  createSerializedImage,
+  isContentEmpty
+} from './chapterContent';
+
+function buildImage(id: number): Image {
+  return {
+    id,
+    url: `https://images.example.com/${id}/public`,
+    avatar: `https://images.example.com/${id}/avatar`,
+    card: `https://images.example.com/${id}/card`,
+    hero: `https://images.example.com/${id}/hero`,
+    ogp: `https://images.example.com/${id}/ogp`
+  };
+}
+
+function buildCheckin(
+  id: number,
+  checkedInAt: string,
+  overrides: Partial<JourneyCheckin> = {}
+): JourneyCheckin {
+  return {
+    id,
+    review_id: id * 100,
+    spot: { name: `Spot ${id}`, latitude: 35, longitude: 139 },
+    checked_in_at: checkedInAt,
+    note: null,
+    images: [],
+    ...overrides
+  };
+}
+
+function buildJourney(checkins: JourneyCheckin[]): Journey {
+  return {
+    id: 1,
+    map_id: 10,
+    started_at: '2026-08-01T00:00:00Z',
+    finished_at: null,
+    milestones: [],
+    checkins,
+    encoded_path: null,
+    chapter_id: null,
+    map: null,
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z'
+  };
+}
+
+function contentOf(nodes: Record<string, unknown>[]): SerializedEditorState {
+  return {
+    root: {
+      children: nodes,
+      direction: null,
+      format: '',
+      indent: 0,
+      type: 'root',
+      version: 1
+    }
+  } as unknown as SerializedEditorState;
+}
+
+describe('createSerializedImage', () => {
+  it('builds an image node carrying the chapter image fields', () => {
+    const image = {
+      image_id: 7,
+      url: 'https://images.example.com/7/public',
+      hero: 'https://images.example.com/7/hero'
+    };
+
+    assert.deepEqual(createSerializedImage(image), {
+      type: 'image',
+      version: 1,
+      ...image
+    });
+  });
+});
+
+describe('isContentEmpty', () => {
+  it('treats a lone empty paragraph as empty', () => {
+    assert.equal(isContentEmpty(createChapterContent(buildJourney([]))), true);
+  });
+
+  it('treats whitespace-only text as empty', () => {
+    const content = contentOf([
+      {
+        type: 'paragraph',
+        version: 1,
+        children: [{ type: 'text', version: 1, text: '  \n ' }]
+      }
+    ]);
+
+    assert.equal(isContentEmpty(content), true);
+  });
+
+  it('finds text nested below the top level', () => {
+    const content = contentOf([
+      {
+        type: 'list',
+        version: 1,
+        children: [
+          {
+            type: 'listitem',
+            version: 1,
+            children: [{ type: 'text', version: 1, text: 'note' }]
+          }
+        ]
+      }
+    ]);
+
+    assert.equal(isContentEmpty(content), false);
+  });
+
+  it('counts an image as content', () => {
+    const content = contentOf([
+      createSerializedImage({
+        image_id: 7,
+        url: 'https://images.example.com/7/public',
+        hero: 'https://images.example.com/7/hero'
+      }) as unknown as Record<string, unknown>
+    ]);
+
+    assert.equal(isContentEmpty(content), false);
+  });
+});
+
+describe('chapterSections', () => {
+  it('orders sections by check-in time and keeps their fields', () => {
+    const image = buildImage(7);
+
+    const journey = buildJourney([
+      buildCheckin(2, '2026-08-02T00:00:00Z', { note: 'second' }),
+      buildCheckin(1, '2026-08-01T00:00:00Z', { images: [image] })
+    ]);
+
+    assert.deepEqual(chapterSections(journey), [
+      { name: 'Spot 1', images: [image], note: null },
+      { name: 'Spot 2', images: [], note: 'second' }
+    ]);
+  });
+});
+
+describe('createChapterContent', () => {
+  it('lays out heading, images, and note per check-in', () => {
+    const image = buildImage(7);
+
+    const journey = buildJourney([
+      buildCheckin(1, '2026-08-01T00:00:00Z', {
+        images: [image],
+        note: 'great view'
+      })
+    ]);
+
+    const { root } = createChapterContent(journey);
+    const [heading, imageNode, paragraph] = root.children;
+
+    assert.equal(root.children.length, 3);
+
+    assert.deepEqual(heading, {
+      children: [
+        {
+          detail: 0,
+          format: 0,
+          mode: 'normal',
+          style: '',
+          text: 'Spot 1',
+          type: 'text',
+          version: 1
+        }
+      ],
+      direction: null,
+      format: '',
+      indent: 0,
+      tag: 'h2',
+      type: 'heading',
+      version: 1
+    });
+
+    assert.deepEqual(imageNode, {
+      type: 'image',
+      version: 1,
+      image_id: image.id,
+      url: image.url,
+      hero: image.hero
+    });
+
+    assert.equal(paragraph.type, 'paragraph');
+  });
+
+  it('omits the note paragraph when a check-in has no note', () => {
+    const journey = buildJourney([buildCheckin(1, '2026-08-01T00:00:00Z')]);
+
+    const { root } = createChapterContent(journey);
+
+    assert.deepEqual(
+      root.children.map((node) => node.type),
+      ['heading']
+    );
+  });
+
+  it('falls back to a single empty paragraph for an empty journey', () => {
+    const { root } = createChapterContent(buildJourney([]));
+
+    assert.equal(root.children.length, 1);
+    assert.equal(root.children[0].type, 'paragraph');
+  });
+});

--- a/src/utils/chapterContent.test.ts
+++ b/src/utils/chapterContent.test.ts
@@ -1,13 +1,13 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { SerializedEditorState } from 'lexical';
-import type { Image, Journey, JourneyCheckin } from '../../types';
+import type { Image, Journey, JourneyCheckin } from '../../types/index.ts';
 import {
   chapterSections,
   createChapterContent,
   createSerializedImage,
   isContentEmpty
-} from './chapterContent';
+} from './chapterContent.ts';
 
 function buildImage(id: number): Image {
   return {

--- a/src/utils/chapterContent.ts
+++ b/src/utils/chapterContent.ts
@@ -6,7 +6,7 @@ import type {
   SerializedRootNode,
   SerializedTextNode
 } from 'lexical';
-import type { Image, Journey } from '../../types';
+import type { Image, Journey } from '../../types/index.ts';
 
 export const IMAGE_NODE_TYPE = 'image';
 

--- a/src/utils/geo.test.ts
+++ b/src/utils/geo.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { distanceInMeters, trailDistanceMeters } from './geo';
+import { distanceInMeters, trailDistanceMeters } from './geo.ts';
 
 const EQUATOR_ONE_DEGREE_METERS = 111194.93;
 

--- a/src/utils/geo.test.ts
+++ b/src/utils/geo.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { distanceInMeters, trailDistanceMeters } from './geo';
+
+const EQUATOR_ONE_DEGREE_METERS = 111194.93;
+
+function assertCloseTo(actual: number, expected: number, tolerance: number) {
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${actual} to be within ${tolerance} of ${expected}`
+  );
+}
+
+describe('distanceInMeters', () => {
+  it('returns zero for identical points', () => {
+    const point = { latitude: 35.6812, longitude: 139.7671 };
+
+    assert.equal(distanceInMeters(point, point), 0);
+  });
+
+  it('measures one degree of longitude along the equator', () => {
+    const a = { latitude: 0, longitude: 0 };
+    const b = { latitude: 0, longitude: 1 };
+
+    assertCloseTo(distanceInMeters(a, b), EQUATOR_ONE_DEGREE_METERS, 0.01);
+  });
+
+  it('measures one degree of latitude along a meridian', () => {
+    const a = { latitude: 10, longitude: 139 };
+    const b = { latitude: 11, longitude: 139 };
+
+    assertCloseTo(distanceInMeters(a, b), EQUATOR_ONE_DEGREE_METERS, 0.01);
+  });
+
+  it('is symmetric', () => {
+    const a = { latitude: 35.6812, longitude: 139.7671 };
+    const b = { latitude: 34.7025, longitude: 135.4959 };
+
+    assert.equal(distanceInMeters(a, b), distanceInMeters(b, a));
+  });
+
+  it('stays finite for antipodal points', () => {
+    const a = { latitude: 0, longitude: 0 };
+    const b = { latitude: 0, longitude: 180 };
+
+    const half = Math.PI * 6371000;
+
+    assert.ok(Number.isFinite(distanceInMeters(a, b)));
+    assertCloseTo(distanceInMeters(a, b), half, 0.01);
+  });
+
+  it('stays finite for near-antipodal points', () => {
+    const a = { latitude: 0.0000001, longitude: 0 };
+    const b = { latitude: -0.0000001, longitude: 179.9999999 };
+
+    assert.ok(Number.isFinite(distanceInMeters(a, b)));
+  });
+});
+
+describe('trailDistanceMeters', () => {
+  it('returns zero for an empty trail', () => {
+    assert.equal(trailDistanceMeters([]), 0);
+  });
+
+  it('returns zero for a single point', () => {
+    assert.equal(trailDistanceMeters([{ latitude: 1, longitude: 1 }]), 0);
+  });
+
+  it('sums consecutive segments', () => {
+    const trail = [
+      { latitude: 0, longitude: 139 },
+      { latitude: 1, longitude: 139 },
+      { latitude: 2, longitude: 139 }
+    ];
+
+    assertCloseTo(
+      trailDistanceMeters(trail),
+      EQUATOR_ONE_DEGREE_METERS * 2,
+      0.01
+    );
+  });
+});

--- a/src/utils/getLegalDocument.ts
+++ b/src/utils/getLegalDocument.ts
@@ -2,7 +2,7 @@ import privacyEn from '../content/legal/privacy.en.md';
 import privacyJa from '../content/legal/privacy.ja.md';
 import termsEn from '../content/legal/terms.en.md';
 import termsJa from '../content/legal/terms.ja.md';
-import { type Locale, toLocale } from './locales';
+import { type Locale, toLocale } from './locales.ts';
 
 type LegalDocumentName = 'privacy' | 'terms';
 

--- a/src/utils/journeyPauseStorage.test.ts
+++ b/src/utils/journeyPauseStorage.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import { deletePaused, loadPaused, savePaused } from './journeyPauseStorage';
+
+type StorageStub = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+function installLocalStorage(stub: StorageStub): void {
+  (globalThis as unknown as { window: { localStorage: StorageStub } }).window =
+    { localStorage: stub };
+}
+
+function memoryStorage(): StorageStub & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+
+  return {
+    store,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    }
+  };
+}
+
+function throwingStorage(): StorageStub {
+  const denied = () => {
+    throw new Error('denied');
+  };
+
+  return { getItem: denied, setItem: denied, removeItem: denied };
+}
+
+describe('journeyPauseStorage', () => {
+  let storage: ReturnType<typeof memoryStorage>;
+
+  beforeEach(() => {
+    storage = memoryStorage();
+    installLocalStorage(storage);
+  });
+
+  it('defaults to not paused', () => {
+    assert.equal(loadPaused('user-1', 1), false);
+  });
+
+  it('round-trips the paused flag per user and journey', () => {
+    savePaused('user-1', 1, true);
+
+    assert.equal(loadPaused('user-1', 1), true);
+    assert.equal(loadPaused('user-1', 2), false);
+    assert.equal(loadPaused('user-2', 1), false);
+  });
+
+  it('stores under the versioned key existing pauses rely on', () => {
+    savePaused('user-1', 1, true);
+
+    assert.ok(storage.store.has('qoodish.journeyPaused.v1:user-1:1'));
+  });
+
+  it('clears the flag when saving an unpaused state', () => {
+    savePaused('user-1', 1, true);
+    savePaused('user-1', 1, false);
+
+    assert.equal(loadPaused('user-1', 1), false);
+    assert.equal(storage.store.size, 0);
+  });
+
+  it('deletes the stored flag', () => {
+    savePaused('user-1', 1, true);
+    deletePaused('user-1', 1);
+
+    assert.equal(loadPaused('user-1', 1), false);
+  });
+
+  it('degrades silently when storage access is denied', () => {
+    installLocalStorage(throwingStorage());
+
+    assert.equal(loadPaused('user-1', 1), false);
+    assert.doesNotThrow(() => savePaused('user-1', 1, true));
+    assert.doesNotThrow(() => deletePaused('user-1', 1));
+  });
+});

--- a/src/utils/journeyPauseStorage.test.ts
+++ b/src/utils/journeyPauseStorage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
-import { deletePaused, loadPaused, savePaused } from './journeyPauseStorage';
+import { deletePaused, loadPaused, savePaused } from './journeyPauseStorage.ts';
 
 type StorageStub = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 

--- a/src/utils/journeyTracking.test.ts
+++ b/src/utils/journeyTracking.test.ts
@@ -1,0 +1,376 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  movingSampleIntervalMs,
+  nearestSpotDistance,
+  nextAnchorState,
+  nextHighAccuracy,
+  reachedSpots,
+  type StationaryAnchor,
+  shouldExtendTrail,
+  stationarySampleIntervalMs,
+  type TrackingFix,
+  trackPosition
+} from './journeyTracking';
+
+const BASE_LATITUDE = 35;
+const BASE_LONGITUDE = 139;
+
+// One meter of northward travel, exact for the haversine formula because the
+// path follows a meridian.
+const DEGREES_PER_METER = 180 / (Math.PI * 6371000);
+
+const MINUTE_MS = 60 * 1000;
+
+function pointAt(metersNorth: number) {
+  return {
+    latitude: BASE_LATITUDE + metersNorth * DEGREES_PER_METER,
+    longitude: BASE_LONGITUDE
+  };
+}
+
+function buildFix(
+  metersNorth: number,
+  overrides: Partial<TrackingFix> = {}
+): TrackingFix {
+  return {
+    ...pointAt(metersNorth),
+    accuracy: 10,
+    speed: null,
+    timestamp: 0,
+    ...overrides
+  };
+}
+
+function buildAnchor(
+  metersNorth: number,
+  overrides: Partial<StationaryAnchor> = {}
+): StationaryAnchor {
+  return { ...pointAt(metersNorth), accuracy: 10, since: 0, ...overrides };
+}
+
+describe('nextAnchorState', () => {
+  it('opens an anchor on a precise fix', () => {
+    const fix = buildFix(0, { timestamp: 1000 });
+
+    assert.deepEqual(
+      nextAnchorState({ anchor: null, stationary: false }, fix),
+      {
+        anchor: {
+          latitude: fix.latitude,
+          longitude: fix.longitude,
+          accuracy: 10,
+          since: 1000
+        },
+        stationary: false
+      }
+    );
+  });
+
+  it('refuses to open an anchor on a coarse fix', () => {
+    const fix = buildFix(0, { accuracy: 150 });
+
+    assert.deepEqual(nextAnchorState({ anchor: null, stationary: true }, fix), {
+      anchor: null,
+      stationary: false
+    });
+  });
+
+  it('stays non-stationary before the stillness threshold', () => {
+    const anchor = buildAnchor(0);
+    const fix = buildFix(1, { timestamp: 3 * MINUTE_MS - 1 });
+
+    assert.deepEqual(nextAnchorState({ anchor, stationary: false }, fix), {
+      anchor,
+      stationary: false
+    });
+  });
+
+  it('turns stationary once the anchor is old enough', () => {
+    const anchor = buildAnchor(0);
+    const fix = buildFix(1, { timestamp: 3 * MINUTE_MS });
+
+    assert.deepEqual(nextAnchorState({ anchor, stationary: false }, fix), {
+      anchor,
+      stationary: true
+    });
+  });
+
+  it('lets a coarse fix inside the radius change nothing', () => {
+    const anchor = buildAnchor(0);
+    const fix = buildFix(1, { accuracy: 150, timestamp: 10 * MINUTE_MS });
+
+    assert.deepEqual(nextAnchorState({ anchor, stationary: true }, fix), {
+      anchor,
+      stationary: true
+    });
+    assert.deepEqual(nextAnchorState({ anchor, stationary: false }, fix), {
+      anchor,
+      stationary: false
+    });
+  });
+
+  it('re-anchors on genuine movement from a precise fix', () => {
+    const anchor = buildAnchor(0);
+    const fix = buildFix(40, { timestamp: 10 * MINUTE_MS });
+
+    assert.deepEqual(nextAnchorState({ anchor, stationary: true }, fix), {
+      anchor: {
+        latitude: fix.latitude,
+        longitude: fix.longitude,
+        accuracy: 10,
+        since: 10 * MINUTE_MS
+      },
+      stationary: false
+    });
+  });
+
+  it('clears the anchor on genuine movement from a coarse fix', () => {
+    const anchor = buildAnchor(0);
+    const fix = buildFix(200, { accuracy: 150 });
+
+    assert.deepEqual(nextAnchorState({ anchor, stationary: true }, fix), {
+      anchor: null,
+      stationary: false
+    });
+  });
+
+  it('treats movement inside the error circle as stillness', () => {
+    const anchor = buildAnchor(0);
+    const fix = buildFix(100, { accuracy: 120, timestamp: 10 * MINUTE_MS });
+
+    assert.deepEqual(nextAnchorState({ anchor, stationary: true }, fix), {
+      anchor,
+      stationary: true
+    });
+  });
+
+  it("widens the movement threshold by the anchor's own accuracy", () => {
+    const anchor = buildAnchor(0, { accuracy: 90 });
+    const fix = buildFix(60, { timestamp: 3 * MINUTE_MS });
+
+    assert.deepEqual(nextAnchorState({ anchor, stationary: false }, fix), {
+      anchor,
+      stationary: true
+    });
+  });
+});
+
+describe('shouldExtendTrail', () => {
+  it('always starts an empty trail', () => {
+    assert.equal(shouldExtendTrail(null, buildFix(0)), true);
+  });
+
+  it('skips points below the minimum distance', () => {
+    assert.equal(shouldExtendTrail(pointAt(0), buildFix(5)), false);
+  });
+
+  it('appends points at the minimum distance', () => {
+    assert.equal(shouldExtendTrail(pointAt(0), buildFix(10.01)), true);
+  });
+
+  it('raises the threshold to the reported accuracy', () => {
+    assert.equal(
+      shouldExtendTrail(pointAt(0), buildFix(30, { accuracy: 50 })),
+      false
+    );
+    assert.equal(
+      shouldExtendTrail(pointAt(0), buildFix(60, { accuracy: 50 })),
+      true
+    );
+  });
+});
+
+describe('nearestSpotDistance', () => {
+  it('is infinite without spots', () => {
+    assert.equal(nearestSpotDistance(pointAt(0), []), Number.POSITIVE_INFINITY);
+  });
+
+  it('picks the closest spot', () => {
+    const nearest = nearestSpotDistance(pointAt(0), [
+      pointAt(200),
+      pointAt(100)
+    ]);
+
+    assert.ok(Math.abs(nearest - 100) < 0.001);
+  });
+});
+
+describe('nextHighAccuracy', () => {
+  it('keeps the continuous watch until well clear of the spot', () => {
+    assert.equal(nextHighAccuracy(true, 500), true);
+    assert.equal(nextHighAccuracy(true, 501), false);
+  });
+
+  it('re-enables the watch only close to a spot', () => {
+    assert.equal(nextHighAccuracy(false, 300), true);
+    assert.equal(nextHighAccuracy(false, 301), false);
+    assert.equal(nextHighAccuracy(false, 400), false);
+  });
+});
+
+describe('stationarySampleIntervalMs', () => {
+  it('backs off exponentially with anchor age', () => {
+    const anchor = buildAnchor(0);
+    const nearest = Number.POSITIVE_INFINITY;
+
+    assert.equal(
+      stationarySampleIntervalMs(anchor, 3 * MINUTE_MS, nearest),
+      60000
+    );
+    assert.equal(
+      stationarySampleIntervalMs(anchor, 6 * MINUTE_MS, nearest),
+      120000
+    );
+    assert.equal(
+      stationarySampleIntervalMs(anchor, 9 * MINUTE_MS, nearest),
+      240000
+    );
+  });
+
+  it('caps the far-from-spots backoff at five minutes', () => {
+    const anchor = buildAnchor(0);
+
+    assert.equal(
+      stationarySampleIntervalMs(
+        anchor,
+        60 * MINUTE_MS,
+        Number.POSITIVE_INFINITY
+      ),
+      300000
+    );
+  });
+
+  it('keeps a tight cap near an unvisited spot', () => {
+    const anchor = buildAnchor(0);
+
+    assert.equal(
+      stationarySampleIntervalMs(anchor, 60 * MINUTE_MS, 400),
+      60000
+    );
+  });
+});
+
+describe('movingSampleIntervalMs', () => {
+  it('waits the maximum interval with no spot to reach', () => {
+    assert.equal(
+      movingSampleIntervalMs(buildFix(0), null, Number.POSITIVE_INFINITY),
+      120000
+    );
+  });
+
+  it('schedules by the reported speed with headroom', () => {
+    const fix = buildFix(0, { speed: 10 });
+
+    assert.equal(movingSampleIntervalMs(fix, null, 2300), 100000);
+  });
+
+  it('never samples faster than the minimum interval', () => {
+    const fix = buildFix(0, { speed: 10 });
+
+    assert.equal(movingSampleIntervalMs(fix, null, 330), 15000);
+    assert.equal(movingSampleIntervalMs(fix, null, 100), 15000);
+  });
+
+  it('derives the speed from the previous fix when unreported', () => {
+    const fix = buildFix(100, { timestamp: 10000 });
+    const previous = { ...pointAt(0), timestamp: 0 };
+
+    const interval = movingSampleIntervalMs(fix, previous, 2300);
+
+    assert.ok(Math.abs(interval - 100000) < 0.001);
+  });
+
+  it('assumes a walking pace without any speed signal', () => {
+    const fix = buildFix(0, { speed: -1 });
+
+    assert.equal(movingSampleIntervalMs(fix, null, 375), 50000);
+  });
+});
+
+describe('reachedSpots', () => {
+  it('reaches only spots inside the check-in radius', () => {
+    const near = pointAt(49);
+    const far = pointAt(60);
+
+    assert.deepEqual(reachedSpots(buildFix(0), [near, far]), [near]);
+  });
+
+  it('never checks in from a coarse fix', () => {
+    assert.deepEqual(
+      reachedSpots(buildFix(0, { accuracy: 101 }), [pointAt(0)]),
+      []
+    );
+  });
+
+  it('still checks in at the accuracy limit', () => {
+    const spot = pointAt(10);
+
+    assert.deepEqual(reachedSpots(buildFix(0, { accuracy: 100 }), [spot]), [
+      spot
+    ]);
+  });
+});
+
+describe('trackPosition', () => {
+  const emptyState = {
+    anchor: null,
+    stationary: false,
+    previousFix: null,
+    lastTrailPoint: null
+  };
+
+  it('checks in, anchors, and samples fast next to a spot', () => {
+    const spot = { ...pointAt(30), id: 1 };
+    const fix = buildFix(0, { timestamp: 1000 });
+
+    const decision = trackPosition(emptyState, fix, [spot]);
+
+    assert.deepEqual(decision.reached, [spot]);
+    assert.equal(decision.extendTrail, true);
+    assert.equal(decision.stationary, false);
+    assert.equal(decision.sampleIntervalMs, 15000);
+    assert.deepEqual(decision.anchor, {
+      latitude: fix.latitude,
+      longitude: fix.longitude,
+      accuracy: 10,
+      since: 1000
+    });
+  });
+
+  it('applies the stationary backoff to a resting traveller', () => {
+    const anchor = buildAnchor(0);
+    const fix = buildFix(1, { timestamp: 6 * MINUTE_MS });
+
+    const decision = trackPosition({ ...emptyState, anchor }, fix, []);
+
+    assert.equal(decision.stationary, true);
+    assert.equal(decision.sampleIntervalMs, 120000);
+    assert.deepEqual(decision.reached, []);
+  });
+
+  it('returns to the moving cadence as soon as the traveller departs', () => {
+    const anchor = buildAnchor(0);
+    const fix = buildFix(100, { timestamp: 10 * MINUTE_MS });
+
+    const decision = trackPosition(
+      { ...emptyState, anchor, stationary: true },
+      fix,
+      []
+    );
+
+    assert.equal(decision.stationary, false);
+    assert.equal(decision.sampleIntervalMs, 120000);
+  });
+
+  it('draws the trail from a coarse fix without checking in', () => {
+    const spot = { ...pointAt(0), id: 1 };
+    const fix = buildFix(0, { accuracy: 150 });
+
+    const decision = trackPosition(emptyState, fix, [spot]);
+
+    assert.equal(decision.extendTrail, true);
+    assert.deepEqual(decision.reached, []);
+    assert.equal(decision.anchor, null);
+  });
+});

--- a/src/utils/journeyTracking.test.ts
+++ b/src/utils/journeyTracking.test.ts
@@ -11,7 +11,7 @@ import {
   stationarySampleIntervalMs,
   type TrackingFix,
   trackPosition
-} from './journeyTracking';
+} from './journeyTracking.ts';
 
 const BASE_LATITUDE = 35;
 const BASE_LONGITUDE = 139;

--- a/src/utils/journeyTracking.ts
+++ b/src/utils/journeyTracking.ts
@@ -1,5 +1,5 @@
-import type { JourneyPathPoint } from '../../types';
-import { distanceInMeters } from './geo';
+import type { JourneyPathPoint } from '../../types/index.ts';
+import { distanceInMeters } from './geo.ts';
 
 export const CHECKIN_RADIUS_METERS = 50;
 export const PATH_MIN_DISTANCE_METERS = 10;

--- a/src/utils/journeyTracking.ts
+++ b/src/utils/journeyTracking.ts
@@ -1,0 +1,240 @@
+import type { JourneyPathPoint } from '../../types';
+import { distanceInMeters } from './geo';
+
+export const CHECKIN_RADIUS_METERS = 50;
+export const PATH_MIN_DISTANCE_METERS = 10;
+
+// A coarse fix can report a spot as reachable from far outside the check-in
+// radius, so anything less certain than this is only used to draw the trail.
+export const CHECKIN_MAX_ACCURACY_METERS = 100;
+
+export const ACCURACY_UPGRADE_RADIUS_METERS = 300;
+export const ACCURACY_DOWNGRADE_RADIUS_METERS = 500;
+
+// The Geolocation API offers no interval or distance filter, so a registered
+// watch keeps the positioning hardware powered the whole time. Away from any
+// unvisited spot the journey samples on a timer instead, and the hardware can
+// power down between fixes.
+export const MOVING_SAMPLE_MIN_INTERVAL_MS = 15000;
+export const MOVING_SAMPLE_MAX_INTERVAL_MS = 2 * 60 * 1000;
+
+// Headroom over the observed speed, so that speeding up between two samples
+// cannot carry the traveller into the continuous-watch zone unseen.
+const SPEED_HEADROOM = 2;
+const MIN_ASSUMED_SPEED_MPS = 1.5;
+
+// Positioning jitter alone can move a fix this far while the device rests.
+export const STATIONARY_RADIUS_METERS = 30;
+export const STATIONARY_AFTER_MS = 3 * 60 * 1000;
+export const STATIONARY_SAMPLE_BASE_INTERVAL_MS = 30000;
+const STATIONARY_BACKOFF_MAX_STEPS = 4;
+
+// Near a spot a stale fix could miss a departure that heads straight into
+// the check-in radius, so the backoff stays tighter there.
+export const STATIONARY_SAMPLE_MAX_NEAR_MS = 60000;
+export const STATIONARY_SAMPLE_MAX_FAR_MS = 5 * 60 * 1000;
+
+export type StationaryAnchor = {
+  latitude: number;
+  longitude: number;
+  accuracy: number;
+  since: number;
+};
+
+export type TrackingFix = {
+  latitude: number;
+  longitude: number;
+  accuracy: number;
+  speed: number | null;
+  timestamp: number;
+};
+
+export type PreviousFix = {
+  latitude: number;
+  longitude: number;
+  timestamp: number;
+};
+
+export type TrackedSpot = {
+  latitude: number;
+  longitude: number;
+};
+
+export type AnchorState = {
+  anchor: StationaryAnchor | null;
+  stationary: boolean;
+};
+
+export function nextAnchorState(
+  prior: AnchorState,
+  fix: TrackingFix
+): AnchorState {
+  const precise = fix.accuracy <= CHECKIN_MAX_ACCURACY_METERS;
+
+  const opened: StationaryAnchor = {
+    latitude: fix.latitude,
+    longitude: fix.longitude,
+    accuracy: fix.accuracy,
+    since: fix.timestamp
+  };
+
+  const { anchor } = prior;
+
+  if (
+    anchor &&
+    distanceInMeters(fix, anchor) >
+      Math.max(STATIONARY_RADIUS_METERS, fix.accuracy, anchor.accuracy)
+  ) {
+    // The fix's error circle excludes the anchor, so this is genuine
+    // movement even when the fix itself is coarse.
+    return { anchor: precise ? opened : null, stationary: false };
+  }
+
+  if (!anchor) {
+    // Only a precise fix may open an anchor: a coarse one would widen the
+    // stillness radius so far that a stroll would read as rest.
+    return { anchor: precise ? opened : null, stationary: false };
+  }
+
+  if (precise) {
+    return {
+      anchor,
+      stationary: fix.timestamp - anchor.since >= STATIONARY_AFTER_MS
+    };
+  }
+
+  // A coarse fix inside the stillness radius proves nothing either way.
+  return prior;
+}
+
+export function shouldExtendTrail(
+  lastPoint: JourneyPathPoint | null,
+  fix: TrackingFix
+): boolean {
+  if (!lastPoint) {
+    return true;
+  }
+
+  // A coarse fix drifts on its own, so the threshold follows the reported
+  // accuracy to keep those jumps out of the trail.
+  const minDistance = Math.max(PATH_MIN_DISTANCE_METERS, fix.accuracy);
+
+  return distanceInMeters(fix, lastPoint) >= minDistance;
+}
+
+export function nearestSpotDistance(
+  from: TrackedSpot,
+  spots: TrackedSpot[]
+): number {
+  return spots.reduce(
+    (shortest, spot) => Math.min(shortest, distanceInMeters(from, spot)),
+    Number.POSITIVE_INFINITY
+  );
+}
+
+export function nextHighAccuracy(
+  enabled: boolean,
+  nearestMeters: number
+): boolean {
+  return enabled
+    ? nearestMeters <= ACCURACY_DOWNGRADE_RADIUS_METERS
+    : nearestMeters <= ACCURACY_UPGRADE_RADIUS_METERS;
+}
+
+export function stationarySampleIntervalMs(
+  anchor: StationaryAnchor,
+  timestamp: number,
+  nearestMeters: number
+): number {
+  const steps = Math.min(
+    STATIONARY_BACKOFF_MAX_STEPS,
+    Math.floor((timestamp - anchor.since) / STATIONARY_AFTER_MS)
+  );
+
+  const cap =
+    nearestMeters <= ACCURACY_DOWNGRADE_RADIUS_METERS
+      ? STATIONARY_SAMPLE_MAX_NEAR_MS
+      : STATIONARY_SAMPLE_MAX_FAR_MS;
+
+  return Math.min(cap, STATIONARY_SAMPLE_BASE_INTERVAL_MS * 2 ** steps);
+}
+
+export function movingSampleIntervalMs(
+  fix: TrackingFix,
+  previousFix: PreviousFix | null,
+  nearestMeters: number
+): number {
+  let observedSpeed = fix.speed ?? Number.NaN;
+
+  if (!Number.isFinite(observedSpeed) || observedSpeed < 0) {
+    observedSpeed =
+      previousFix && fix.timestamp > previousFix.timestamp
+        ? distanceInMeters(fix, previousFix) /
+          ((fix.timestamp - previousFix.timestamp) / 1000)
+        : 0;
+  }
+
+  const speed = Math.max(MIN_ASSUMED_SPEED_MPS, observedSpeed * SPEED_HEADROOM);
+
+  // The next sample only has to land before the traveller could reach
+  // the continuous-watch zone around the nearest unvisited spot.
+  const travelMs =
+    ((nearestMeters - ACCURACY_UPGRADE_RADIUS_METERS) / speed) * 1000;
+
+  return Math.min(
+    MOVING_SAMPLE_MAX_INTERVAL_MS,
+    Math.max(MOVING_SAMPLE_MIN_INTERVAL_MS, travelMs)
+  );
+}
+
+export function reachedSpots<S extends TrackedSpot>(
+  fix: TrackingFix,
+  spots: S[]
+): S[] {
+  if (fix.accuracy > CHECKIN_MAX_ACCURACY_METERS) {
+    return [];
+  }
+
+  return spots.filter(
+    (spot) => distanceInMeters(fix, spot) <= CHECKIN_RADIUS_METERS
+  );
+}
+
+export type TrackingState = {
+  anchor: StationaryAnchor | null;
+  stationary: boolean;
+  previousFix: PreviousFix | null;
+  lastTrailPoint: JourneyPathPoint | null;
+};
+
+export type TrackingDecision<S extends TrackedSpot> = {
+  anchor: StationaryAnchor | null;
+  stationary: boolean;
+  extendTrail: boolean;
+  nearestMeters: number;
+  sampleIntervalMs: number;
+  reached: S[];
+};
+
+export function trackPosition<S extends TrackedSpot>(
+  state: TrackingState,
+  fix: TrackingFix,
+  remainingSpots: S[]
+): TrackingDecision<S> {
+  const { anchor, stationary } = nextAnchorState(state, fix);
+  const nearestMeters = nearestSpotDistance(fix, remainingSpots);
+
+  const sampleIntervalMs =
+    stationary && anchor
+      ? stationarySampleIntervalMs(anchor, fix.timestamp, nearestMeters)
+      : movingSampleIntervalMs(fix, state.previousFix, nearestMeters);
+
+  return {
+    anchor,
+    stationary,
+    extendTrail: shouldExtendTrail(state.lastTrailPoint, fix),
+    nearestMeters,
+    sampleIntervalMs,
+    reached: reachedSpots(fix, remainingSpots)
+  };
+}

--- a/src/utils/journeyTrailStorage.test.ts
+++ b/src/utils/journeyTrailStorage.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import { deleteTrail, loadTrail, saveTrail } from './journeyTrailStorage';
+
+type StorageStub = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+function installLocalStorage(stub: StorageStub): void {
+  (globalThis as unknown as { window: { localStorage: StorageStub } }).window =
+    { localStorage: stub };
+}
+
+function memoryStorage(): StorageStub & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+
+  return {
+    store,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    }
+  };
+}
+
+function throwingStorage(): StorageStub {
+  const denied = () => {
+    throw new Error('denied');
+  };
+
+  return { getItem: denied, setItem: denied, removeItem: denied };
+}
+
+const TRAIL = [
+  { latitude: 35.6586, longitude: 139.7454 },
+  { latitude: 35.659, longitude: 139.746 }
+];
+
+describe('journeyTrailStorage', () => {
+  let storage: ReturnType<typeof memoryStorage>;
+
+  beforeEach(() => {
+    storage = memoryStorage();
+    installLocalStorage(storage);
+  });
+
+  it('round-trips a trail per user and journey', () => {
+    saveTrail('user-1', 1, TRAIL);
+
+    assert.deepEqual(loadTrail('user-1', 1), TRAIL);
+    assert.deepEqual(loadTrail('user-1', 2), []);
+    assert.deepEqual(loadTrail('user-2', 1), []);
+  });
+
+  it('stores under the versioned key existing trails rely on', () => {
+    saveTrail('user-1', 1, TRAIL);
+
+    assert.ok(storage.store.has('qoodish.journeyTrail.v1:user-1:1'));
+  });
+
+  it('returns an empty trail when nothing is stored', () => {
+    assert.deepEqual(loadTrail('user-1', 1), []);
+  });
+
+  it('recovers from a corrupted entry', () => {
+    storage.store.set('qoodish.journeyTrail.v1:user-1:1', '{not json');
+
+    assert.deepEqual(loadTrail('user-1', 1), []);
+  });
+
+  it('deletes only the addressed trail', () => {
+    saveTrail('user-1', 1, TRAIL);
+    saveTrail('user-1', 2, TRAIL);
+
+    deleteTrail('user-1', 1);
+
+    assert.deepEqual(loadTrail('user-1', 1), []);
+    assert.deepEqual(loadTrail('user-1', 2), TRAIL);
+  });
+
+  it('degrades silently when storage access is denied', () => {
+    installLocalStorage(throwingStorage());
+
+    assert.deepEqual(loadTrail('user-1', 1), []);
+    assert.doesNotThrow(() => saveTrail('user-1', 1, TRAIL));
+    assert.doesNotThrow(() => deleteTrail('user-1', 1));
+  });
+});

--- a/src/utils/journeyTrailStorage.test.ts
+++ b/src/utils/journeyTrailStorage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
-import { deleteTrail, loadTrail, saveTrail } from './journeyTrailStorage';
+import { deleteTrail, loadTrail, saveTrail } from './journeyTrailStorage.ts';
 
 type StorageStub = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 

--- a/src/utils/journeyTrailStorage.ts
+++ b/src/utils/journeyTrailStorage.ts
@@ -1,4 +1,4 @@
-import type { JourneyPathPoint } from '../../types';
+import type { JourneyPathPoint } from '../../types/index.ts';
 
 const KEY_PREFIX = 'qoodish.journeyTrail.v1';
 

--- a/src/utils/locales.test.ts
+++ b/src/utils/locales.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { DEFAULT_LOCALE, isLocale, localePath, toLocale } from './locales';
+import { DEFAULT_LOCALE, isLocale, localePath, toLocale } from './locales.ts';
 
 describe('isLocale', () => {
   it('accepts every supported locale', () => {

--- a/src/utils/locales.test.ts
+++ b/src/utils/locales.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { DEFAULT_LOCALE, isLocale, localePath, toLocale } from './locales';
+
+describe('isLocale', () => {
+  it('accepts every supported locale', () => {
+    assert.equal(isLocale('en'), true);
+    assert.equal(isLocale('ja'), true);
+  });
+
+  it('rejects unsupported values', () => {
+    assert.equal(isLocale('fr'), false);
+    assert.equal(isLocale('EN'), false);
+    assert.equal(isLocale(''), false);
+    assert.equal(isLocale(null), false);
+    assert.equal(isLocale(undefined), false);
+  });
+});
+
+describe('toLocale', () => {
+  it('passes supported locales through', () => {
+    assert.equal(toLocale('ja'), 'ja');
+  });
+
+  it('falls back to the default locale', () => {
+    assert.equal(toLocale('fr'), DEFAULT_LOCALE);
+    assert.equal(toLocale(null), DEFAULT_LOCALE);
+    assert.equal(toLocale(undefined), DEFAULT_LOCALE);
+  });
+});
+
+describe('localePath', () => {
+  it('prefixes the path with the locale', () => {
+    assert.equal(localePath('ja', '/maps/1'), '/ja/maps/1');
+  });
+
+  it('treats the root path as the bare locale', () => {
+    assert.equal(localePath('ja', '/'), '/ja');
+    assert.equal(localePath('ja'), '/ja');
+  });
+
+  it('normalizes unsupported locales to the default', () => {
+    assert.equal(localePath('fr', '/maps/1'), '/en/maps/1');
+  });
+});

--- a/src/utils/mapFeatures.test.ts
+++ b/src/utils/mapFeatures.test.ts
@@ -6,8 +6,8 @@ import type {
   MapFeature,
   MapFeatureCollection,
   Spot
-} from '../../types';
-import { createMapFeatures, featureSpots, spotFeature } from './mapFeatures';
+} from '../../types/index.ts';
+import { createMapFeatures, featureSpots, spotFeature } from './mapFeatures.ts';
 
 function buildCheckin(
   id: number,

--- a/src/utils/mapFeatures.test.ts
+++ b/src/utils/mapFeatures.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type {
+  Journey,
+  JourneyCheckin,
+  MapFeature,
+  MapFeatureCollection,
+  Spot
+} from '../../types';
+import { createMapFeatures, featureSpots, spotFeature } from './mapFeatures';
+
+function buildCheckin(
+  id: number,
+  checkedInAt: string,
+  spot: Spot
+): JourneyCheckin {
+  return {
+    id,
+    review_id: id * 100,
+    spot,
+    checked_in_at: checkedInAt,
+    note: null,
+    images: []
+  };
+}
+
+function buildJourney(checkins: JourneyCheckin[]): Journey {
+  return {
+    id: 1,
+    map_id: 10,
+    started_at: '2026-08-01T00:00:00Z',
+    finished_at: null,
+    milestones: [],
+    checkins,
+    encoded_path: null,
+    chapter_id: null,
+    map: null,
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z'
+  };
+}
+
+const tower: Spot = {
+  name: 'Tokyo Tower',
+  latitude: 35.6586,
+  longitude: 139.7454
+};
+const castle: Spot = {
+  name: 'Osaka Castle',
+  latitude: 34.6873,
+  longitude: 135.5262
+};
+
+describe('spotFeature', () => {
+  it('builds a Point feature with GeoJSON coordinate order', () => {
+    assert.deepEqual(spotFeature(tower), {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [139.7454, 35.6586]
+      },
+      properties: { title: 'Tokyo Tower' }
+    });
+  });
+});
+
+describe('createMapFeatures', () => {
+  it('orders features by check-in time', () => {
+    const journey = buildJourney([
+      buildCheckin(2, '2026-08-02T00:00:00Z', castle),
+      buildCheckin(1, '2026-08-01T00:00:00Z', tower)
+    ]);
+
+    const collection = createMapFeatures(journey);
+
+    assert.deepEqual(
+      collection.features.map((feature) => feature.properties?.title),
+      ['Tokyo Tower', 'Osaka Castle']
+    );
+  });
+
+  it('builds an empty collection for a journey without check-ins', () => {
+    assert.deepEqual(createMapFeatures(buildJourney([])), {
+      type: 'FeatureCollection',
+      features: []
+    });
+  });
+});
+
+describe('featureSpots', () => {
+  it('round-trips spots through a feature collection', () => {
+    const journey = buildJourney([
+      buildCheckin(1, '2026-08-01T00:00:00Z', tower),
+      buildCheckin(2, '2026-08-02T00:00:00Z', castle)
+    ]);
+
+    assert.deepEqual(featureSpots(createMapFeatures(journey)), [tower, castle]);
+  });
+
+  it('ignores features that are not points', () => {
+    const line = {
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [139.7454, 35.6586],
+          [135.5262, 34.6873]
+        ]
+      },
+      properties: null
+    } as unknown as MapFeature;
+
+    const collection: MapFeatureCollection = {
+      type: 'FeatureCollection',
+      features: [line, spotFeature(tower)]
+    };
+
+    assert.deepEqual(featureSpots(collection), [tower]);
+  });
+
+  it('defaults a missing title to an empty name', () => {
+    const collection: MapFeatureCollection = {
+      type: 'FeatureCollection',
+      features: [{ ...spotFeature(tower), properties: null }]
+    };
+
+    assert.deepEqual(featureSpots(collection), [{ ...tower, name: '' }]);
+  });
+
+  it('tolerates a collection without a features array', () => {
+    const collection = {
+      type: 'FeatureCollection'
+    } as MapFeatureCollection;
+
+    assert.deepEqual(featureSpots(collection), []);
+  });
+});

--- a/src/utils/mapFeatures.ts
+++ b/src/utils/mapFeatures.ts
@@ -3,7 +3,7 @@ import type {
   MapFeature,
   MapFeatureCollection,
   Spot
-} from '../../types';
+} from '../../types/index.ts';
 
 export function spotFeature(spot: Spot): MapFeature {
   return {

--- a/src/utils/metadata.test.ts
+++ b/src/utils/metadata.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildAlternates, defaultOgImage } from './metadata';
+
+describe('defaultOgImage', () => {
+  it('returns the English image for en', () => {
+    assert.match(defaultOgImage('en'), /ogp-image-en/);
+  });
+
+  it('returns the Japanese image for any other language', () => {
+    assert.match(defaultOgImage('ja'), /ogp-image-ja/);
+    assert.match(defaultOgImage('fr'), /ogp-image-ja/);
+  });
+});
+
+describe('buildAlternates', () => {
+  it('builds canonical and hreflang paths for a localized page', () => {
+    assert.deepEqual(buildAlternates('ja', '/maps/5'), {
+      canonical: '/ja/maps/5',
+      languages: {
+        en: '/en/maps/5',
+        ja: '/ja/maps/5',
+        'x-default': '/en/maps/5'
+      }
+    });
+  });
+
+  it('normalizes an unsupported language in the canonical path', () => {
+    assert.deepEqual(buildAlternates('fr', '/maps/5'), {
+      canonical: '/en/maps/5',
+      languages: {
+        en: '/en/maps/5',
+        ja: '/ja/maps/5',
+        'x-default': '/en/maps/5'
+      }
+    });
+  });
+
+  it('maps the root page to bare locale paths', () => {
+    assert.deepEqual(buildAlternates('en'), {
+      canonical: '/en',
+      languages: {
+        en: '/en',
+        ja: '/ja',
+        'x-default': '/en'
+      }
+    });
+  });
+});

--- a/src/utils/metadata.test.ts
+++ b/src/utils/metadata.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { buildAlternates, defaultOgImage } from './metadata';
+import { buildAlternates, defaultOgImage } from './metadata.ts';
 
 describe('defaultOgImage', () => {
   it('returns the English image for en', () => {

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { DEFAULT_LOCALE, localePath } from './locales';
+import { DEFAULT_LOCALE, localePath } from './locales.ts';
 
 export const SITE_ORIGIN = 'https://qoodish.com';
 

--- a/src/utils/polyline.test.ts
+++ b/src/utils/polyline.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import type { JourneyPathPoint } from '../../types';
-import { decodePath, encodePath } from './polyline';
+import type { JourneyPathPoint } from '../../types/index.ts';
+import { decodePath, encodePath } from './polyline.ts';
 
 // Worked example from Google's Encoded Polyline Algorithm Format reference.
 const REFERENCE_POINTS: JourneyPathPoint[] = [

--- a/src/utils/polyline.test.ts
+++ b/src/utils/polyline.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { JourneyPathPoint } from '../../types';
+import { decodePath, encodePath } from './polyline';
+
+// Worked example from Google's Encoded Polyline Algorithm Format reference.
+const REFERENCE_POINTS: JourneyPathPoint[] = [
+  { latitude: 38.5, longitude: -120.2 },
+  { latitude: 40.7, longitude: -120.95 },
+  { latitude: 43.252, longitude: -126.453 }
+];
+
+const REFERENCE_ENCODED = '_p~iF~ps|U_ulLnnqC_mqNvxq`@';
+
+function assertPathsClose(
+  actual: JourneyPathPoint[],
+  expected: JourneyPathPoint[]
+) {
+  assert.equal(actual.length, expected.length);
+
+  actual.forEach((point, index) => {
+    // Encoding rounds coordinates to a 1e-5 grid.
+    const tolerance = 0.5e-5;
+
+    assert.ok(
+      Math.abs(point.latitude - expected[index].latitude) <= tolerance,
+      `latitude ${point.latitude} differs from ${expected[index].latitude}`
+    );
+    assert.ok(
+      Math.abs(point.longitude - expected[index].longitude) <= tolerance,
+      `longitude ${point.longitude} differs from ${expected[index].longitude}`
+    );
+  });
+}
+
+describe('encodePath', () => {
+  it('matches the reference encoding', () => {
+    assert.equal(encodePath(REFERENCE_POINTS), REFERENCE_ENCODED);
+  });
+
+  it('returns an empty string for an empty path', () => {
+    assert.equal(encodePath([]), '');
+  });
+});
+
+describe('decodePath', () => {
+  it('matches the reference decoding', () => {
+    assertPathsClose(decodePath(REFERENCE_ENCODED), REFERENCE_POINTS);
+  });
+
+  it('returns an empty path for null and empty input', () => {
+    assert.deepEqual(decodePath(null), []);
+    assert.deepEqual(decodePath(''), []);
+  });
+});
+
+describe('round trip', () => {
+  it('preserves a single point', () => {
+    const points = [{ latitude: 35.65803, longitude: 139.74544 }];
+
+    assert.deepEqual(decodePath(encodePath(points)), points);
+  });
+
+  it('preserves points across hemisphere boundaries', () => {
+    const points = [
+      { latitude: -0.00001, longitude: 0.00001 },
+      { latitude: 0.00002, longitude: -0.00003 },
+      { latitude: -33.86882, longitude: 151.20929 },
+      { latitude: 40.71278, longitude: -74.00594 }
+    ];
+
+    assertPathsClose(decodePath(encodePath(points)), points);
+  });
+
+  it('preserves a dense trail of small deltas', () => {
+    const points = Array.from({ length: 200 }, (_, index) => ({
+      latitude: 35.6 + index * 0.00013,
+      longitude: 139.7 - index * 0.00017
+    }));
+
+    assertPathsClose(decodePath(encodePath(points)), points);
+  });
+});

--- a/src/utils/polyline.ts
+++ b/src/utils/polyline.ts
@@ -1,4 +1,4 @@
-import type { JourneyPathPoint } from '../../types';
+import type { JourneyPathPoint } from '../../types/index.ts';
 
 function encodeValue(value: number, output: string[]): void {
   let coded = value < 0 ? ~(value << 1) : value << 1;

--- a/src/utils/uploadImage.test.ts
+++ b/src/utils/uploadImage.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildVariants } from './uploadImage';
+
+const DELIVERY_BASE = 'https://imagedelivery.net/hash/image-1';
+
+function variantUrls(names: string[]): string[] {
+  return names.map((name) => `${DELIVERY_BASE}/${name}`);
+}
+
+describe('buildVariants', () => {
+  it('maps Cloudflare variant names onto the API image keys', () => {
+    const urls = variantUrls(['avatar', 'card', 'hero', 'ogp', 'public']);
+
+    assert.deepEqual(buildVariants(urls), {
+      url: `${DELIVERY_BASE}/public`,
+      avatar: `${DELIVERY_BASE}/avatar`,
+      card: `${DELIVERY_BASE}/card`,
+      hero: `${DELIVERY_BASE}/hero`,
+      ogp: `${DELIVERY_BASE}/ogp`
+    });
+  });
+
+  it('ignores extra variants Cloudflare may add', () => {
+    const urls = variantUrls([
+      'avatar',
+      'card',
+      'hero',
+      'ogp',
+      'public',
+      'thumbnail'
+    ]);
+
+    assert.equal(buildVariants(urls).url, `${DELIVERY_BASE}/public`);
+  });
+
+  it('rejects a response missing a configured variant', () => {
+    const urls = variantUrls(['avatar', 'card', 'hero', 'public']);
+
+    assert.throws(() => buildVariants(urls), /"ogp" is not configured/);
+  });
+
+  it('rejects a response missing the built-in public variant', () => {
+    const urls = variantUrls(['avatar', 'card', 'hero', 'ogp']);
+
+    assert.throws(() => buildVariants(urls), /"public" is not configured/);
+  });
+});

--- a/src/utils/uploadImage.test.ts
+++ b/src/utils/uploadImage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { buildVariants } from './uploadImage';
+import { buildVariants } from './uploadImage.ts';
 
 const DELIVERY_BASE = 'https://imagedelivery.net/hash/image-1';
 

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -25,7 +25,7 @@ const VARIANT_BY_KEY: Record<keyof ImageVariants, string> = {
   ogp: 'ogp'
 };
 
-function buildVariants(urls: string[]): ImageVariants {
+export function buildVariants(urls: string[]): ImageVariants {
   const byName = new Map<string, string>();
   for (const url of urls) {
     const name = url.split('/').pop();

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -1,5 +1,5 @@
-import type { Image, ImageVariants } from '../../types';
-import dataUrlToBlob from './dataUrlToBlob';
+import type { Image, ImageVariants } from '../../types/index.ts';
+import dataUrlToBlob from './dataUrlToBlob.ts';
 
 type DirectUploadAllocation = {
   upload_url: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
# Summary

Introduces a unit test layer built on the Node.js built-in `node:test` runner with **zero new runtime or dev dependencies**, covering the pure logic in `src/utils` and the API client contract in `src/lib/api.ts`. The suite runs 106 tests in about 1.5 seconds via `pnpm test` and now gates pull requests in CI.

# Motivation

Large automated refactors need a fast regression net under the logic where a silent bug corrupts persisted data (encoded trails, distances, generated chapter content) or breaks the API contract. Node's built-in type stripping runs the tests directly; its one gap — it does not search extensions for relative imports — is closed by writing the `.ts` extension explicitly, the resolution browsers, Deno, and Node ESM already require, instead of adding a loader dependency.

# Changes

- Add a `test` script running `node --test` over `src/**/*.test.ts` on native type stripping, and a Test step in the Dev workflow
- Adopt explicit `.ts`/`.tsx` extensions for relative imports across `src`, rewritten and enforced by Biome's `useImportExtensions` rule (safe fix), with `allowImportingTsExtensions` in tsconfig
- Cover the pure utils: `polyline` (reference-encoding parity and round trips), `geo` (known distances, antipodal NaN guard), `chapterContent`, `mapFeatures`, `locales`, `metadata`
- Extract the GPS decision logic (stationary anchoring, sampling backoff, check-in gating) from `useJourney` into pure functions in `src/utils/journeyTracking.ts` and pin it with tests; the hook keeps effects only, with no behavior change
- Split the API transport into `performApiFetch`, taking the auth token and language as plain values, so the guest fallback, error-detail extraction, 204 handling, and the timeout/network distinction are testable with a fetch stub; `apiFetch` / `apiFetchOrThrow` are unchanged. `next/headers` is imported lazily inside the request-scope lookups, since the `next` package ships no exports map and a static specifier fails Node's strict ESM resolution under the test runner
- Export `buildVariants` from `uploadImage` and pin the Cloudflare Images variant mapping; pin the versioned localStorage keys of the journey trail/pause storage

# Testing

- `pnpm test`: 106 tests pass
- `pnpm biome ci ./src`: no errors
- `pnpm exec tsc --noEmit`: no errors
- `pnpm build` (`next build`): succeeds with the extension-suffixed imports