### PR TITLE
refactor: build every backend request the same way

### DIFF
--- a/src/app/api/v1/[...path]/route.ts
+++ b/src/app/api/v1/[...path]/route.ts
@@ -1,5 +1,12 @@
-import { cookies } from 'next/headers';
 import { type NextRequest, NextResponse } from 'next/server';
+import {
+  apiUrl,
+  buildApiHeaders,
+  DEFAULT_TIMEOUT_MS,
+  getAuthToken,
+  isTimeoutError,
+  parseAcceptLanguage
+} from '../../../../lib/apiRequest.ts';
 
 type Params = {
   params: Promise<{ path: string[] }>;
@@ -39,39 +46,31 @@ async function proxyRequest(request: NextRequest, { params }: Params) {
     return NextResponse.json({ detail: 'Not found' }, { status: 404 });
   }
 
-  const cookieStore = await cookies();
-  const token = cookieStore.get('__session')?.value;
+  const token = classification === 'auth' ? await getAuthToken() : null;
 
   if (classification === 'auth' && !token) {
     return NextResponse.json({ detail: 'Unauthorized' }, { status: 401 });
   }
 
   const url = new URL(request.url);
-  const apiUrl = `${process.env.API_ENDPOINT}/${joinedPath}${url.search}`;
-
-  const headers: Record<string, string> = {
-    Accept: 'application/json',
-    'Accept-Language':
-      request.headers.get('accept-language')?.split(',')[0] ?? 'en'
-  };
-
-  if (classification === 'auth' && token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
 
   const init: RequestInit = {
     method: request.method,
-    headers,
-    signal: AbortSignal.timeout(30000)
+    headers: buildApiHeaders({
+      token,
+      acceptLanguage: parseAcceptLanguage(
+        request.headers.get('accept-language')
+      )
+    }),
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS)
   };
 
   if (request.method === 'POST') {
-    headers['Content-Type'] = 'application/json';
     init.body = await request.text();
   }
 
   try {
-    const res = await fetch(apiUrl, init);
+    const res = await fetch(apiUrl(`/${joinedPath}${url.search}`), init);
     const body = await res.text();
 
     return new NextResponse(body, {
@@ -83,7 +82,7 @@ async function proxyRequest(request: NextRequest, { params }: Params) {
   } catch (error) {
     console.error(`Proxy error for /${joinedPath}:`, error);
 
-    if (error instanceof DOMException && error.name === 'TimeoutError') {
+    if (isTimeoutError(error)) {
       return NextResponse.json({ detail: 'Upstream timeout' }, { status: 504 });
     }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,12 @@
+import {
+  apiUrl,
+  buildApiHeaders,
+  DEFAULT_TIMEOUT_MS,
+  getAcceptLanguage,
+  getAuthToken,
+  isTimeoutError
+} from './apiRequest.ts';
+
 type ApiFetchOptions = RequestInit & {
   guest?: boolean;
   lang?: string;
@@ -18,26 +27,6 @@ export type ApiResult<T> = {
   status: number;
 };
 
-const DEFAULT_TIMEOUT_MS = 15000;
-
-// Imported lazily: `next` ships no exports map, so a static specifier fails
-// Node's strict ESM resolution when this module runs under the test runner.
-async function getAuthToken(): Promise<string | null> {
-  const { cookies } = await import('next/headers');
-  const cookieStore = await cookies();
-  return cookieStore.get('__session')?.value ?? null;
-}
-
-async function getAcceptLanguage(lang?: string): Promise<string> {
-  if (lang) {
-    return lang;
-  }
-
-  const { headers } = await import('next/headers');
-  const headerStore = await headers();
-  return headerStore.get('accept-language')?.split(',')[0] ?? 'en';
-}
-
 // The transport half of apiFetch: everything below the request-context
 // lookups, so it stays callable outside a Next.js request scope.
 export async function performApiFetch<T>(
@@ -48,30 +37,17 @@ export async function performApiFetch<T>(
 
   const apiPath = token ? path : `/guest${path}`;
 
-  // Headers matches names case-insensitively, so a caller's 'content-type'
-  // replaces the default instead of the two being sent comma-joined as one
-  // value, which is what merging plain objects by spread produced.
-  const requestHeaders = new Headers({
-    Accept: 'application/json',
-    'Accept-Language': acceptLanguage,
-    'Content-Type': 'application/json'
-  });
-
-  if (token) {
-    requestHeaders.set('Authorization', `Bearer ${token}`);
-  }
-
-  new Headers(fetchOptions.headers).forEach((value, name) => {
-    requestHeaders.set(name, value);
-  });
-
   try {
-    const res = await fetch(`${process.env.API_ENDPOINT}${apiPath}`, {
+    const res = await fetch(apiUrl(apiPath), {
       ...fetchOptions,
       signal:
         fetchOptions.signal ??
         AbortSignal.timeout(timeoutMs ?? DEFAULT_TIMEOUT_MS),
-      headers: requestHeaders,
+      headers: buildApiHeaders({
+        token,
+        acceptLanguage,
+        headers: fetchOptions.headers
+      }),
       next
     });
 
@@ -90,12 +66,9 @@ export async function performApiFetch<T>(
   } catch (error) {
     console.error(`API fetch error for ${path}:`, error);
 
-    const timedOut =
-      error instanceof DOMException && error.name === 'TimeoutError';
-
     return {
       data: null,
-      error: timedOut ? 'Request timed out' : 'Network error',
+      error: isTimeoutError(error) ? 'Request timed out' : 'Network error',
       status: 0
     };
   }

--- a/src/lib/apiRequest.test.ts
+++ b/src/lib/apiRequest.test.ts
@@ -17,6 +17,7 @@ describe('parseAcceptLanguage', () => {
 
   it('ignores a language the reader refuses', () => {
     assert.equal(parseAcceptLanguage('ja;q=0,en'), 'en');
+    assert.equal(parseAcceptLanguage('ja;Q=0,en'), 'en');
   });
 
   it('names no locale for a wildcard', () => {

--- a/src/lib/apiRequest.test.ts
+++ b/src/lib/apiRequest.test.ts
@@ -7,8 +7,25 @@ describe('parseAcceptLanguage', () => {
     assert.equal(parseAcceptLanguage('ja,en-US;q=0.9,en;q=0.8'), 'ja');
   });
 
-  it('falls back to English without a header', () => {
+  it('prefers the heaviest language over the first one', () => {
+    assert.equal(parseAcceptLanguage('en;q=0.5,ja'), 'ja');
+  });
+
+  it('leaves the weight off the language it picks', () => {
+    assert.equal(parseAcceptLanguage('en-US;q=0.9'), 'en-US');
+  });
+
+  it('ignores a language the reader refuses', () => {
+    assert.equal(parseAcceptLanguage('ja;q=0,en'), 'en');
+  });
+
+  it('names no locale for a wildcard', () => {
+    assert.equal(parseAcceptLanguage('*'), 'en');
+  });
+
+  it('falls back to English without a usable header', () => {
     assert.equal(parseAcceptLanguage(null), 'en');
+    assert.equal(parseAcceptLanguage(''), 'en');
   });
 });
 

--- a/src/lib/apiRequest.test.ts
+++ b/src/lib/apiRequest.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildApiHeaders, parseAcceptLanguage } from './apiRequest.ts';
+
+describe('parseAcceptLanguage', () => {
+  it('keeps the first language of a weighted list', () => {
+    assert.equal(parseAcceptLanguage('ja,en-US;q=0.9,en;q=0.8'), 'ja');
+  });
+
+  it('falls back to English without a header', () => {
+    assert.equal(parseAcceptLanguage(null), 'en');
+  });
+});
+
+describe('buildApiHeaders', () => {
+  it('omits the authorization header for a guest', () => {
+    const headers = buildApiHeaders({ token: null, acceptLanguage: 'en' });
+
+    assert.equal(headers.has('authorization'), false);
+    assert.equal(headers.get('accept'), 'application/json');
+    assert.equal(headers.get('accept-language'), 'en');
+    assert.equal(headers.get('content-type'), 'application/json');
+  });
+
+  it('carries the bearer token of a signed-in reader', () => {
+    const headers = buildApiHeaders({ token: 'abc', acceptLanguage: 'ja' });
+
+    assert.equal(headers.get('authorization'), 'Bearer abc');
+    assert.equal(headers.get('accept-language'), 'ja');
+  });
+
+  it('lets a caller header replace the default of any casing', () => {
+    const headers = buildApiHeaders({
+      token: null,
+      acceptLanguage: 'en',
+      headers: { 'content-type': 'multipart/form-data' }
+    });
+
+    assert.equal(headers.get('content-type'), 'multipart/form-data');
+  });
+});

--- a/src/lib/apiRequest.ts
+++ b/src/lib/apiRequest.ts
@@ -14,9 +14,41 @@ export async function getAuthToken(): Promise<string | null> {
   return cookieStore.get('__session')?.value ?? null;
 }
 
-// The Rails API takes one locale, not a q-weighted list.
+function quality(params: string[]): number {
+  for (const param of params) {
+    const trimmed = param.trim();
+
+    if (trimmed.startsWith('q=')) {
+      const value = Number.parseFloat(trimmed.slice(2));
+      return Number.isFinite(value) ? value : 1;
+    }
+  }
+
+  return 1;
+}
+
+// The Rails API takes one locale, not a q-weighted list. The header is under
+// no obligation to be ordered by preference, so the first entry is not
+// necessarily the wanted one, and a weight left on the value would reach the
+// backend as part of the locale.
 export function parseAcceptLanguage(header: string | null): string {
-  return header?.split(',')[0] ?? 'en';
+  let best = '';
+  let bestQuality = 0;
+
+  for (const entry of header?.split(',') ?? []) {
+    const [tag, ...params] = entry.trim().split(';');
+    const weight = quality(params);
+
+    // A wildcard names no locale, and a zero weight refuses one.
+    if (!tag || tag === '*' || weight <= 0 || weight <= bestQuality) {
+      continue;
+    }
+
+    best = tag;
+    bestQuality = weight;
+  }
+
+  return best || 'en';
 }
 
 export async function getAcceptLanguage(lang?: string): Promise<string> {

--- a/src/lib/apiRequest.ts
+++ b/src/lib/apiRequest.ts
@@ -1,0 +1,63 @@
+export const DEFAULT_TIMEOUT_MS = 15000;
+
+type ApiHeaderOptions = {
+  token: string | null;
+  acceptLanguage: string;
+  headers?: HeadersInit;
+};
+
+// Imported lazily: `next` ships no exports map, so a static specifier fails
+// Node's strict ESM resolution when this module runs under the test runner.
+export async function getAuthToken(): Promise<string | null> {
+  const { cookies } = await import('next/headers');
+  const cookieStore = await cookies();
+  return cookieStore.get('__session')?.value ?? null;
+}
+
+// The Rails API takes one locale, not a q-weighted list.
+export function parseAcceptLanguage(header: string | null): string {
+  return header?.split(',')[0] ?? 'en';
+}
+
+export async function getAcceptLanguage(lang?: string): Promise<string> {
+  if (lang) {
+    return lang;
+  }
+
+  const { headers } = await import('next/headers');
+  const headerStore = await headers();
+  return parseAcceptLanguage(headerStore.get('accept-language'));
+}
+
+export function buildApiHeaders({
+  token,
+  acceptLanguage,
+  headers
+}: ApiHeaderOptions): Headers {
+  // Headers matches names case-insensitively, so a caller's 'content-type'
+  // replaces the default instead of the two being sent comma-joined as one
+  // value, which is what merging plain objects by spread produced.
+  const requestHeaders = new Headers({
+    Accept: 'application/json',
+    'Accept-Language': acceptLanguage,
+    'Content-Type': 'application/json'
+  });
+
+  if (token) {
+    requestHeaders.set('Authorization', `Bearer ${token}`);
+  }
+
+  new Headers(headers).forEach((value, name) => {
+    requestHeaders.set(name, value);
+  });
+
+  return requestHeaders;
+}
+
+export function apiUrl(path: string): string {
+  return `${process.env.API_ENDPOINT}${path}`;
+}
+
+export function isTimeoutError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'TimeoutError';
+}

--- a/src/lib/apiRequest.ts
+++ b/src/lib/apiRequest.ts
@@ -16,7 +16,9 @@ export async function getAuthToken(): Promise<string | null> {
 
 function quality(params: string[]): number {
   for (const param of params) {
-    const trimmed = param.trim();
+    // A parameter name is case-insensitive, and a 'Q=0' read as no weight at
+    // all would let through a language the reader had refused.
+    const trimmed = param.trim().toLowerCase();
 
     if (trimmed.startsWith('q=')) {
       const value = Number.parseFloat(trimmed.slice(2));


### PR DESCRIPTION
# Summary

Moves the pieces both paths to the Rails API had written separately — the session cookie read, the `Accept-Language` parse, the header assembly, the timeout, the timeout check — into one `lib/apiRequest.ts`, and corrects the locale that parse arrives at.

# Motivation

Two things in this app talk to the backend: `performApiFetch`, used by the server fetchers and the Server Actions, and the `/api/v1/[...path]` route handler that client components reach. They were built independently, and the values had already drifted apart:

- the proxy waited 30 seconds where the server fetchers wait 15
- the proxy sent `Content-Type` only on a POST
- the proxy assembled headers as a plain object, so the case-insensitive matching that `performApiFetch` was fixed for did not apply to it

None of these is visible today, which is the problem: the next change to how this app authenticates or what it sends would land in one of the two and be silently absent from the other.

Consolidating them then made a defect they had both been carrying cheap to fix. `Accept-Language` was read as its first entry, which assumes the header arrives ordered by preference — it is under no obligation to be. A reader sending `en;q=0.5,ja` was served English. Nothing stripped the weight either, so `en-US;q=0.9` reached the backend as the locale itself, and an empty header was forwarded as an empty locale rather than falling back to English.

# Changes

- `lib/apiRequest.ts`: new module holding `getAuthToken`, `getAcceptLanguage`, `parseAcceptLanguage`, `buildApiHeaders`, `apiUrl`, `isTimeoutError`, and `DEFAULT_TIMEOUT_MS`. `next/headers` stays behind a lazy import so the module keeps loading under the test runner.
- `parseAcceptLanguage` picks the heaviest language rather than the first, sends it without its weight, and falls back to English when the header names no locale. A wildcard names none and a `q=0` refuses one, so neither can win.
- `lib/api.ts`: `performApiFetch` builds its headers and URL through the shared module.
- `api/v1/[...path]/route.ts`: same, and its timeout drops from 30s to the shared 15s. The proxy keeps its own failure handling, since it answers with an HTTP status where `performApiFetch` answers with a result object.

# Testing

- `pnpm test`: 116 tests pass, including a new `apiRequest` suite covering the header defaults, a caller override of any casing, and each of the four `Accept-Language` cases above
- `pnpm biome ci ./src`: no errors or warnings
- `pnpm exec tsc --noEmit`: no errors