### PR TITLE
fix: judge check-ins against the current spots

### DIFF
--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -652,9 +652,18 @@ export default function useJourney({
       milestones.length < 1 &&
       latest.checkins.length < 1
     ) {
-      deleteJourney(latest.id);
-      commitJourney(null);
-      return;
+      const { success: deleted, error: deleteError } = await deleteJourney(
+        latest.id
+      );
+
+      if (deleted) {
+        commitJourney(null);
+        return;
+      }
+
+      // Clearing a journey the server still holds would strand it: the next
+      // milestone would open a second one for the same map.
+      onError(deleteError);
     }
 
     commitJourney({ ...latest, milestones });

--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -119,6 +119,15 @@ export default function useJourney({
 
   const pendingCheckinsRef = useRef(new Set<number>());
 
+  // resume and start hand a fix to processPosition after awaiting the device,
+  // which can take the best part of a minute; a router refresh landing in that
+  // window must not leave the check-in decision judging a stale spot list.
+  const reviewsRef = useRef(reviews);
+
+  useEffect(() => {
+    reviewsRef.current = reviews;
+  }, [reviews]);
+
   const commitJourney = useCallback((next: Journey | null) => {
     journeyRef.current = next;
     setJourney(next);
@@ -333,7 +342,7 @@ export default function useJourney({
         lastTrailPoint: trailRef.current.at(-1) ?? null
       },
       fix,
-      reviews.filter((review) => !visitedIds.has(review.id))
+      reviewsRef.current.filter((review) => !visitedIds.has(review.id))
     );
 
     lastFixRef.current = {
@@ -365,9 +374,9 @@ export default function useJourney({
 
   // The geolocation watch and the sampling timer outlive the render that
   // registered them, so they deliver fixes through an effect event, which
-  // always sees the latest committed review list without the watch having to
-  // re-register every time that list changes. Event handlers call
-  // processPosition directly.
+  // always sees the latest committed callbacks without the watch having to
+  // re-register every time they change. Event handlers call processPosition
+  // directly, which effect events do not allow.
   const handlePosition = useEffectEvent(processPosition);
 
   // Losing the permission mid-journey must not cost the traveller their

--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -5,6 +5,7 @@ import {
   useContext,
   useEffect,
   useEffectEvent,
+  useLayoutEffect,
   useRef,
   useState
 } from 'react';
@@ -122,9 +123,12 @@ export default function useJourney({
   // resume and start hand a fix to processPosition after awaiting the device,
   // which can take the best part of a minute; a router refresh landing in that
   // window must not leave the check-in decision judging a stale spot list.
+  // The copy runs as a layout effect so it lands in the commit itself: a
+  // geolocation callback is a task, and no task can run before the commit
+  // finishes, whereas one can arrive ahead of a passive effect.
   const reviewsRef = useRef(reviews);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     reviewsRef.current = reviews;
   }, [reviews]);
 


### PR DESCRIPTION
# Summary

Fixes two journey defects found by the code review of #1120: resuming or starting a journey could judge check-ins against a stale spot list, and removing the last milestone cleared the journey from the screen even when the server refused to delete it.

# Motivation

`resume` and `start` ask the device for a fix and hand it straight to the position handler. That wait runs to fifteen seconds before the server action that follows it, and a `router.refresh()` arriving in that window updates the spot list — but the handler was still reading the list captured by the render the button belonged to. The traveller could then be checked into a spot they had already visited, or miss one added while they waited. The watch and the sampling timer are unaffected: they go through the effect event, which sees the latest render. The two direct callers cannot, since effect events may only be called from an Effect. This is a regression from the `reviewsRef.current` read that the code carried before d230544.

Separately, `removeMilestone` deletes an unstarted journey once its last milestone and check-in are gone, but issued that deletion without awaiting it and never read the result. A failed request left an empty journey stranded on the account while the screen showed none, so the next milestone opened a second journey for the same map.

# Changes

- The spot list is read through a ref, so every caller of the position handler judges check-ins against the list the server last sent
- The ref is filled by a layout effect rather than a passive one. A passive effect runs after paint, leaving a frame in which a geolocation callback could still read the previous list; a layout effect lands in the commit itself, and a geolocation callback is a task, so none can arrive in between. Writing the ref during render would close the same window but give up more than it gains: `router.refresh()` renders in a transition, a transition can be discarded, and judging a check-in against spots that were never committed is worse than being one frame behind
- The journey deletion is awaited; on failure the error surfaces and the journey stays on screen, now without the milestone

# Testing

- `pnpm test`: 106 tests pass, including the `journeyTracking` suite covering the decision the spot list feeds
- `pnpm build`: succeeds
- `pnpm biome ci ./src` / `pnpm exec tsc --noEmit`: no errors
- The commit-versus-callback ordering has no test: the unit suite is `node:test` over pure modules, with no DOM or renderer, so a test for it has nowhere to live yet

---
_Generated by [Claude Code](https://claude.ai/code/session_014wCMqUghcBhW41T6T8fuNT)_