### PR TITLE
fix: apply the active locale to Google Maps

### DIFF
--- a/src/components/chapters/ChapterMapCard.tsx
+++ b/src/components/chapters/ChapterMapCard.tsx
@@ -40,12 +40,7 @@ function ChapterMapCard({
       <Divider sx={{ mb: 4 }} />
 
       <Box sx={{ borderRadius: 1, overflow: 'hidden', mb: 3 }}>
-        <JourneyMap
-          spots={spots}
-          path={[]}
-          locale={locale}
-          fallbackCenter={fallbackCenter}
-        />
+        <JourneyMap spots={spots} path={[]} fallbackCenter={fallbackCenter} />
       </Box>
 
       {children && <Box sx={{ mb: 3 }}>{children}</Box>}

--- a/src/components/journeys/JourneyDetailView.tsx
+++ b/src/components/journeys/JourneyDetailView.tsx
@@ -446,7 +446,6 @@ export default function JourneyDetailView({
           spots={checkinSpots}
           milestones={pendingMilestones}
           path={trail}
-          locale={lang}
           fallbackCenter={mapCenter}
           height={{ xs: 260, sm: 320 }}
         />

--- a/src/components/journeys/JourneyMap.tsx
+++ b/src/components/journeys/JourneyMap.tsx
@@ -221,7 +221,6 @@ const JourneyMapOverlay = memo(function JourneyMapOverlay({
 type Props = {
   spots: Spot[];
   path: JourneyPathPoint[];
-  locale: string;
   milestones?: Spot[];
   fallbackCenter?: JourneyPathPoint;
   height?: number | { xs?: number; sm?: number; md?: number };
@@ -236,7 +235,6 @@ const noMilestones: Spot[] = [];
 function JourneyMap({
   spots,
   path,
-  locale,
   milestones = noMilestones,
   fallbackCenter,
   height = 240
@@ -246,7 +244,6 @@ function JourneyMap({
       mapId={process.env.NEXT_PUBLIC_GOOGLE_MAP_ID}
       sx={{ height, width: '100%' }}
       mapOptions={mapOptions}
-      locale={locale}
     >
       <JourneyMapOverlay
         spots={spots}

--- a/src/components/maps/GoogleMaps.tsx
+++ b/src/components/maps/GoogleMaps.tsx
@@ -1,5 +1,6 @@
 import { Loader } from '@googlemaps/js-api-loader';
 import { Box, type SxProps, useMediaQuery, useTheme } from '@mui/material';
+import { useParams } from 'next/navigation';
 import {
   memo,
   type ReactNode,
@@ -10,6 +11,7 @@ import {
   useState
 } from 'react';
 import GoogleMapsContext from '../../context/GoogleMapsContext.ts';
+import { toLocale } from '../../utils/locales.ts';
 
 type Props = {
   mapId: string;
@@ -18,30 +20,27 @@ type Props = {
   mapOptions?: Partial<google.maps.MapOptions>;
   center?: google.maps.LatLngLiteral;
   zoom?: number;
-  locale?: string;
 };
 
-function GoogleMaps({
-  mapId,
-  children,
-  sx,
-  mapOptions,
-  center,
-  zoom,
-  locale
-}: Props) {
+function GoogleMaps({ mapId, children, sx, mapOptions, center, zoom }: Props) {
   const mapRef = useRef<HTMLDivElement>(null);
+  const { lang } = useParams<{ lang: string }>();
 
   const [googleMap, setGoogleMap] = useState<google.maps.Map | null>(null);
   const [currentPosition, setCurrentPosition] =
     useState<GeolocationPosition | null>(null);
 
+  // Loader は options ごとのシングルトンで、言語はスクリプト URL に焼き込まれる。
+  // 読み込み後の差し替えはできないため、生成時に渡す唯一の機会となる。
+  const language = toLocale(lang);
+
   const loader = useMemo(() => {
     return new Loader({
       apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
-      version: 'beta'
+      version: 'beta',
+      language
     });
-  }, []);
+  }, [language]);
 
   const theme = useTheme();
   const mdUp = useMediaQuery(theme.breakpoints.up('md'));
@@ -74,14 +73,6 @@ function GoogleMaps({
 
     setGoogleMap(map);
   }, [mapId, mapOptions, mdUp, loader]);
-
-  useEffect(() => {
-    if (!locale) {
-      return;
-    }
-
-    loader.options.language = locale;
-  }, [loader, locale]);
 
   useEffect(() => {
     if (!googleMap && mapRef.current && loader) {

--- a/src/components/maps/GoogleMaps.tsx
+++ b/src/components/maps/GoogleMaps.tsx
@@ -13,6 +13,26 @@ import {
 import GoogleMapsContext from '../../context/GoogleMapsContext.ts';
 import { toLocale } from '../../utils/locales.ts';
 
+// The Maps script carries its language in the URL it is loaded from, so the
+// first map on a document settles the language for every later one, and the
+// Loader enforces that by throwing when constructed again with different
+// options. Handing back the existing instance keeps a locale reached by
+// client navigation from throwing on a change the loaded script could not
+// have honoured anyway; a full load picks the new language up.
+let loader: Loader | null = null;
+
+function getLoader(language: string): Loader {
+  if (!loader) {
+    loader = new Loader({
+      apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
+      version: 'beta',
+      language
+    });
+  }
+
+  return loader;
+}
+
 type Props = {
   mapId: string;
   children?: ReactNode;
@@ -30,17 +50,7 @@ function GoogleMaps({ mapId, children, sx, mapOptions, center, zoom }: Props) {
   const [currentPosition, setCurrentPosition] =
     useState<GeolocationPosition | null>(null);
 
-  // The loader is a singleton per option set, and the language is baked into
-  // the script URL it builds, so construction is the only chance to set it.
-  const language = toLocale(lang);
-
-  const loader = useMemo(() => {
-    return new Loader({
-      apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
-      version: 'beta',
-      language
-    });
-  }, [language]);
+  const loader = getLoader(toLocale(lang));
 
   const theme = useTheme();
   const mdUp = useMediaQuery(theme.breakpoints.up('md'));

--- a/src/components/maps/GoogleMaps.tsx
+++ b/src/components/maps/GoogleMaps.tsx
@@ -30,8 +30,8 @@ function GoogleMaps({ mapId, children, sx, mapOptions, center, zoom }: Props) {
   const [currentPosition, setCurrentPosition] =
     useState<GeolocationPosition | null>(null);
 
-  // Loader は options ごとのシングルトンで、言語はスクリプト URL に焼き込まれる。
-  // 読み込み後の差し替えはできないため、生成時に渡す唯一の機会となる。
+  // The loader is a singleton per option set, and the language is baked into
+  // the script URL it builds, so construction is the only chance to set it.
   const language = toLocale(lang);
 
   const loader = useMemo(() => {

--- a/src/components/maps/MapDetailView.tsx
+++ b/src/components/maps/MapDetailView.tsx
@@ -286,7 +286,6 @@ export default function MapDetailView({
           }}
           center={center}
           zoom={currentZoom}
-          locale={lang}
         >
           <CustomOverlays
             map={map}

--- a/src/components/maps/PlaceAutocomplete.tsx
+++ b/src/components/maps/PlaceAutocomplete.tsx
@@ -87,10 +87,12 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
   ) => {
     setInputValue(newInputValue);
 
-    // Searching for the label MUI writes back on selection would open a new
-    // billing session the moment resolvePlace closed one, and no place lookup
-    // would ever close it.
-    if (reason === 'input' || reason === 'clear') {
+    // Selecting a suggestion writes its label back through here, and searching
+    // for that would open a billing session the moment resolvePlace closed
+    // one, with no place lookup left to close it. Only the visitor's own
+    // typing is worth a query; the reasons that write a label back matter
+    // just when they empty the field, which has to drop the suggestions too.
+    if (reason === 'input' || newInputValue === '') {
       setQuery(newInputValue);
     }
   };

--- a/src/components/maps/PlaceAutocomplete.tsx
+++ b/src/components/maps/PlaceAutocomplete.tsx
@@ -1,6 +1,7 @@
 import { LocationOn, Search } from '@mui/icons-material';
 import {
   Autocomplete,
+  type AutocompleteInputChangeReason,
   InputAdornment,
   ListItem,
   ListItemIcon,
@@ -32,10 +33,11 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
     null
   );
   const [inputValue, setInputValue] = useState('');
+  const [query, setQuery] = useState('');
 
   const selectionIdRef = useRef(0);
 
-  const { predictions, isLoading, resolvePlace } = usePlaceSearch(inputValue);
+  const { predictions, isLoading, resolvePlace } = usePlaceSearch(query);
 
   // 選択済みの候補が options から外れると MUI が value を不正とみなすため、
   // 最新の候補に含まれていない場合は選択済みの候補を補う
@@ -78,8 +80,18 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
     }
   };
 
-  const handleInputChange = (_event: SyntheticEvent, newInputValue: string) => {
+  const handleInputChange = (
+    _event: SyntheticEvent,
+    newInputValue: string,
+    reason: AutocompleteInputChangeReason
+  ) => {
     setInputValue(newInputValue);
+
+    // 候補選択時に書き戻されるラベルまで検索すると、resolvePlace が終了させた
+    // 直後に新しいセッションが始まり、fetchFields で閉じられないまま課金される
+    if (reason === 'input' || reason === 'clear') {
+      setQuery(newInputValue);
+    }
   };
 
   return (

--- a/src/components/maps/PlaceAutocomplete.tsx
+++ b/src/components/maps/PlaceAutocomplete.tsx
@@ -16,8 +16,8 @@ import {
   useRef,
   useState
 } from 'react';
-import useDictionary from '../../hooks/useDictionary';
-import { usePlaceSearch } from '../../hooks/usePlaceSearch';
+import useDictionary from '../../hooks/useDictionary.ts';
+import { usePlaceSearch } from '../../hooks/usePlaceSearch.ts';
 
 type Props = {
   ref: MutableRefObject<HTMLInputElement>;
@@ -39,8 +39,8 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
 
   const { predictions, isLoading, resolvePlace } = usePlaceSearch(query);
 
-  // 選択済みの候補が options から外れると MUI が value を不正とみなすため、
-  // 最新の候補に含まれていない場合は選択済みの候補を補う
+  // MUI reads a value that is missing from the options as invalid, so the
+  // selection is kept in the list whenever the latest suggestions drop it.
   const options =
     !value ||
     predictions.some((prediction) => prediction.placeId === value.placeId)
@@ -51,8 +51,8 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
     _event: SyntheticEvent,
     prediction: google.maps.places.PlacePrediction | null
   ) => {
-    // Place の取得中に別の候補が選択された場合、
-    // 遅れて解決した Place で新しい選択を上書きしないようにする
+    // A Place that resolves late must not overwrite a suggestion the visitor
+    // picked while it was still loading.
     const selectionId = ++selectionIdRef.current;
 
     setValue(prediction);
@@ -87,8 +87,9 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
   ) => {
     setInputValue(newInputValue);
 
-    // 候補選択時に書き戻されるラベルまで検索すると、resolvePlace が終了させた
-    // 直後に新しいセッションが始まり、fetchFields で閉じられないまま課金される
+    // Searching for the label MUI writes back on selection would open a new
+    // billing session the moment resolvePlace closed one, and no place lookup
+    // would ever close it.
     if (reason === 'input' || reason === 'clear') {
       setQuery(newInputValue);
     }

--- a/src/hooks/usePlaceDetails.ts
+++ b/src/hooks/usePlaceDetails.ts
@@ -1,12 +1,15 @@
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { toLocale } from '../utils/locales.ts';
 import { useGoogleMap } from './useGoogleMap.ts';
+import { PLACE_FIELDS } from './usePlaceSearch.ts';
 
 const placeCache = new Map<string, google.maps.places.Place>();
 
 export function usePlaceDetails(placeId: string | null | undefined) {
   const { loader } = useGoogleMap();
   const { lang } = useParams<{ lang: string }>();
+  const language = toLocale(lang);
 
   const [place, setPlace] = useState<google.maps.places.Place | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -17,7 +20,7 @@ export function usePlaceDetails(placeId: string | null | undefined) {
       return;
     }
 
-    const cacheKey = `${placeId}-${lang}`;
+    const cacheKey = `${placeId}-${language}`;
     const cached = placeCache.get(cacheKey);
 
     if (cached) {
@@ -36,17 +39,11 @@ export function usePlaceDetails(placeId: string | null | undefined) {
 
         const placeInstance = new Place({
           id: placeId,
-          requestedLanguage: lang ?? 'en'
+          requestedLanguage: language
         });
 
         const data = await placeInstance.fetchFields({
-          fields: [
-            'id',
-            'location',
-            'displayName',
-            'plusCode',
-            'formattedAddress'
-          ]
+          fields: PLACE_FIELDS
         });
 
         if (!cancelled) {
@@ -69,7 +66,7 @@ export function usePlaceDetails(placeId: string | null | undefined) {
     return () => {
       cancelled = true;
     };
-  }, [placeId, loader, lang]);
+  }, [placeId, loader, language]);
 
   return {
     place,

--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -22,8 +22,9 @@ export function usePlaceSearch(input: string) {
   >([]);
   const [isLoading, setIsLoading] = useState(false);
 
-  // 入力開始から Place の取得までを 1 セッションとして課金させるためのトークン。
-  // fetchFields でセッションが終了するので、そのたびに破棄して次のセッション用に再発行する。
+  // The token bills everything from the first keystroke to the place lookup
+  // as one session. fetchFields ends that session, so the token is discarded
+  // and reissued for the next one.
   const sessionTokenRef =
     useRef<google.maps.places.AutocompleteSessionToken | null>(null);
   const requestIdRef = useRef(0);
@@ -75,8 +76,9 @@ export function usePlaceSearch(input: string) {
   const resolvePlace = async (
     prediction: google.maps.places.PlacePrediction
   ) => {
-    // セッションは fetchFields の応答ではなく呼び出しで終了するため、
-    // 待っている間に始まった入力が終了済みのトークンを使い回さないよう先に破棄する
+    // The session ends when fetchFields is called rather than when it
+    // answers, so the token goes first: input that starts while the response
+    // is in flight must not reuse a spent one.
     sessionTokenRef.current = null;
 
     const { place } = await prediction
@@ -87,8 +89,8 @@ export function usePlaceSearch(input: string) {
   };
 
   useEffect(() => {
-    // 実行中のリクエストは debounce の待ち時間中にも解決しうるため、
-    // ID の採番は待ち時間の前、入力が変わった時点で行う
+    // A request already in flight can resolve during the debounce wait, so
+    // the id is taken when the input changes rather than after the wait.
     const requestId = ++requestIdRef.current;
 
     if (!input) {
@@ -100,9 +102,9 @@ export function usePlaceSearch(input: string) {
       return;
     }
 
-    // デバウンスの待ち時間もリクエスト中と同じ扱いにする。
-    // 本体の先頭で立てると、その間だけ候補ゼロかつ非ローディングになり
-    // Autocomplete が「見つかりません」を表示してしまう。
+    // The debounce wait counts as part of the request. Raising this inside
+    // the debounced body instead leaves a window with no suggestions and no
+    // loading flag, which is what the Autocomplete renders "not found" for.
     setIsLoading(true);
 
     fetchSuggestions(input, requestId);

--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -1,9 +1,10 @@
 import debounce from 'lodash.debounce';
 import { useParams } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { toLocale } from '../utils/locales.ts';
 import { useGoogleMap } from './useGoogleMap.ts';
 
-const PLACE_FIELDS = [
+export const PLACE_FIELDS = [
   'id',
   'location',
   'displayName',
@@ -14,6 +15,7 @@ const PLACE_FIELDS = [
 export function usePlaceSearch(input: string) {
   const { loader } = useGoogleMap();
   const { lang } = useParams<{ lang: string }>();
+  const language = toLocale(lang);
 
   const [predictions, setPredictions] = useState<
     google.maps.places.PlacePrediction[]
@@ -46,7 +48,7 @@ export function usePlaceSearch(input: string) {
           const { suggestions } =
             await AutocompleteSuggestion.fetchAutocompleteSuggestions({
               input: query,
-              language: lang,
+              language,
               sessionToken: sessionTokenRef.current
             });
 
@@ -69,7 +71,7 @@ export function usePlaceSearch(input: string) {
           }
         }
       }, 300),
-    [loader, lang]
+    [loader, language]
   );
 
   const resolvePlace = async (

--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -31,13 +31,11 @@ export function usePlaceSearch(input: string) {
   const fetchSuggestions = useMemo(
     () =>
       debounce(async (query: string, requestId: number) => {
-        if (!loader) {
-          return;
-        }
-
-        setIsLoading(true);
-
         try {
+          if (!loader) {
+            return;
+          }
+
           const { AutocompleteSessionToken, AutocompleteSuggestion } =
             await loader.importLibrary('places');
 
@@ -101,6 +99,11 @@ export function usePlaceSearch(input: string) {
 
       return;
     }
+
+    // デバウンスの待ち時間もリクエスト中と同じ扱いにする。
+    // 本体の先頭で立てると、その間だけ候補ゼロかつ非ローディングになり
+    // Autocomplete が「見つかりません」を表示してしまう。
+    setIsLoading(true);
 
     fetchSuggestions(input, requestId);
 


### PR DESCRIPTION
# Summary

Fixes three defects in the map and place-search paths found by the code review of #1120: the Maps JavaScript API was never told which language to render in, picking a suggestion issued one extra billed Places request, and the place field showed "place not found" for the first 300 ms of every search.

# Motivation

The locale was assigned through `loader.options.language`, but `options` is a getter that builds a fresh object on every read, so the assignment was discarded and the API script URL never carried `&language=`. Place names and map labels therefore followed the browser's own language, not the locale being browsed — a Japanese page could render its map entirely in English. The language is baked into the script URL and cannot be changed after the script loads, so it has to be passed when the loader is constructed.

On the place field, MUI writes the selected label back through `onInputChange`, and the handler treated that like typing. `resolvePlace` has already closed the billing session by then, so the extra request opens a session that no place lookup ever closes and Google bills it separately from the one the visitor completed.

# Changes

- The map component reads the locale from the route and passes it to the `Loader` constructor; the `locale` prop and the discarded assignment are gone. Reading the route directly also keeps every loader instance in agreement, which the loader requires — it is a singleton that rejects a second construction with different options
- The place field searches only on the input-change reasons that represent the visitor's own typing, so selecting a suggestion no longer starts an unclosable billing session
- The loading flag is raised when the input changes rather than inside the debounced body, so the debounce wait no longer renders as "no results"
- `PLACE_FIELDS` and the locale resolution are shared between the two place hooks instead of being declared twice with diverging fallbacks

# Testing

- `pnpm build`: succeeds, and the built client chunk constructs the loader as `version:"beta",language:…`, confirming the language now reaches the script URL
- `pnpm test`: 106 tests pass
- `pnpm biome ci ./src` / `pnpm exec tsc --noEmit`: no errors (Biome prints an internal panic from its React Compiler rule on multibyte comments; it exits 0 and reproduces unchanged on `master`)

---
_Generated by [Claude Code](https://claude.ai/code/session_014wCMqUghcBhW41T6T8fuNT)_