### PR TITLE
feat: make place autocomplete location aware

### DIFF
--- a/src/components/maps/CurrentPositionButton.tsx
+++ b/src/components/maps/CurrentPositionButton.tsx
@@ -1,10 +1,12 @@
-import { MyLocation } from '@mui/icons-material';
-import { Box, CircularProgress, Fab } from '@mui/material';
+import { LocationSearching, MyLocation } from '@mui/icons-material';
+import { CircularProgress, IconButton } from '@mui/material';
 import { memo, useState } from 'react';
+import useDictionary from '../../hooks/useDictionary.ts';
 import { useGoogleMap } from '../../hooks/useGoogleMap.ts';
 
 function CurrentPositionButton() {
-  const { googleMap, setCurrentPosition } = useGoogleMap();
+  const { googleMap, currentPosition, setCurrentPosition } = useGoogleMap();
+  const dictionary = useDictionary();
 
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -43,28 +45,32 @@ function CurrentPositionButton() {
   };
 
   return (
-    <Box position="relative">
-      <Fab
-        onClick={handleClick}
-        sx={{
-          bgcolor: 'background.paper'
-        }}
-      >
-        <MyLocation fontSize="small" />
-      </Fab>
-      {loading && (
-        <CircularProgress
-          size={68}
-          sx={{
-            color: 'info.main',
-            position: 'absolute',
-            top: -6,
-            left: -6,
-            zIndex: 1
-          }}
-        />
+    <IconButton
+      onClick={handleClick}
+      aria-label={dictionary['current position']}
+      // Fixed colors rather than theme tokens: the button sits among the
+      // Maps API's own controls, which keep their palette in every theme.
+      sx={{
+        width: 40,
+        height: 40,
+        borderRadius: '50%',
+        bgcolor: '#fff',
+        color: '#666',
+        boxShadow: '0 1px 4px -1px rgba(0,0,0,0.3)',
+        '&:hover': {
+          bgcolor: '#fff',
+          color: '#333'
+        }
+      }}
+    >
+      {loading ? (
+        <CircularProgress size={20} color="inherit" />
+      ) : currentPosition ? (
+        <MyLocation fontSize="small" sx={{ color: '#1A73E8' }} />
+      ) : (
+        <LocationSearching fontSize="small" />
       )}
-    </Box>
+    </IconButton>
   );
 }
 

--- a/src/components/maps/CustomMapControls.tsx
+++ b/src/components/maps/CustomMapControls.tsx
@@ -89,7 +89,8 @@ function CustomMapControls({ onPlaceChange }: Props) {
       </MapControl>
 
       <MapControl controlPosition={buttonPosition}>
-        <Stack spacing={2} sx={{ p: 2 }}>
+        {/* The Maps API gives its own controls a 10px margin. */}
+        <Stack spacing={2} sx={{ p: '10px' }}>
           <CurrentPositionButton />
         </Stack>
       </MapControl>

--- a/src/components/maps/GoogleMaps.tsx
+++ b/src/components/maps/GoogleMaps.tsx
@@ -91,6 +91,50 @@ function GoogleMaps({ mapId, children, sx, mapOptions, center, zoom }: Props) {
   }, [googleMap, loader, initGoogleMaps]);
 
   useEffect(() => {
+    if (!('geolocation' in navigator) || !('permissions' in navigator)) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const restoreCurrentPosition = async () => {
+      let status: PermissionStatus;
+
+      try {
+        status = await navigator.permissions.query({ name: 'geolocation' });
+      } catch {
+        // Safari below 16 rejects the geolocation query; without a readable
+        // permission state, getCurrentPosition could raise the browser prompt.
+        return;
+      }
+
+      if (cancelled || status.state !== 'granted') {
+        return;
+      }
+
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          if (!cancelled) {
+            setCurrentPosition(position);
+          }
+        },
+        () => {},
+        {
+          enableHighAccuracy: false,
+          maximumAge: 30000,
+          timeout: 10000
+        }
+      );
+    };
+
+    restoreCurrentPosition();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     if (googleMap && center) {
       googleMap.panTo(center);
     }

--- a/src/components/maps/PlaceAutocomplete.tsx
+++ b/src/components/maps/PlaceAutocomplete.tsx
@@ -6,8 +6,11 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  TextField
+  Stack,
+  TextField,
+  Typography
 } from '@mui/material';
+import { useParams } from 'next/navigation';
 import { enqueueSnackbar } from 'notistack';
 import {
   type MutableRefObject,
@@ -18,6 +21,8 @@ import {
 } from 'react';
 import useDictionary from '../../hooks/useDictionary.ts';
 import { usePlaceSearch } from '../../hooks/usePlaceSearch.ts';
+import { formatDistanceMeters } from '../../utils/geo.ts';
+import { toLocale } from '../../utils/locales.ts';
 
 type Props = {
   ref: MutableRefObject<HTMLInputElement>;
@@ -28,6 +33,9 @@ type Props = {
 
 function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
   const dictionary = useDictionary();
+
+  const { lang } = useParams<{ lang: string }>();
+  const locale = toLocale(lang);
 
   const [value, setValue] = useState<google.maps.places.PlacePrediction | null>(
     null
@@ -123,13 +131,24 @@ function PlaceAutocomplete({ ref, onChange, label, autoFocus = true }: Props) {
         option.placeId === selected.placeId
       }
       renderOption={({ key, ...optionProps }, option) => (
-        <ListItem key={key} {...optionProps}>
+        <ListItem key={key} divider {...optionProps}>
           <ListItemIcon>
-            <LocationOn />
+            <Stack alignItems="center" spacing={0.5}>
+              <LocationOn />
+              {option.distanceMeters !== null && (
+                <Typography variant="caption" color="text.secondary">
+                  {formatDistanceMeters(option.distanceMeters, locale)}
+                </Typography>
+              )}
+            </Stack>
           </ListItemIcon>
           <ListItemText
             primary={option.mainText?.text ?? option.text.text}
             secondary={option.secondaryText?.text}
+            slotProps={{
+              primary: { noWrap: true },
+              secondary: { noWrap: true }
+            }}
           />
         </ListItem>
       )}

--- a/src/hooks/usePlaceSearch.ts
+++ b/src/hooks/usePlaceSearch.ts
@@ -13,7 +13,7 @@ export const PLACE_FIELDS = [
 ];
 
 export function usePlaceSearch(input: string) {
-  const { loader } = useGoogleMap();
+  const { loader, googleMap, currentPosition } = useGoogleMap();
   const { lang } = useParams<{ lang: string }>();
   const language = toLocale(lang);
 
@@ -40,14 +40,23 @@ export function usePlaceSearch(input: string) {
         await AutocompleteSuggestion.fetchAutocompleteSuggestions({
           input: query,
           language,
-          sessionToken: sessionTokenRef.current
+          sessionToken: sessionTokenRef.current,
+          locationBias: googleMap?.getBounds(),
+          // origin only yields distanceMeters on each prediction; it does
+          // not affect ranking.
+          origin: currentPosition
+            ? {
+                lat: currentPosition.coords.latitude,
+                lng: currentPosition.coords.longitude
+              }
+            : undefined
         });
 
       return suggestions
         .map((suggestion) => suggestion.placePrediction)
         .filter((prediction) => prediction !== null);
     },
-    [loader, language]
+    [loader, language, googleMap, currentPosition]
   );
 
   const { results: predictions, isLoading } = useDebouncedSearch(input, search);

--- a/src/utils/geo.test.ts
+++ b/src/utils/geo.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { assertCloseTo } from '../test/assertions.ts';
-import { distanceInMeters, trailDistanceMeters } from './geo.ts';
+import {
+  distanceInMeters,
+  formatDistanceMeters,
+  trailDistanceMeters
+} from './geo.ts';
 
 const EQUATOR_ONE_DEGREE_METERS = 111194.93;
 
@@ -48,6 +52,24 @@ describe('distanceInMeters', () => {
     const b = { latitude: -0.0000001, longitude: 179.9999999 };
 
     assert.ok(Number.isFinite(distanceInMeters(a, b)));
+  });
+});
+
+describe('formatDistanceMeters', () => {
+  it('formats sub-kilometer distances as whole meters', () => {
+    assert.equal(formatDistanceMeters(350.4, 'en'), '350 m');
+  });
+
+  it('formats kilometer distances with one decimal', () => {
+    assert.equal(formatDistanceMeters(1234, 'ja'), '1.2 km');
+  });
+
+  it('switches to kilometers when meters round up to a thousand', () => {
+    assert.equal(formatDistanceMeters(999.6, 'en'), '1 km');
+  });
+
+  it('keeps zero in meters', () => {
+    assert.equal(formatDistanceMeters(0, 'en'), '0 m');
   });
 });
 

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -15,6 +15,22 @@ export function trailDistanceMeters(points: LatLng[]): number {
   return meters;
 }
 
+export function formatDistanceMeters(meters: number, locale: string): string {
+  if (Math.round(meters) < 1000) {
+    return new Intl.NumberFormat(locale, {
+      style: 'unit',
+      unit: 'meter',
+      maximumFractionDigits: 0
+    }).format(meters);
+  }
+
+  return new Intl.NumberFormat(locale, {
+    style: 'unit',
+    unit: 'kilometer',
+    maximumFractionDigits: 1
+  }).format(meters / 1000);
+}
+
 export function distanceInMeters(a: LatLng, b: LatLng): number {
   const toRad = (deg: number) => (deg * Math.PI) / 180;
 


### PR DESCRIPTION
# Summary

Place autocomplete suggestions are now biased by the visible map viewport, and each suggestion shows its distance from the visitor's position under the pin icon, the way the Google Maps app lays its suggestions out. No permission dialog is ever raised for this: the position is only used when the browser already reports an existing geolocation grant. The current-position button is also restyled to match the Maps API's built-in controls.

# Motivation

The autocomplete request carried no location signal, so the API fell back to weak IP-based biasing and surfacing the intended place required typing an area name into the query (e.g. "cafe + city name"). Requiring a geolocation grant before creating a pin was not acceptable either, so the ranking signal had to work without one.

# Changes

- Pass the map's visible viewport (`googleMap.getBounds()`) as `locationBias` to `fetchAutocompleteSuggestions`, so suggestions favor the area the visitor is looking at without any geolocation grant
- Restore the current position silently on map load (with a finite 10 s timeout), but only when the Permissions API reports the geolocation permission as already `granted`; `prompt`/`denied`, unsupported browsers (Safari < 16), and lookup failures fall back to the previous behavior, and the map never pans automatically
- Pass the current position as the request `origin` when available and render the resulting `distanceMeters` under the pin icon of each suggestion
- Add `formatDistanceMeters` to `src/utils/geo.ts` (locale-aware via `Intl.NumberFormat`: whole meters below 1 km, one decimal in kilometers above)
- Restyle `CurrentPositionButton` from an MUI Fab to the Maps API control look (40px white circle, flat shadow, 10px edge margin); the glyph follows the Google Maps app's states — gray crosshair while no position is known, filled icon in Google blue once it is

# Testing

- `pnpm biome ci ./src`: exit 0, no diagnostics on the changed files
- `pnpm exec tsc --noEmit`: clean
- `pnpm test`: 121 tests pass, including new unit tests for `formatDistanceMeters`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MH7sVBXFGQ7D2Qcwy3DJF1

---
_Generated by [Claude Code](https://claude.ai/code/session_01MH7sVBXFGQ7D2Qcwy3DJF1)_