### PR TITLE
test: share the fixtures the suites duplicated

### DIFF
--- a/src/test/assertions.ts
+++ b/src/test/assertions.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+
+export function assertCloseTo(
+  actual: number,
+  expected: number,
+  tolerance: number
+): void {
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${actual} to be within ${tolerance} of ${expected}`
+  );
+}

--- a/src/test/journeys.ts
+++ b/src/test/journeys.ts
@@ -1,0 +1,33 @@
+import type { Journey, JourneyCheckin } from '../../types/index.ts';
+
+export function buildCheckin(
+  id: number,
+  checkedInAt: string,
+  overrides: Partial<JourneyCheckin> = {}
+): JourneyCheckin {
+  return {
+    id,
+    review_id: id * 100,
+    spot: { name: `Spot ${id}`, latitude: 35, longitude: 139 },
+    checked_in_at: checkedInAt,
+    note: null,
+    images: [],
+    ...overrides
+  };
+}
+
+export function buildJourney(checkins: JourneyCheckin[]): Journey {
+  return {
+    id: 1,
+    map_id: 10,
+    started_at: '2026-08-01T00:00:00Z',
+    finished_at: null,
+    milestones: [],
+    checkins,
+    encoded_path: null,
+    chapter_id: null,
+    map: null,
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z'
+  };
+}

--- a/src/test/localStorage.ts
+++ b/src/test/localStorage.ts
@@ -1,0 +1,31 @@
+export type StorageStub = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export function installLocalStorage(stub: StorageStub): void {
+  (globalThis as unknown as { window: { localStorage: StorageStub } }).window =
+    {
+      localStorage: stub
+    };
+}
+
+export function memoryStorage(): StorageStub & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+
+  return {
+    store,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    }
+  };
+}
+
+export function throwingStorage(): StorageStub {
+  const denied = () => {
+    throw new Error('denied');
+  };
+
+  return { getItem: denied, setItem: denied, removeItem: denied };
+}

--- a/src/utils/chapterContent.test.ts
+++ b/src/utils/chapterContent.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { SerializedEditorState } from 'lexical';
 import type { Image, Journey, JourneyCheckin } from '../../types/index.ts';
+import { buildCheckin, buildJourney } from '../test/journeys.ts';
 import {
   chapterSections,
   createChapterContent,
@@ -17,38 +18,6 @@ function buildImage(id: number): Image {
     card: `https://images.example.com/${id}/card`,
     hero: `https://images.example.com/${id}/hero`,
     ogp: `https://images.example.com/${id}/ogp`
-  };
-}
-
-function buildCheckin(
-  id: number,
-  checkedInAt: string,
-  overrides: Partial<JourneyCheckin> = {}
-): JourneyCheckin {
-  return {
-    id,
-    review_id: id * 100,
-    spot: { name: `Spot ${id}`, latitude: 35, longitude: 139 },
-    checked_in_at: checkedInAt,
-    note: null,
-    images: [],
-    ...overrides
-  };
-}
-
-function buildJourney(checkins: JourneyCheckin[]): Journey {
-  return {
-    id: 1,
-    map_id: 10,
-    started_at: '2026-08-01T00:00:00Z',
-    finished_at: null,
-    milestones: [],
-    checkins,
-    encoded_path: null,
-    chapter_id: null,
-    map: null,
-    created_at: '2026-08-01T00:00:00Z',
-    updated_at: '2026-08-01T00:00:00Z'
   };
 }
 

--- a/src/utils/geo.test.ts
+++ b/src/utils/geo.test.ts
@@ -1,15 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { assertCloseTo } from '../test/assertions.ts';
 import { distanceInMeters, trailDistanceMeters } from './geo.ts';
 
 const EQUATOR_ONE_DEGREE_METERS = 111194.93;
