### PR TITLE
chore: drop the imports the shared builders replaced

### DIFF
--- a/src/utils/chapterContent.test.ts
+++ b/src/utils/chapterContent.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { SerializedEditorState } from 'lexical';
-import type { Image, Journey, JourneyCheckin } from '../../types/index.ts';
+import type { Image } from '../../types/index.ts';
 import { buildCheckin, buildJourney } from '../test/journeys.ts';
 import {
   chapterSections,

--- a/src/utils/mapFeatures.test.ts
+++ b/src/utils/mapFeatures.test.ts
@@ -1,8 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type {
-  Journey,
-  JourneyCheckin,
   MapFeature,
   MapFeatureCollection,
   Spot


### PR DESCRIPTION
# Summary

Removes the journey type imports that `chapterContent.test.ts` and `mapFeatures.test.ts` stopped using when they moved onto the shared fixture builders.

# Motivation

The two suites used to construct `Journey` and `JourneyCheckin` literals inline. Moving them onto `buildCheckin` and `buildJourney` left the type imports behind.

`noUnusedImports` reports these at warning level, so `biome ci` kept exiting 0 with them present and nothing failed. They are only visible in the report body.

# Changes

- `src/utils/chapterContent.test.ts`: drops `Journey` and `JourneyCheckin` from the type import
- `src/utils/mapFeatures.test.ts`: same

# Testing

- `pnpm biome ci ./src`: exits 0, and the warning count is now 0
- `pnpm exec tsc --noEmit`: no errors
- `pnpm test`: 107 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_014wCMqUghcBhW41T6T8fuNT)_