### PR TITLE
fix: serve the terms of service from the server

### DIFF
--- a/src/components/common/MarkdownContent.tsx
+++ b/src/components/common/MarkdownContent.tsx
@@ -1,3 +1,10 @@
+'use client';
+
+// react-markdown takes its renderers as props, and a component is a function.
+// Building this map on the server would mean handing functions across the
+// boundary, which fails the render rather than degrading it: the document goes
+// missing from the server's HTML and only the client puts it back.
+
 import { Link, Typography } from '@mui/material';
 import NextLink from 'next/link';
 import Markdown, { type Components } from 'react-markdown';


### PR DESCRIPTION
# Summary

`MarkdownContent` becomes a client component, so the legal documents appear in the HTML the server sends rather than only after the browser has run.

# Motivation

`qoodish.com/ja/terms` answers 200 and looks right, and the terms are not in it. The body is put back on the client, so a reader sees the page and a crawler sees a page with no terms on it. Every visit also logs an uncaught `Minified React error #419` — the server could not finish a Suspense boundary and fell back to client rendering.

The cause is a server/client boundary. `react-markdown` takes its renderers as props and a renderer is a function, so building that map in a server component hands functions across the boundary:

```
⨯ Error: Functions cannot be passed directly to Client Components unless you
   explicitly expose it by marking it with "use server".
  <... component={function LinkComponent} href=... children=...>
                 ^^^^^^^^^^^^^^^^^^^^^^^^
```

Only one branch of the renderer map reaches for `next/link`, the one for links to another page on this site, and only one of the four documents contains such a link:

```
src/content/legal/terms.ja.md:102: … [プライバシーポリシー](/privacy) に従って …
src/content/legal/terms.en.md:102: … [Privacy Policy](/privacy).
```

That is the whole reason the privacy policy renders correctly and the terms of service does not, from otherwise identical pages.

# Changes

- `components/common/MarkdownContent.tsx`: marked `'use client'`. The document arrives as a string, which crosses the boundary happily; the renderer map is now built on the side that uses it. `react-markdown` was already a client component, so nothing new reaches the browser.

# Testing

Reproduced and verified against a real Cloudflare Worker build, since this only appears once the render is server-side:

| | before | after |
| --- | --- | --- |
| `/ja/terms` | 135 KB, no body, SSR error digest present | 183 KB, body present, no digest |
| `/en/terms` | 132 KB, no body, SSR error digest present | 179 KB, body present, no digest |
| `/ja/privacy` | correct | correct |

The same failure was confirmed on production before the change: `qoodish.com/ja/terms` carries an SSR error digest and one occurrence of its first article heading, where `/ja/privacy` carries three and no digest.

`next dev` was used to read the unminified error quoted above, and reports none after the change.

Also run: `pnpm exec tsc --noEmit`, `pnpm biome ci ./src`, `pnpm test` (117 tests) — all clean.

# How it was found

The Playwright smoke suite in #1133, on its first run that actually reached the code under review. Nothing else in the pipeline had opened the page: the route answers 200, the shell renders, and the unit tests never mount a component.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wCMqUghcBhW41T6T8fuNT)_