### PR TITLE
refactor: search from one debounced lifecycle

### DIFF
--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -1,0 +1,88 @@
+import debounce from 'lodash.debounce';
+import { useEffect, useMemo, useState } from 'react';
+
+const DEBOUNCE_MS = 300;
+
+// One identity for every reset, so clearing an already empty list does not
+// hand the consumer a new array to re-render for.
+const NO_RESULTS: never[] = [];
+
+/**
+ * Runs a search over a debounced input and reports only the answer to the
+ * most recent one. `search` has to keep a stable identity — wrap it in
+ * `useCallback` or `useMemo` — or the debounce restarts on every render.
+ */
+export function useDebouncedSearch<R>(
+  input: string | null | undefined,
+  search: (query: string, signal: AbortSignal) => Promise<R[]>
+) {
+  const [results, setResults] = useState<R[]>(NO_RESULTS);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const run = useMemo(
+    () =>
+      debounce(
+        async (
+          query: string,
+          isCurrent: () => boolean,
+          signal: AbortSignal
+        ) => {
+          try {
+            const next = await search(query, signal);
+
+            if (isCurrent()) {
+              setResults(next);
+            }
+          } catch {
+            if (isCurrent()) {
+              setResults(NO_RESULTS);
+            }
+          } finally {
+            if (isCurrent()) {
+              setIsLoading(false);
+            }
+          }
+        },
+        DEBOUNCE_MS
+      ),
+    [search]
+  );
+
+  useEffect(() => {
+    // A request already in flight can resolve during the debounce wait of the
+    // one replacing it, so what counts as current is settled when the input
+    // changes rather than after the wait.
+    let current = true;
+    const isCurrent = () => current;
+
+    const abandon = () => {
+      current = false;
+      run.cancel();
+    };
+
+    if (!input) {
+      run.cancel();
+
+      setResults(NO_RESULTS);
+      setIsLoading(false);
+
+      return abandon;
+    }
+
+    // The debounce wait is part of the request. Raising this inside the
+    // debounced body instead leaves a window with no results and no loading
+    // flag, which is what an Autocomplete renders "not found" for.
+    setIsLoading(true);
+
+    const controller = new AbortController();
+
+    run(input, isCurrent, controller.signal);
+
+    return () => {
+      abandon();
+      controller.abort();
+    };
+  }, [input, run]);
+
+  return { results, isLoading };
+}