-
-function assertCloseTo(actual: number, expected: number, tolerance: number) {
-  assert.ok(
-    Math.abs(actual - expected) <= tolerance,
-    `expected ${actual} to be within ${tolerance} of ${expected}`
-  );
-}
 
 describe('distanceInMeters', () => {
   it('returns zero for identical points', () => {

--- a/src/utils/journeyPauseStorage.test.ts
+++ b/src/utils/journeyPauseStorage.test.ts
@@ -1,36 +1,11 @@
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
+import {
+  installLocalStorage,
+  memoryStorage,
+  throwingStorage
+} from '../test/localStorage.ts';
 import { deletePaused, loadPaused, savePaused } from './journeyPauseStorage.ts';
-
-type StorageStub = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
-
-function installLocalStorage(stub: StorageStub): void {
-  (globalThis as unknown as { window: { localStorage: StorageStub } }).window =
-    { localStorage: stub };
-}
-
-function memoryStorage(): StorageStub & { store: Map<string, string> } {
-  const store = new Map<string, string>();
-
-  return {
-    store,
-    getItem: (key) => store.get(key) ?? null,
-    setItem: (key, value) => {
-      store.set(key, value);
-    },
-    removeItem: (key) => {
-      store.delete(key);
-    }
-  };
-}
-
-function throwingStorage(): StorageStub {
-  const denied = () => {
-    throw new Error('denied');
-  };
-
-  return { getItem: denied, setItem: denied, removeItem: denied };
-}
 
 describe('journeyPauseStorage', () => {
   let storage: ReturnType<typeof memoryStorage>;

--- a/src/utils/journeyTracking.test.ts
+++ b/src/utils/journeyTracking.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { assertCloseTo } from '../test/assertions.ts';
 import {
   movingSampleIntervalMs,
   nearestSpotDistance,
@@ -192,7 +193,7 @@ describe('nearestSpotDistance', () => {
       pointAt(100)
     ]);
 
-    assert.ok(Math.abs(nearest - 100) < 0.001);
+    assertCloseTo(nearest, 100, 0.001);
   });
 });
 
@@ -278,7 +279,7 @@ describe('movingSampleIntervalMs', () => {
 
     const interval = movingSampleIntervalMs(fix, previous, 2300);
 
-    assert.ok(Math.abs(interval - 100000) < 0.001);
+    assertCloseTo(interval, 100000, 0.001);
   });
 
   it('assumes a walking pace without any speed signal', () => {

--- a/src/utils/journeyTracking.ts
+++ b/src/utils/journeyTracking.ts
@@ -1,22 +1,22 @@
 import type { JourneyPathPoint } from '../../types/index.ts';
 import { distanceInMeters } from './geo.ts';
 
-export const CHECKIN_RADIUS_METERS = 50;
-export const PATH_MIN_DISTANCE_METERS = 10;
+const CHECKIN_RADIUS_METERS = 50;
+const PATH_MIN_DISTANCE_METERS = 10;
 
 // A coarse fix can report a spot as reachable from far outside the check-in
 // radius, so anything less certain than this is only used to draw the trail.
-export const CHECKIN_MAX_ACCURACY_METERS = 100;
+const CHECKIN_MAX_ACCURACY_METERS = 100;
 
-export const ACCURACY_UPGRADE_RADIUS_METERS = 300;
-export const ACCURACY_DOWNGRADE_RADIUS_METERS = 500;
+const ACCURACY_UPGRADE_RADIUS_METERS = 300;
+const ACCURACY_DOWNGRADE_RADIUS_METERS = 500;
 
 // The Geolocation API offers no interval or distance filter, so a registered
 // watch keeps the positioning hardware powered the whole time. Away from any
 // unvisited spot the journey samples on a timer instead, and the hardware can
 // power down between fixes.
 export const MOVING_SAMPLE_MIN_INTERVAL_MS = 15000;
-export const MOVING_SAMPLE_MAX_INTERVAL_MS = 2 * 60 * 1000;
+const MOVING_SAMPLE_MAX_INTERVAL_MS = 2 * 60 * 1000;
 
 // Headroom over the observed speed, so that speeding up between two samples
 // cannot carry the traveller into the continuous-watch zone unseen.
@@ -24,15 +24,15 @@ const SPEED_HEADROOM = 2;
 const MIN_ASSUMED_SPEED_MPS = 1.5;
 
 // Positioning jitter alone can move a fix this far while the device rests.
-export const STATIONARY_RADIUS_METERS = 30;
-export const STATIONARY_AFTER_MS = 3 * 60 * 1000;
-export const STATIONARY_SAMPLE_BASE_INTERVAL_MS = 30000;
+const STATIONARY_RADIUS_METERS = 30;
+const STATIONARY_AFTER_MS = 3 * 60 * 1000;
+const STATIONARY_SAMPLE_BASE_INTERVAL_MS = 30000;
 const STATIONARY_BACKOFF_MAX_STEPS = 4;
 
 // Near a spot a stale fix could miss a departure that heads straight into
 // the check-in radius, so the backoff stays tighter there.
-export const STATIONARY_SAMPLE_MAX_NEAR_MS = 60000;
-export const STATIONARY_SAMPLE_MAX_FAR_MS = 5 * 60 * 1000;
+const STATIONARY_SAMPLE_MAX_NEAR_MS = 60000;
+const STATIONARY_SAMPLE_MAX_FAR_MS = 5 * 60 * 1000;
 
 export type StationaryAnchor = {
   latitude: number;

--- a/src/utils/journeyTrailStorage.test.ts
+++ b/src/utils/journeyTrailStorage.test.ts
@@ -1,36 +1,11 @@
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
+import {
+  installLocalStorage,
+  memoryStorage,
+  throwingStorage
+} from '../test/localStorage.ts';
 import { deleteTrail, loadTrail, saveTrail } from './journeyTrailStorage.ts';
-
-type StorageStub = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
-
-function installLocalStorage(stub: StorageStub): void {
-  (globalThis as unknown as { window: { localStorage: StorageStub } }).window =
-    { localStorage: stub };
-}
-
-function memoryStorage(): StorageStub & { store: Map<string, string> } {
-  const store = new Map<string, string>();
-
-  return {
-    store,
-    getItem: (key) => store.get(key) ?? null,
-    setItem: (key, value) => {
-      store.set(key, value);
-    },
-    removeItem: (key) => {
-      store.delete(key);
-    }
-  };
-}
-
-function throwingStorage(): StorageStub {
-  const denied = () => {
-    throw new Error('denied');
-  };
-
-  return { getItem: denied, setItem: denied, removeItem: denied };
-}
 
 const TRAIL = [
   { latitude: 35.6586, longitude: 139.7454 },

--- a/src/utils/mapFeatures.test.ts
+++ b/src/utils/mapFeatures.test.ts
@@ -7,38 +7,8 @@ import type {
   MapFeatureCollection,
   Spot
 } from '../../types/index.ts';
+import { buildCheckin, buildJourney } from '../test/journeys.ts';
 import { createMapFeatures, featureSpots, spotFeature } from './mapFeatures.ts';
-
-function buildCheckin(
-  id: number,
-  checkedInAt: string,
-  spot: Spot
-): JourneyCheckin {
-  return {
-    id,
-    review_id: id * 100,
-    spot,
-    checked_in_at: checkedInAt,
-    note: null,
-    images: []
-  };
-}
-
-function buildJourney(checkins: JourneyCheckin[]): Journey {
-  return {
-    id: 1,
-    map_id: 10,
-    started_at: '2026-08-01T00:00:00Z',
-    finished_at: null,
-    milestones: [],
-    checkins,
-    encoded_path: null,
-    chapter_id: null,
-    map: null,
-    created_at: '2026-08-01T00:00:00Z',
-    updated_at: '2026-08-01T00:00:00Z'
-  };
-}
 
 const tower: Spot = {
   name: 'Tokyo Tower',
@@ -67,8 +37,8 @@ describe('spotFeature', () => {
 describe('createMapFeatures', () => {
   it('orders features by check-in time', () => {
     const journey = buildJourney([
-      buildCheckin(2, '2026-08-02T00:00:00Z', castle),
-      buildCheckin(1, '2026-08-01T00:00:00Z', tower)
+      buildCheckin(2, '2026-08-02T00:00:00Z', { spot: castle }),
+      buildCheckin(1, '2026-08-01T00:00:00Z', { spot: tower })
     ]);
 
     const collection = createMapFeatures(journey);
@@ -90,8 +60,8 @@ describe('createMapFeatures', () => {
 describe('featureSpots', () => {
   it('round-trips spots through a feature collection', () => {
     const journey = buildJourney([
-      buildCheckin(1, '2026-08-01T00:00:00Z', tower),
-      buildCheckin(2, '2026-08-02T00:00:00Z', castle)
+      buildCheckin(1, '2026-08-01T00:00:00Z', { spot: tower }),
+      buildCheckin(2, '2026-08-02T00:00:00Z', { spot: castle })
     ]);
 
     assert.deepEqual(featureSpots(createMapFeatures(journey)), [tower, castle]);


### PR DESCRIPTION
# Summary

Removes the fixture duplication the code review of #1120 found across the unit suites, and stops `journeyTracking` exporting eleven tuning constants that nothing imports. Behaviour is unchanged: the same 106 tests pass, with 116 fewer lines.

# Motivation

The two storage suites carried the same thirty lines of `localStorage` stub verbatim, the journey and checkin builders were repeated between two more, and three suites each wrote their own float comparison. A fixture that exists in two places drifts — a builder gains a field on one side only, and the suite on the other keeps asserting against a shape the type no longer describes. Having one place to reach for also spares the next suite from copying whichever neighbour looks closest.

Separately, `journeyTracking` exported twelve tuning constants but only one has an importer. Exporting the rest advertises a public surface the module does not mean to offer: a caller could read a threshold, or compare against it, instead of asking the module for the decision it exists to make.

# Changes

- `src/test/localStorage.ts`, `src/test/journeys.ts` and `src/test/assertions.ts` hold the stubs, the `Journey`/`JourneyCheckin` builders and `assertCloseTo`; the six suites import them
- The two `buildCheckin` variants become one taking `Partial<JourneyCheckin>` overrides, which covers both the spot-only and the arbitrary-field call sites
- Every tracking constant except `MOVING_SAMPLE_MIN_INTERVAL_MS`, which the journey hook seeds its sample timer with, becomes module-private

# Testing

- `pnpm test`: the same 106 tests pass
- `pnpm build`: succeeds (`src/test` has no importer in the app, so it stays out of the bundle)
- `pnpm biome ci ./src` / `pnpm exec tsc --noEmit`: no errors

---
_Generated by [Claude Code](https://claude.ai/code/session_014wCMqUghcBhW41T6T8fuNT)_