### PR TITLE
fix(maps): stop the place search field collapsing

### DIFF
--- a/src/components/maps/PlaceAutocomplete.tsx
+++ b/src/components/maps/PlaceAutocomplete.tsx
@@ -89,6 +89,10 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
       includeInputInList
       filterSelectedOptions
       forcePopupIcon={false}
+      // The input is width: 0, so the field collapses inside a container that
+      // sizes to its contents, as the map control does. Narrow screens get
+      // their width from fullWidth instead.
+      sx={{ minWidth: { xs: 0, md: 320 } }}
       options={options}
       loading={isLoading}
       loadingText={dictionary.loading}


### PR DESCRIPTION
# Summary

The place search box on the map collapses to roughly 116px on desktop, too
narrow to read the placeholder or type a query. Adding a pin is effectively
unusable there. This gives the field a width floor from the `md` breakpoint up.

# Motivation

A regression from #1116. MUI styles `.MuiAutocomplete-input` as
`width: 0; min-width: 30px`, so the field has no intrinsic width; the plain
input element it replaced still had one from its default `size` attribute.

The desktop map control (`MapControl` with `fullWidth={false}`) sets its
container to `width: auto` and therefore sizes itself to its contents. With
nothing to size to, it shrinks to the input's 30px minimum plus the adornments.
The mobile control is `fullWidth`, which is why only desktop is affected.

# Changes

- `PlaceAutocomplete` sets `minWidth` on the `Autocomplete` root, scoped to
  `md` and up so the full-width mobile control and the full-width control in
  `CoodinatesConverter` keep their current behaviour.

# Testing

- `pnpm biome ci ./src` — passes
- `pnpm exec tsc --noEmit` — passes
- `pnpm build` — passes

Measured in Chromium on a standalone reproduction of the control's box tree
(auto-width container → `Box p:2` → `Paper` → Autocomplete root, with MUI's
`width: 0; min-width: 30px` on the input):

| | container | field | input |
|---|---|---|---|
| before | 148px | 116px | 34px |
| after | 352px | 320px | 238px |

The "before" numbers match the reported screenshot. Not verified in the real
app: this environment has no Google Maps API key, so the map — and with it the
control — never mounts.