--- a/src/hooks/useMapSearch.ts
+++ b/src/hooks/useMapSearch.ts
@@ -1,55 +1,25 @@
-import debounce from 'lodash.debounce';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import type { AppMap } from '../../types/index.ts';
+import { useDebouncedSearch } from './useDebouncedSearch.ts';
 
 export function useMapSearch(input: string | null | undefined) {
-  const [options, setOptions] = useState<AppMap[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const abortControllerRef = useRef<AbortController | null>(null);
+  const search = useCallback(async (query: string, signal: AbortSignal) => {
+    const res = await fetch(
+      `/api/v1/guest/maps?input=${encodeURIComponent(query)}`,
+      { signal }
+    );
 
-  const fetchMaps = useMemo(
-    () =>
-      debounce(async (query: string) => {
-        abortControllerRef.current?.abort();
-        const controller = new AbortController();
-        abortControllerRef.current = controller;
-
-        setIsLoading(true);
-
-        try {
-          const res = await fetch(
-            `/api/v1/guest/maps?input=${encodeURIComponent(query)}`,
-            { signal: controller.signal }
-          );
-
-          if (res.ok) {
-            const data: AppMap[] = await res.json();
-            setOptions(data);
-          }
-        } catch (error) {
-          if ((error as Error).name === 'AbortError') return;
-          throw error;
-        } finally {
-          if (!controller.signal.aborted) {
-            setIsLoading(false);
-          }
-        }
-      }, 300),
-    []
-  );
-
-  useEffect(() => {
-    if (!input) {
-      setOptions([]);
-      return;
+    if (!res.ok) {
+      return [];
     }
 
-    fetchMaps(input);
-    return () => fetchMaps.cancel();
-  }, [input, fetchMaps]);
+    return (await res.json()) as AppMap[];
+  }, []);
+
+  const { results, isLoading } = useDebouncedSearch(input, search);
 
   return {
-    options,
+    options: results,
     isLoading
   };
 }

--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -1,7 +1,7 @@
-import debounce from 'lodash.debounce';
 import { useParams } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef } from 'react';
 import { toLocale } from '../utils/locales.ts';
+import { useDebouncedSearch } from './useDebouncedSearch.ts';
 import { useGoogleMap } from './useGoogleMap.ts';
 
 export const PLACE_FIELDS = [
@@ -17,61 +17,40 @@ export function usePlaceSearch(input: string) {
   const { lang } = useParams<{ lang: string }>();
   const language = toLocale(lang);
 
-  const [predictions, setPredictions] = useState<
-    google.maps.places.PlacePrediction[]
-  >([]);
-  const [isLoading, setIsLoading] = useState(false);
-
   // The token bills everything from the first keystroke to the place lookup
   // as one session. fetchFields ends that session, so the token is discarded
   // and reissued for the next one.
   const sessionTokenRef =
     useRef<google.maps.places.AutocompleteSessionToken | null>(null);
-  const requestIdRef = useRef(0);
 
-  const fetchSuggestions = useMemo(
-    () =>
-      debounce(async (query: string, requestId: number) => {
-        try {
-          if (!loader) {
-            return;
-          }
+  const search = useCallback(
+    async (query: string) => {
+      if (!loader) {
+        return [];
+      }
 
-          const { AutocompleteSessionToken, AutocompleteSuggestion } =
-            await loader.importLibrary('places');
+      const { AutocompleteSessionToken, AutocompleteSuggestion } =
+        await loader.importLibrary('places');
 
-          if (!sessionTokenRef.current) {
-            sessionTokenRef.current = new AutocompleteSessionToken();
-          }
+      if (!sessionTokenRef.current) {
+        sessionTokenRef.current = new AutocompleteSessionToken();
+      }
 
-          const { suggestions } =
-            await AutocompleteSuggestion.fetchAutocompleteSuggestions({
-              input: query,
-              language,
-              sessionToken: sessionTokenRef.current
-            });
+      const { suggestions } =
+        await AutocompleteSuggestion.fetchAutocompleteSuggestions({
+          input: query,
+          language,
+          sessionToken: sessionTokenRef.current
+        });
 
-          if (requestId !== requestIdRef.current) {
-            return;
-          }
-
-          setPredictions(
-            suggestions
-              .map((suggestion) => suggestion.placePrediction)
-              .filter((prediction) => prediction !== null)
-          );
-        } catch {
-          if (requestId === requestIdRef.current) {
-            setPredictions([]);
-          }
-        } finally {
-          if (requestId === requestIdRef.current) {
-            setIsLoading(false);
-          }
-        }
-      }, 300),
+      return suggestions
+        .map((suggestion) => suggestion.placePrediction)
+        .filter((prediction) => prediction !== null);
+    },
     [loader, language]
   );
+
+  const { results: predictions, isLoading } = useDebouncedSearch(input, search);
 
   const resolvePlace = async (
     prediction: google.maps.places.PlacePrediction
@@ -87,30 +66,6 @@ export function usePlaceSearch(input: string) {
 
     return place;
   };
-
-  useEffect(() => {
-    // A request already in flight can resolve during the debounce wait, so
-    // the id is taken when the input changes rather than after the wait.
-    const requestId = ++requestIdRef.current;
-
-    if (!input) {
-      fetchSuggestions.cancel();
-
-      setPredictions([]);
-      setIsLoading(false);
-
-      return;
-    }
-
-    // The debounce wait counts as part of the request. Raising this inside
-    // the debounced body instead leaves a window with no suggestions and no
-    // loading flag, which is what the Autocomplete renders "not found" for.
-    setIsLoading(true);
-
-    fetchSuggestions(input, requestId);
-
-    return () => fetchSuggestions.cancel();
-  }, [input, fetchSuggestions]);
 
   return {
     predictions,


### PR DESCRIPTION
# Summary

Puts `useMapSearch` and `usePlaceSearch` on a shared `useDebouncedSearch` hook that owns the debounce, the loading flag, and the discarding of superseded answers.

# Motivation

The two hooks were the same skeleton written twice: a `lodash.debounce` wrapper, an `isLoading` flag, an effect that fires on input changes and cancels on the way out. The duplication had already cost something — `usePlaceSearch` learned two lessons that never reached `useMapSearch`:

- A request already in flight can resolve during the debounce wait of the one replacing it. `useMapSearch` aborted the previous fetch at the top of the debounced body, which is 300ms too late, so a stale response could still win.
- The debounce wait is part of the request. Raising `isLoading` inside the debounced body leaves 300ms with no results and no loading flag, which is exactly what an Autocomplete renders "not found" for.

Keeping one lifecycle means the next fix lands in both places.

# Changes

- `useDebouncedSearch.ts`: new hook taking the input and a stable `search(query, signal)`. It settles what counts as the current request when the input changes, raises the loading flag there, and cancels the debounce and aborts the request on input change and on unmount.
- `useMapSearch.ts`: keeps only the guest-maps fetch, now taking the hook's `AbortSignal`. A failed or superseded search clears its options instead of leaving the previous ones on screen.
- `usePlaceSearch.ts`: keeps only the Places call and the session token. The token still outlives the search function, so a lookup closes the session it opened.

# Testing

- `pnpm biome ci ./src`: no errors or warnings, and 5 fewer `useReactCompiler` infos than master
- `pnpm exec tsc --noEmit`: no errors
- `pnpm test`: 107 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_014wCMqUghcBhW41T6T8fuNT)_