### PR TITLE
fix: replace useEffectEvent with a local shim

### DIFF
--- a/src/hooks/useChapter.ts
+++ b/src/hooks/useChapter.ts
@@ -2,16 +2,11 @@
 
 import type { SerializedEditorState } from 'lexical';
 import { enqueueSnackbar } from 'notistack';
-import {
-  useCallback,
-  useEffect,
-  useEffectEvent,
-  useRef,
-  useState
-} from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Chapter, MapFeatureCollection } from '../../types/index.ts';
 import { deleteChapter, updateChapter } from '../actions/chapters.ts';
 import useDictionary from './useDictionary.ts';
+import useLatestCallback from './useLatestCallback.ts';
 
 const AUTOSAVE_DELAY = 800;
 
@@ -97,9 +92,9 @@ export default function useChapter(initialChapter: Chapter) {
   };
 
   // The debounce timer and the pagehide listener outlive the render that
-  // registered them, so they flush through an effect event, which always
-  // sees the latest committed values. Event handlers call flush directly.
-  const flushLatest = useEffectEvent(flush);
+  // registered them, so they flush through the latest committed closure,
+  // which sees the newest draft. Event handlers call flush directly.
+  const flushLatest = useLatestCallback(flush);
 
   useEffect(() => {
     if (chapter.updated_at === savedAt) {
@@ -109,7 +104,7 @@ export default function useChapter(initialChapter: Chapter) {
     const timer = window.setTimeout(() => flushLatest(), AUTOSAVE_DELAY);
 
     return () => window.clearTimeout(timer);
-  }, [chapter, savedAt]);
+  }, [chapter, savedAt, flushLatest]);
 
   useEffect(() => {
     const handlePageHide = () => {
@@ -122,7 +117,7 @@ export default function useChapter(initialChapter: Chapter) {
       window.removeEventListener('pagehide', handlePageHide);
       flushLatest();
     };
-  }, []);
+  }, [flushLatest]);
 
   const mutate = useCallback((updater: (chapter: Chapter) => Chapter) => {
     setChapter((current) => ({

--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -1,13 +1,6 @@
 'use client';
 
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useEffectEvent,
-  useRef,
-  useState
-} from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import type {
   AppMap,
   Image,
@@ -48,6 +41,7 @@ import {
   saveTrail
 } from '../utils/journeyTrailStorage.ts';
 import { encodePath } from '../utils/polyline.ts';
+import useLatestCallback from './useLatestCallback.ts';
 
 const CHECKIN_VIBRATION_MS = 30;
 
@@ -364,11 +358,11 @@ export default function useJourney({
   };
 
   // The geolocation watch and the sampling timer outlive the render that
-  // registered them, so they deliver fixes through an effect event, which
-  // always sees the latest committed review list without the watch having to
+  // registered them, so they deliver fixes through the latest committed
+  // closure, which sees the newest review list without the watch having to
   // re-register every time that list changes. Event handlers call
   // processPosition directly.
-  const handlePosition = useEffectEvent(processPosition);
+  const handlePosition = useLatestCallback(processPosition);
 
   // Losing the permission mid-journey must not cost the traveller their
   // milestones and check-ins, so recording only pauses.
@@ -487,7 +481,15 @@ export default function useJourney({
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [uid, watching, highAccuracy, stationary, handleError, onLocationError]);
+  }, [
+    uid,
+    watching,
+    highAccuracy,
+    stationary,
+    handlePosition,
+    handleError,
+    onLocationError
+  ]);
 
   const requestPosition =
     useCallback((): Promise<GeolocationPosition | null> => {

--- a/src/hooks/useLatestCallback.ts
+++ b/src/hooks/useLatestCallback.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+/**
+ * Wraps a callback so listeners and timers that outlive the render which
+ * registered them still reach the newest committed closure, without the
+ * registration having to be torn down whenever that closure changes.
+ *
+ * React 19.2 ships useEffectEvent for exactly this, but Next.js serves the
+ * client its own bundled copy of React, and that copy does not export it — the
+ * installed react does, so the type check and the build both pass and only the
+ * browser throws.
+ */
+export default function useLatestCallback<A extends unknown[], R>(
+  callback: (...args: A) => R
+): (...args: A) => R {
+  const latest = useRef(callback);
+
+  // Published in the commit phase, so a fix or an event arriving before the
+  // passive effects run is still handled by the closure that belongs to the
+  // rendered state.
+  useLayoutEffect(() => {
+    latest.current = callback;
+  });
+
+  return useCallback((...args: A) => latest.current(...args), []);
+}


### PR DESCRIPTION
# Summary

Fixes the production crash on the map detail page — `Uncaught TypeError: (0 , d.useEffectEvent) is not a function` — which prevented the map from rendering at all. `useEffectEvent` is replaced with a local ref-backed shim, `useLatestCallback`, with the same contract.

# Motivation

Next.js serves the client its own bundled copy of React, and that copy does not export `useEffectEvent`. The installed `react` 19.2.8 does export it, so both the type check and the build pass — the failure only surfaces in the browser, where `useJourney` (mounted by the map detail view) calls it during render.

# Changes

- Add `src/hooks/useLatestCallback.ts`: a ref updated in the commit phase plus a stable wrapper, preserving the effect-event contract (a stable identity that always invokes the newest committed closure)
- Replace `useEffectEvent` with `useLatestCallback` in `useJourney` (geolocation watch / sampling timer) and `useChapter` (autosave flush, pagehide)
- Add the shim's stable identity to the dependency arrays that the effect-event lint exemption used to cover

# Testing

- Reproduced the failure path: `next build` emits `useEffectEvent` calls into the page chunk while the bundled React in the framework chunk has no such export; after the fix, app chunks contain no `useEffectEvent` reference
- `pnpm test`: 106 tests pass
- `pnpm biome ci ./src`: no errors
- `pnpm exec tsc --noEmit`: no errors
- `pnpm build` (`next build`): succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_014wCMqUghcBhW41T6T8fuNT)_