### PR TITLE
feat: let a reader change the language

### DIFF
--- a/src/components/layouts/LocaleMenuButton.tsx
+++ b/src/components/layouts/LocaleMenuButton.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { Check, Language } from '@mui/icons-material';
+import {
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem
+} from '@mui/material';
+import Link from 'next/link';
+import { memo, useRef, useState } from 'react';
+import useDictionary from '../../hooks/useDictionary.ts';
+import useLocaleLinks from '../../hooks/useLocaleLinks.ts';
+
+type Props = {
+  // The rail shows icons alone, so the label has to live in a tooltip there.
+  variant: 'rail' | 'list';
+  onNavigate?: () => void;
+};
+
+export default memo(function LocaleMenuButton({ variant, onNavigate }: Props) {
+  const dictionary = useDictionary();
+  const links = useLocaleLinks();
+
+  const buttonRef = useRef<HTMLDivElement | null>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleSelect = () => {
+    setAnchorEl(null);
+    onNavigate?.();
+  };
+
+  return (
+    <>
+      <ListItemButton
+        ref={buttonRef}
+        dense={variant === 'list'}
+        onClick={() => setAnchorEl(buttonRef.current)}
+        title={dictionary.language}
+        sx={variant === 'rail' ? { justifyContent: 'center' } : undefined}
+      >
+        {variant === 'rail' ? (
+          <ListItemIcon sx={{ minWidth: 0 }}>
+            <Language sx={{ color: 'primary.contrastText' }} />
+          </ListItemIcon>
+        ) : (
+          <ListItemText
+            primary={dictionary.language}
+            slotProps={{ primary: { color: 'text.secondary' } }}
+          />
+        )}
+      </ListItemButton>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+      >
+        {links.map((link) => (
+          <MenuItem
+            key={link.locale}
+            selected={link.current}
+            component={Link}
+            href={link.href}
+            hrefLang={link.locale}
+            lang={link.locale}
+            onClick={handleSelect}
+          >
+            <ListItemIcon>
+              {link.current && <Check fontSize="small" />}
+            </ListItemIcon>
+            <ListItemText primary={link.label} />
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+});

--- a/src/components/layouts/MiniDrawer.tsx
+++ b/src/components/layouts/MiniDrawer.tsx
@@ -38,6 +38,7 @@ import useDictionary from '../../hooks/useDictionary.ts';
 import useLocalePath from '../../hooks/useLocalePath.ts';
 import NotificationList from '../notifications/NotificationList.tsx';
 import AccountMenuButton from './AccountMenuButton.tsx';
+import LocaleMenuButton from './LocaleMenuButton.tsx';
 import LogoAvatar from './LogoAvatar.tsx';
 
 export default memo(function MiniDrawer() {
@@ -267,6 +268,8 @@ export default memo(function MiniDrawer() {
         </List>
 
         <List component="nav">
+          <LocaleMenuButton variant="rail" />
+
           <AccountMenuButton />
         </List>
       </Drawer>

--- a/src/components/layouts/MobileDrawer.tsx
+++ b/src/components/layouts/MobileDrawer.tsx
@@ -4,7 +4,6 @@ import {
   Bookmarks,
   ChevronLeft,
   DirectionsWalk,
-  ExitToApp,
   Explore,
   Home,
   Mail,
@@ -34,6 +33,7 @@ import ProfileContext from '../../context/ProfileContext.ts';
 import useDictionary from '../../hooks/useDictionary.ts';
 import useLocalePath from '../../hooks/useLocalePath.ts';
 import ProfileAvatar from '../common/ProfileAvatar.tsx';
+import LocaleMenuButton from './LocaleMenuButton.tsx';
 import Logo from './Logo.tsx';
 
 type Props = {
@@ -236,9 +236,6 @@ export default memo(function MobileDrawer({
             href={localePath('/login')}
             title={dictionary.login}
           >
-            <ListItemIcon>
-              <ExitToApp />
-            </ListItemIcon>
             <ListItemText
               primary={dictionary.login}
               slotProps={{
@@ -247,6 +244,7 @@ export default memo(function MobileDrawer({
             />
           </ListItemButton>
         )}
+        <LocaleMenuButton variant="list" onNavigate={onClose} />
         <ListItemButton
           dense
           onClick={onClose}

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -380,5 +380,8 @@
   "record as chapter": "Write a chapter",
   "not recorded as chapter": "This journey hasn't been written up as a chapter yet.",
   "checkins count": "{count} check-ins",
-  "no checkins": "No check-ins."
+  "no checkins": "No check-ins.",
+  "language": "Language",
+  "en language": "English",
+  "ja language": "日本語"
 }

--- a/src/dictionaries/ja.json
+++ b/src/dictionaries/ja.json
@@ -380,5 +380,8 @@
   "record as chapter": "チャプターを執筆",
   "not recorded as chapter": "この旅のチャプターはまだ執筆されていません。",
   "checkins count": "{count} 件のチェックイン",
-  "no checkins": "チェックインがありません。"
+  "no checkins": "チェックインがありません。",
+  "language": "言語",
+  "en language": "English",
+  "ja language": "日本語"
 }

--- a/src/hooks/useLocaleLinks.ts
+++ b/src/hooks/useLocaleLinks.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import {
+  isLocale,
+  LOCALES,
+  type Locale,
+  localePath
+} from '../utils/locales.ts';
+import useDictionary from './useDictionary.ts';
+
+export type LocaleLink = {
+  locale: Locale;
+  label: string;
+  href: string;
+  current: boolean;
+};
+
+/**
+ * Every locale this page exists under, the reader's own included, so the
+ * choice can be shown rather than merely offered. The query string is left
+ * behind: reading it would force a Suspense boundary around whichever layout
+ * renders the switch, and a locale change is a fresh look at the page rather
+ * than a continuation of a selection made within it.
+ */
+export default function useLocaleLinks(): LocaleLink[] {
+  const pathname = usePathname();
+  const dictionary = useDictionary();
+
+  const segments = pathname.split('/').filter(Boolean);
+  const current = isLocale(segments[0]) ? segments[0] : null;
+  const rest = current ? segments.slice(1) : segments;
+  const path = rest.length > 0 ? `/${rest.join('/')}` : '';
+
+  return LOCALES.map((locale) => ({
+    locale,
+    // Both dictionaries answer with the language's own name, so a reader
+    // finds their language written in a way they can read whichever one
+    // they are stuck in. Translating either would defeat the switch.
+    label: dictionary[`${locale} language`],
+    href: localePath(locale, path),
+    current: locale === current
+  }));
+}


### PR DESCRIPTION
# Summary

Adds a language switch to both drawers: a row that opens a menu of every locale, the reader's own ticked.

# Motivation

A visitor lands in whichever language `middleware.ts` reads out of their `Accept-Language` header, and nothing in the interface leads out of that guess. Neither the drawers nor the footer link one locale to the other, so the two languages are reachable only by editing the address bar. A Japanese browser opening an English map, or a reader who simply prefers the other language, is stuck.

# Changes

- `hooks/useLocaleLinks.ts`: derives the same path under every locale from `usePathname()`, marking which one the reader is on. It strips the leading segment only when that segment is actually a locale, so a path that somehow arrives without one keeps its page. Each label is looked up under a dictionary key named after the locale — `` dictionary[`${locale} language`] `` — the shape `ReviewMarker.tsx` already uses for its milestone labels, which leaves no second per-locale list to keep in step.
- `components/layouts/LocaleMenuButton.tsx`: a row that opens a menu listing the locales, the current one ticked and highlighted. Each entry is a `next/link`, so the change is a client navigation, and carries `lang`/`hrefLang`.
- `MobileDrawer`: the row joins the meta list beside terms and privacy, labelled with the dictionary's word for language. `MiniDrawer`: the same control as an icon in the rail, where every entry is an icon.
- Both dictionaries name each language in that language — `en.json` answers `日本語`, not `Japanese` — so a reader stranded in a language they cannot read still recognises their own. The dictionaries are where this codebase keeps user-facing text even when the value is identical in both files; `ok`, `google` and `km` already are.
- The sign-in link loses its icon. It was the only entry in the meta list carrying one, so the group read differently signed in and signed out. Icons throughout is not the way out, since terms of service and privacy policy have none that would mean anything. This is a pre-existing inconsistency in the list this PR edits, changed openly rather than left to make the new row look wrong.

**Why a menu rather than a direct link.** One row per other locale would switch the language the moment it is touched, asking the reader to act before being told what the options are or which one they are already in. The menu shows the choice rather than only offering it, and names each locale in its own language for the same reason.

**Why the drawers rather than the settings page.** Settings is the natural home for a preference, but `(contained)/settings` is entirely account-bound — email, providers, push, account deletion — and the drawer only links to it when signed in. A language kept there would be hidden from exactly the readers the `Accept-Language` guess strands. Adding it to settings as well, for signed-in readers, would be a reasonable follow-up.

# Deliberate omissions

**The query string is left behind.** Reading `useSearchParams()` here would force a Suspense boundary around whichever layout renders the switch, and a language change reads as a fresh look at the page rather than a continuation of a selection made inside it. On the map detail page that means a selected review is deselected.

**The choice is not remembered.** The URL carries the locale, so the page the reader switched to stays in that language, but a later visit to a locale-less link is routed by `Accept-Language` again. Remembering it needs a cookie read in `middleware.ts`, which touches routing and caching for every request — worth doing deliberately rather than as a side effect of this.

# Testing

- `pnpm build`: succeeds
- `pnpm biome ci ./src`: no errors or warnings, and the `useReactCompiler` info count is unchanged
- `pnpm exec tsc --noEmit`: no errors
- `pnpm test`: passes

Not yet looked at in a browser. The environment this was written in cannot reach one, so the menu's appearance is unverified until the dev deployment is opened by hand.

# Follow-up this unlocks

#1133 notes that the client navigation between `/ja` and `/en` which #1124 fixed could not be reached from inside the app, so no smoke test was written for it. This makes that path real. Once both land, the test is worth adding.