### PR TITLE
perf: stop the position callback redoing settled work

### DIFF
--- a/src/hooks/useJourney.ts
+++ b/src/hooks/useJourney.ts
@@ -69,7 +69,43 @@ const LOW_ACCURACY_OPTIONS: PositionOptions = {
 // A fix that never resolves would otherwise stall the sampling loop.
 const SAMPLE_TIMEOUT_MS = 30000;
 
+// Every write serialises the whole trail, so writing on each point makes the
+// cost grow with the journey inside the position callback. The store only has
+// to survive a reload, and a flush before the page goes away covers that.
+const TRAIL_SAVE_INTERVAL_MS = 15000;
+
 export type PauseReason = 'permission' | 'inactivity';
+
+type RemainingSpots = {
+  reviews: Review[];
+  checkins: JourneyCheckin[];
+  spots: Review[];
+};
+
+// A fix arrives at roughly 1 Hz, while the two inputs change only on a
+// check-in or a router refresh, so the derived list outlives the fix that
+// asked for it.
+function remainingSpots(
+  previous: RemainingSpots | null,
+  reviews: Review[],
+  checkins: JourneyCheckin[]
+): RemainingSpots {
+  if (
+    previous &&
+    previous.reviews === reviews &&
+    previous.checkins === checkins
+  ) {
+    return previous;
+  }
+
+  const visitedIds = new Set(checkins.map((checkin) => checkin.review_id));
+
+  return {
+    reviews,
+    checkins,
+    spots: reviews.filter((review) => !visitedIds.has(review.id))
+  };
+}
 
 type Args = {
   map: AppMap;
@@ -132,24 +168,69 @@ export default function useJourney({
     reviewsRef.current = reviews;
   }, [reviews]);
 
+  const remainingRef = useRef<RemainingSpots | null>(null);
+
+  const trailSaveRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const trailDirtyRef = useRef(false);
+
   const commitJourney = useCallback((next: Journey | null) => {
     journeyRef.current = next;
     setJourney(next);
   }, []);
+
+  const discardTrailSave = useCallback(() => {
+    if (trailSaveRef.current !== null) {
+      clearTimeout(trailSaveRef.current);
+      trailSaveRef.current = null;
+    }
+
+    trailDirtyRef.current = false;
+  }, []);
+
+  const flushTrail = useCallback(() => {
+    const dirty = trailDirtyRef.current;
+
+    discardTrailSave();
+
+    const current = journeyRef.current;
+
+    if (dirty && uid && current) {
+      saveTrail(uid, current.id, trailRef.current);
+    }
+  }, [uid, discardTrailSave]);
 
   const commitTrail = useCallback(
     (points: JourneyPathPoint[]) => {
       trailRef.current = points;
       setTrail(points);
 
-      const current = journeyRef.current;
+      trailDirtyRef.current = true;
 
-      if (uid && current) {
-        saveTrail(uid, current.id, points);
+      if (trailSaveRef.current === null) {
+        trailSaveRef.current = setTimeout(flushTrail, TRAIL_SAVE_INTERVAL_MS);
       }
     },
-    [uid]
+    [flushTrail]
   );
+
+  useEffect(() => {
+    const flush = () => {
+      if (document.visibilityState === 'hidden') {
+        flushTrail();
+      }
+    };
+
+    // pagehide is the only one of the two a bfcache navigation guarantees,
+    // and visibilitychange the only one backgrounding an app fires.
+    window.addEventListener('pagehide', flushTrail);
+    document.addEventListener('visibilitychange', flush);
+
+    return () => {
+      window.removeEventListener('pagehide', flushTrail);
+      document.removeEventListener('visibilitychange', flush);
+      flushTrail();
+    };
+  }, [flushTrail]);
 
   const commitPaused = useCallback(
     (next: boolean) => {
@@ -334,8 +415,10 @@ export default function useJourney({
       timestamp: position.timestamp
     };
 
-    const visitedIds = new Set(
-      current.checkins.map((checkin) => checkin.review_id)
+    remainingRef.current = remainingSpots(
+      remainingRef.current,
+      reviewsRef.current,
+      current.checkins
     );
 
     const decision = trackPosition(
@@ -346,7 +429,7 @@ export default function useJourney({
         lastTrailPoint: trailRef.current.at(-1) ?? null
       },
       fix,
-      reviewsRef.current.filter((review) => !visitedIds.has(review.id))
+      remainingRef.current.spots
     );
 
     lastFixRef.current = {
@@ -716,6 +799,9 @@ export default function useJourney({
       onError(error);
       return null;
     }
+
+    // A pending write would put the finished trail straight back.
+    discardTrailSave();
 
     deleteTrail(uid, current.id);
     deletePaused(uid, current.id);

--- a/src/utils/journeyTracking.test.ts
+++ b/src/utils/journeyTracking.test.ts
@@ -3,13 +3,12 @@ import { describe, it } from 'node:test';
 import { assertCloseTo } from '../test/assertions.ts';
 import {
   movingSampleIntervalMs,
-  nearestSpotDistance,
   nextAnchorState,
   nextHighAccuracy,
-  reachedSpots,
   type StationaryAnchor,
   shouldExtendTrail,
   stationarySampleIntervalMs,
+  surveySpots,
   type TrackingFix,
   trackPosition
 } from './journeyTracking.ts';
@@ -182,18 +181,46 @@ describe('shouldExtendTrail', () => {
   });
 });
 
-describe('nearestSpotDistance', () => {
+describe('surveySpots', () => {
   it('is infinite without spots', () => {
-    assert.equal(nearestSpotDistance(pointAt(0), []), Number.POSITIVE_INFINITY);
+    const survey = surveySpots(buildFix(0), []);
+
+    assert.equal(survey.nearestMeters, Number.POSITIVE_INFINITY);
+    assert.deepEqual(survey.reached, []);
   });
 
   it('picks the closest spot', () => {
-    const nearest = nearestSpotDistance(pointAt(0), [
-      pointAt(200),
-      pointAt(100)
-    ]);
+    const survey = surveySpots(buildFix(0), [pointAt(200), pointAt(100)]);
 
-    assertCloseTo(nearest, 100, 0.001);
+    assertCloseTo(survey.nearestMeters, 100, 0.001);
+  });
+
+  it('reaches only spots inside the check-in radius', () => {
+    const near = pointAt(49);
+    const far = pointAt(60);
+
+    assert.deepEqual(surveySpots(buildFix(0), [near, far]).reached, [near]);
+  });
+
+  it('never checks in from a coarse fix', () => {
+    const survey = surveySpots(buildFix(0, { accuracy: 101 }), [pointAt(0)]);
+
+    assert.deepEqual(survey.reached, []);
+  });
+
+  it('still measures the distance a coarse fix may not check in from', () => {
+    const survey = surveySpots(buildFix(0, { accuracy: 101 }), [pointAt(100)]);
+
+    assertCloseTo(survey.nearestMeters, 100, 0.001);
+  });
+
+  it('still checks in at the accuracy limit', () => {
+    const spot = pointAt(10);
+
+    assert.deepEqual(
+      surveySpots(buildFix(0, { accuracy: 100 }), [spot]).reached,
+      [spot]
+    );
   });
 });
 
@@ -286,30 +313,6 @@ describe('movingSampleIntervalMs', () => {
     const fix = buildFix(0, { speed: -1 });
 
     assert.equal(movingSampleIntervalMs(fix, null, 375), 50000);
-  });
-});
-
-describe('reachedSpots', () => {
-  it('reaches only spots inside the check-in radius', () => {
-    const near = pointAt(49);
-    const far = pointAt(60);
-
-    assert.deepEqual(reachedSpots(buildFix(0), [near, far]), [near]);
-  });
-
-  it('never checks in from a coarse fix', () => {
-    assert.deepEqual(
-      reachedSpots(buildFix(0, { accuracy: 101 }), [pointAt(0)]),
-      []
-    );
-  });
-
-  it('still checks in at the accuracy limit', () => {
-    const spot = pointAt(10);
-
-    assert.deepEqual(reachedSpots(buildFix(0, { accuracy: 100 }), [spot]), [
-      spot
-    ]);
   });
 });
 

--- a/src/utils/journeyTracking.ts
+++ b/src/utils/journeyTracking.ts
@@ -122,14 +122,36 @@ export function shouldExtendTrail(
   return distanceInMeters(fix, lastPoint) >= minDistance;
 }
 
-export function nearestSpotDistance(
-  from: TrackedSpot,
-  spots: TrackedSpot[]
-): number {
-  return spots.reduce(
-    (shortest, spot) => Math.min(shortest, distanceInMeters(from, spot)),
-    Number.POSITIVE_INFINITY
-  );
+export type SpotSurvey<S extends TrackedSpot> = {
+  nearestMeters: number;
+  reached: S[];
+};
+
+// The sampling cadence and the check-in decision both need the distance to
+// every remaining spot, and haversine over that list is the heaviest work a
+// continuous watch repeats at roughly 1 Hz. One pass answers both.
+export function surveySpots<S extends TrackedSpot>(
+  fix: TrackingFix,
+  spots: S[]
+): SpotSurvey<S> {
+  const canCheckIn = fix.accuracy <= CHECKIN_MAX_ACCURACY_METERS;
+
+  let nearestMeters = Number.POSITIVE_INFINITY;
+  const reached: S[] = [];
+
+  for (const spot of spots) {
+    const meters = distanceInMeters(fix, spot);
+
+    if (meters < nearestMeters) {
+      nearestMeters = meters;
+    }
+
+    if (canCheckIn && meters <= CHECKIN_RADIUS_METERS) {
+      reached.push(spot);
+    }
+  }
+
+  return { nearestMeters, reached };
 }
 
 export function nextHighAccuracy(
@@ -187,19 +209,6 @@ export function movingSampleIntervalMs(
   );
 }
 
-export function reachedSpots<S extends TrackedSpot>(
-  fix: TrackingFix,
-  spots: S[]
-): S[] {
-  if (fix.accuracy > CHECKIN_MAX_ACCURACY_METERS) {
-    return [];
-  }
-
-  return spots.filter(
-    (spot) => distanceInMeters(fix, spot) <= CHECKIN_RADIUS_METERS
-  );
-}
-
 export type TrackingState = {
   anchor: StationaryAnchor | null;
   stationary: boolean;
@@ -222,7 +231,7 @@ export function trackPosition<S extends TrackedSpot>(
   remainingSpots: S[]
 ): TrackingDecision<S> {
   const { anchor, stationary } = nextAnchorState(state, fix);
-  const nearestMeters = nearestSpotDistance(fix, remainingSpots);
+  const { nearestMeters, reached } = surveySpots(fix, remainingSpots);
 
   const sampleIntervalMs =
     stationary && anchor
@@ -235,6 +244,6 @@ export function trackPosition<S extends TrackedSpot>(
     extendTrail: shouldExtendTrail(state.lastTrailPoint, fix),
     nearestMeters,
     sampleIntervalMs,
-    reached: reachedSpots(fix, remainingSpots)
+    reached
   };
 }


### PR DESCRIPTION
# Summary

Removes three pieces of repeated work from the geolocation callback that runs on every fix during a recording journey.

# Motivation

A continuous watch delivers a fix roughly once a second on the phone of someone walking a map. Everything the callback does lands on the main thread of a device that is already keeping the positioning hardware powered, so work that the fix itself did not invalidate is worth not repeating.

Three places did:

- `trackPosition` asked for the nearest spot distance and the reached list separately, and each walked every remaining spot with its own haversine. Half the trigonometry was a second answer to a question already asked.
- `processPosition` rebuilt the unvisited list from a `Set` of the journey's check-ins and a filter over the map's reviews on every fix, although both inputs change only on a check-in or a router refresh.
- `commitTrail` serialised the entire trail and wrote it to `localStorage` for every appended point, so the cost of a single write grew with the length of the journey. The store exists to survive a reload, and nothing reads it between writes.

# Changes

- `journeyTracking.ts`: `nearestSpotDistance` and `reachedSpots` are replaced by `surveySpots`, which walks the remaining spots once and returns both the nearest distance and the reached list. A coarse fix still contributes to the distance while never checking in.
- `useJourney.ts`: the unvisited list is derived once and kept while the reviews and the check-ins are both the same arrays. Reading `journeyRef.current.checkins` keeps the synchronous view a check-in in flight depends on.
- `useJourney.ts`: trail writes are spaced 15 seconds apart and flushed on `pagehide`, on the page becoming hidden, and on unmount. `end()` cancels a pending write so it cannot put the finished trail back after `deleteTrail`.

# Testing

- `pnpm test`: 108 tests pass. The `nearestSpotDistance` and `reachedSpots` suites become one `surveySpots` suite covering both answers, with a case pinning that a coarse fix still measures the distance it may not check in from.
- `pnpm biome ci ./src`: no errors or warnings
- `pnpm exec tsc --noEmit`: no errors

---
_Generated by [Claude Code](https://claude.ai/code/session_014wCMqUghcBhW41T6T8fuNT)_