### PR TITLE
fix: keep a checkin note pending until it saves

### DIFF
--- a/src/components/journeys/CheckinNoteField.tsx
+++ b/src/components/journeys/CheckinNoteField.tsx
@@ -10,7 +10,7 @@ const NOTE_MAX_LENGTH = 500;
 
 type Props = {
   checkin: JourneyCheckin;
-  onSave: (checkin: JourneyCheckin, note: string | null) => Promise<void>;
+  onSave: (checkin: JourneyCheckin, note: string | null) => Promise<boolean>;
 };
 
 function CheckinNoteField({ checkin, onSave }: Props) {
@@ -44,7 +44,16 @@ function CheckinNoteField({ checkin, onSave }: Props) {
     }
 
     stateRef.current.dirty = false;
-    save(latest, draft.trim() ? draft : null);
+
+    // 保存できなかった下書きを保存済みとして扱うと、離脱時の flush でも
+    // 送られずに失われるため、失敗したら未保存に戻して再送の対象にする
+    save(latest, draft.trim() ? draft : null)
+      .catch(() => false)
+      .then((saved) => {
+        if (!saved) {
+          stateRef.current.dirty = true;
+        }
+      });
   }, []);
 
   useEffect(() => {

--- a/src/components/journeys/CheckinNoteField.tsx
+++ b/src/components/journeys/CheckinNoteField.tsx
@@ -45,8 +45,9 @@ function CheckinNoteField({ checkin, onSave }: Props) {
 
     stateRef.current.dirty = false;
 
-    // 保存できなかった下書きを保存済みとして扱うと、離脱時の flush でも
-    // 送られずに失われるため、失敗したら未保存に戻して再送の対象にする
+    // Treating a draft that failed to save as saved would lose it outright:
+    // even the flush on leaving the page would find nothing to send. A
+    // failure puts it back in the pending state so the next flush retries.
     save(latest, draft.trim() ? draft : null)
       .catch(() => false)
       .then((saved) => {

--- a/src/components/journeys/JourneyDetailView.tsx
+++ b/src/components/journeys/JourneyDetailView.tsx
@@ -253,8 +253,8 @@ export default function JourneyDetailView({
   );
 
   const handleSaveNote = useCallback(
-    async (checkin: JourneyCheckin, note: string | null) => {
-      await saveCheckin(checkin, { note });
+    (checkin: JourneyCheckin, note: string | null): Promise<boolean> => {
+      return saveCheckin(checkin, { note });
     },
     [saveCheckin]
   );

--- a/src/components/journeys/JourneyProgressSheet.tsx
+++ b/src/components/journeys/JourneyProgressSheet.tsx
@@ -59,7 +59,10 @@ type RowProps = {
   onRemove: () => void;
   onAttachImage: (checkin: JourneyCheckin, image: Image) => Promise<void>;
   onRemoveImage: (checkin: JourneyCheckin, imageId: number) => Promise<boolean>;
-  onSaveNote: (checkin: JourneyCheckin, note: string | null) => Promise<void>;
+  onSaveNote: (
+    checkin: JourneyCheckin,
+    note: string | null
+  ) => Promise<boolean>;
 };
 
 function TimelineRow({
@@ -199,7 +202,10 @@ type Props = {
   onRemoveCheckin: (checkin: JourneyCheckin) => void;
   onAttachImage: (checkin: JourneyCheckin, image: Image) => Promise<void>;
   onRemoveImage: (checkin: JourneyCheckin, imageId: number) => Promise<boolean>;
-  onSaveNote: (checkin: JourneyCheckin, note: string | null) => Promise<void>;
+  onSaveNote: (
+    checkin: JourneyCheckin,
+    note: string | null
+  ) => Promise<boolean>;
   onStartClick: () => void;
   onPauseClick: () => void;
   onResumeClick: () => void | Promise<void>;

--- a/src/hooks/useChapter.ts
+++ b/src/hooks/useChapter.ts
@@ -35,11 +35,18 @@ export default function useChapter(initialChapter: Chapter) {
     request: Promise<boolean>;
   } | null>(null);
 
-  const flush = (draft?: Chapter): Promise<boolean> | undefined => {
+  const flush = (draft?: Chapter): Promise<boolean> => {
     const current = draft ?? chapter;
 
-    if (discardedRef.current || current.updated_at === savedAt) {
-      return inFlightRef.current?.request;
+    // A discarded chapter has nothing left to save, and a draft already on
+    // the server is saved; callers that report to the user need those two
+    // apart rather than both arriving as "no request was made".
+    if (discardedRef.current) {
+      return Promise.resolve(false);
+    }
+
+    if (current.updated_at === savedAt) {
+      return inFlightRef.current?.request ?? Promise.resolve(true);
     }
 
     const inFlight = inFlightRef.current;
@@ -209,7 +216,14 @@ export default function useChapter(initialChapter: Chapter) {
     // must always be able to report, so the dedup flag resets first.
     saveErrorNotifiedRef.current = false;
 
-    const saved = (await flush(next)) ?? true;
+    const saved = await flush(next);
+
+    if (!saved) {
+      // Leaving the new status on screen would claim the chapter is published
+      // when the server still has it as a draft. Edits typed while the
+      // request was in flight stay; only the status goes back.
+      setChapter((current) => ({ ...current, status: chapter.status }));
+    }
 
     return { success: saved };
   };

--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -260,11 +260,11 @@ export default function useJourney({
     });
   };
 
-  const updateCheckinNote = async (
+  const updateCheckinNote = (
     checkin: JourneyCheckin,
     note: string | null
-  ) => {
-    await mutateCheckin(checkin, { note });
+  ): Promise<boolean> => {
+    return mutateCheckin(checkin, { note });
   };
 
   const performCheckin = useCallback(

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -27,11 +27,11 @@ describe('performApiFetch', () => {
     });
 
     const [url, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
-    const requestHeaders = init?.headers as Record<string, string>;
+    const requestHeaders = init?.headers as Headers;
 
     assert.equal(url, 'https://api.example.com/maps');
-    assert.equal(requestHeaders.Authorization, 'Bearer token-1');
-    assert.equal(requestHeaders['Accept-Language'], 'ja');
+    assert.equal(requestHeaders.get('Authorization'), 'Bearer token-1');
+    assert.equal(requestHeaders.get('Accept-Language'), 'ja');
     assert.deepEqual(result, { data: { id: 1 }, error: null, status: 200 });
   });
 
@@ -43,10 +43,10 @@ describe('performApiFetch', () => {
     await performApiFetch('/maps', { token: null, acceptLanguage: 'en' });
 
     const [url, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
-    const requestHeaders = init?.headers as Record<string, string>;
+    const requestHeaders = init?.headers as Headers;
 
     assert.equal(url, 'https://api.example.com/guest/maps');
-    assert.equal('Authorization' in requestHeaders, false);
+    assert.equal(requestHeaders.has('Authorization'), false);
   });
 
   it('passes caller headers through alongside the defaults', async (t) => {
@@ -61,10 +61,27 @@ describe('performApiFetch', () => {
     });
 
     const [, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
-    const requestHeaders = init?.headers as Record<string, string>;
+    const requestHeaders = init?.headers as Headers;
 
-    assert.equal(requestHeaders['x-requested-with'], 'test');
-    assert.equal(requestHeaders.Accept, 'application/json');
+    assert.equal(requestHeaders.get('X-Requested-With'), 'test');
+    assert.equal(requestHeaders.get('Accept'), 'application/json');
+  });
+
+  it('lets a caller header replace the default of any casing', async (t) => {
+    const fetchMock = t.mock.method(globalThis, 'fetch', async () =>
+      jsonResponse({})
+    );
+
+    await performApiFetch('/maps', {
+      token: 'token-1',
+      acceptLanguage: 'en',
+      headers: { 'content-type': 'multipart/form-data' }
+    });
+
+    const [, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
+    const requestHeaders = init?.headers as Headers;
+
+    assert.equal(requestHeaders.get('Content-Type'), 'multipart/form-data');
   });
 
   it('surfaces the backend error detail', async (t) => {
@@ -181,10 +198,10 @@ describe('apiFetch', () => {
     const result = await apiFetch('/maps', { guest: true, lang: 'ja' });
 
     const [url, init] = fetchMock.mock.calls[0].arguments as FetchArgs;
-    const requestHeaders = init?.headers as Record<string, string>;
+    const requestHeaders = init?.headers as Headers;
 
     assert.equal(url, 'https://api.example.com/guest/maps');
-    assert.equal(requestHeaders['Accept-Language'], 'ja');
+    assert.equal(requestHeaders.get('Accept-Language'), 'ja');
     assert.deepEqual(result, { data: [], error: null, status: 200 });
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -48,15 +48,22 @@ export async function performApiFetch<T>(
 
   const apiPath = token ? path : `/guest${path}`;
 
-  const requestHeaders: Record<string, string> = {
+  // Headers matches names case-insensitively, so a caller's 'content-type'
+  // replaces the default instead of the two being sent comma-joined as one
+  // value, which is what merging plain objects by spread produced.
+  const requestHeaders = new Headers({
     Accept: 'application/json',
     'Accept-Language': acceptLanguage,
     'Content-Type': 'application/json'
-  };
+  });
 
   if (token) {
-    requestHeaders.Authorization = `Bearer ${token}`;
+    requestHeaders.set('Authorization', `Bearer ${token}`);
   }
+
+  new Headers(fetchOptions.headers).forEach((value, name) => {
+    requestHeaders.set(name, value);
+  });
 
   try {
     const res = await fetch(`${process.env.API_ENDPOINT}${apiPath}`, {
@@ -64,10 +71,7 @@ export async function performApiFetch<T>(
       signal:
         fetchOptions.signal ??
         AbortSignal.timeout(timeoutMs ?? DEFAULT_TIMEOUT_MS),
-      headers: {
-        ...requestHeaders,
-        ...Object.fromEntries(new Headers(fetchOptions.headers).entries())
-      },
+      headers: requestHeaders,
       next
     });
 


### PR DESCRIPTION
# Summary

Fixes three save-path defects found by the code review of #1120: a checkin note whose save failed was lost silently, a chapter whose publish failed kept showing as published, and a caller header could not override an API default.

# Motivation

The note field marked its draft saved before the request went out and never learned the outcome, so a failed save left nothing for the retry on blur, on the next keystroke or on leaving the page to send — the note was simply gone. The outcome was in fact available: it was reported as far up as the field's own callback and then dropped there.

Publishing applies the new status before the request so the editor reacts at once, but nothing put it back when the request failed. The author was then looking at a chapter marked published while the server still held a draft, with only the error notice to tell them otherwise.

In `performApiFetch`, the defaults were declared with their conventional casing and merged with caller headers by spreading a plain object. Caller names arrive lowercased, so both spellings of a header survived as separate keys and `fetch` sent them comma-joined. Nothing overrides a default today, so this is a trap rather than a visible failure.

# Changes

- The save result is carried through `useJourney` and the journey views into the note field, which puts a failed draft back in the pending state so the next flush sends it again
- `useChapter.changeStatus` reverts the status when the save fails, keeping edits typed while the request was in flight; `flush` now always answers with what is actually saved instead of a third "no request was made" value the caller had to read as success
- API request headers are merged through `Headers`, so a caller's value replaces the default the way the protocol matches names

# Testing

- `pnpm test`: 107 tests pass, including a new case asserting a caller's `content-type` replaces the default (against the previous code it comes back as `application/json, multipart/form-data`)
- `pnpm build`: succeeds
- `pnpm biome ci ./src` / `pnpm exec tsc --noEmit`: no errors

---
_Generated by [Claude Code](https://claude.ai/code/session_014wCMqUghcBhW41T6T8fuNT)_