### PR TITLE
feat: export worker telemetry via OTLP

### DIFF
--- a/.github/workflows/post-deploy.yaml
+++ b/.github/workflows/post-deploy.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Wait for the deployment of this commit
         run: |
           for i in $(seq 1 80); do
-            deployed=$(curl -sf --max-time 10 "$BASE_URL/api/health" | jq -r '.sha // empty' || true)
+            deployed=$(curl -s --max-time 10 "$BASE_URL/api/health" | jq -r '.sha // empty' || true)
             if [ "$deployed" = "${{ github.sha }}" ]; then
               echo "Deployed SHA matches ${{ github.sha }}"
               exit 0

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ https://qoodish.com
 ## Installation
 
 ```bash
-$ pnpm install
+pnpm install
 ```
 
 ## Decrypt secrets
 
 ```bash
-$ gcloud secrets versions access latest --secret=QOODISH_WEB_DOTENV --project=$PROJECT_ID --out-file=.env.local
+gcloud secrets versions access latest --secret=QOODISH_WEB_DOTENV --project=$PROJECT_ID --out-file=.env.local
 ```
 
 ## Running app
 
 ```bash
-$ pnpm dev
+pnpm dev
 ```

--- a/src/app/[lang]/Providers.tsx
+++ b/src/app/[lang]/Providers.tsx
@@ -22,6 +22,7 @@ import {
 } from 'react';
 import type { Notification, Profile } from '../../../types/index.ts';
 import AuthProvider from '../../components/auth/AuthProvider.tsx';
+import ClientErrorReporter from '../../components/common/ClientErrorReporter.tsx';
 import SplashScreen from '../../components/common/SplashScreen.tsx';
 import ServiceWorkerContext from '../../context/ServiceWorkerContext.ts';
 import useDictionary from '../../hooks/useDictionary.ts';
@@ -182,6 +183,7 @@ export default function Providers({
             </Button>
           )}
         >
+          <ClientErrorReporter />
           <AuthProvider
             serverAuthenticated={serverAuthenticated}
             serverUid={serverUid ?? null}

--- a/src/app/[lang]/error.tsx
+++ b/src/app/[lang]/error.tsx
@@ -4,6 +4,7 @@ import { Refresh } from '@mui/icons-material';
 import { Alert, AlertTitle, Button, Container, Grid } from '@mui/material';
 import { useEffect } from 'react';
 import useDictionary from '../../hooks/useDictionary.ts';
+import reportClientError from '../../utils/reportClientError.ts';
 
 type Props = {
   error: Error & { digest?: string };
@@ -14,7 +15,7 @@ export default function ErrorPage({ error, reset }: Props) {
   const dictionary = useDictionary();
 
   useEffect(() => {
-    console.error(error);
+    reportClientError(error, 'error-boundary');
   }, [error]);
 
   return (

--- a/src/app/api/errors/route.ts
+++ b/src/app/api/errors/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+
+const MAX_BODY_BYTES = 8 * 1024;
+
+type ClientErrorReport = {
+  message: string;
+  stack?: string;
+  digest?: string;
+  url?: string;
+  source?: string;
+};
+
+// request.text() would buffer the whole body before any check could run, so
+// the stream is counted chunk by chunk and dropped once it passes the limit.
+async function readBodyWithinLimit(request: Request): Promise<string | null> {
+  if (Number(request.headers.get('content-length')) > MAX_BODY_BYTES) {
+    return null;
+  }
+
+  const reader = request.body?.getReader();
+
+  if (!reader) {
+    return '';
+  }
+
+  const decoder = new TextDecoder();
+  let received = 0;
+  let text = '';
+
+  for (;;) {
+    const { done, value } = await reader.read();
+
+    if (done) {
+      break;
+    }
+
+    received += value.byteLength;
+
+    if (received > MAX_BODY_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+
+    text += decoder.decode(value, { stream: true });
+  }
+
+  return text + decoder.decode();
+}
+
+export async function POST(request: Request) {
+  const origin = request.headers.get('origin');
+
+  // The Origin check only stops cross-site browsers; a scripted caller is
+  // bounded by the WAF rate limiting rule on this path.
+  if (origin && origin !== new URL(request.url).origin) {
+    return new NextResponse(null, { status: 403 });
+  }
+
+  const body = await readBodyWithinLimit(request);
+
+  if (body === null) {
+    return new NextResponse(null, { status: 413 });
+  }
+
+  let report: ClientErrorReport;
+
+  try {
+    report = JSON.parse(body);
+  } catch {
+    return new NextResponse(null, { status: 400 });
+  }
+
+  if (typeof report?.message !== 'string') {
+    return new NextResponse(null, { status: 400 });
+  }
+
+  // Same shape as the server-side error line, so one query covers both.
+  console.error(
+    JSON.stringify({
+      kind: 'client-error',
+      message: report.message,
+      stack_trace: report.stack,
+      digest: report.digest,
+      url: report.url,
+      source: report.source,
+      userAgent: request.headers.get('user-agent')
+    })
+  );
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -5,14 +5,36 @@ import { NextResponse } from 'next/server';
 // the post-deploy workflow could never see the new commit arrive.
 export const dynamic = 'force-dynamic';
 
-export function GET() {
+async function checkApi(): Promise<'ok' | 'failed'> {
+  try {
+    const res = await fetch(`${process.env.API_ENDPOINT}/healthcheck`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(5000)
+    });
+
+    return res.ok ? 'ok' : 'failed';
+  } catch {
+    return 'failed';
+  }
+}
+
+// The status code carries the verdict so any external monitor can judge the
+// endpoint without parsing the body, while the body keeps the SHA the
+// post-deploy workflow reads even during an API outage.
+export async function GET() {
+  const api = await checkApi();
+
   return NextResponse.json(
     {
-      status: 'ok',
+      status: api === 'ok' ? 'ok' : 'degraded',
+      checks: { api },
       sha: process.env.DEPLOYED_COMMIT_SHA ?? 'unknown',
       appEnv: process.env.APP_ENV ?? 'unknown',
       time: new Date().toISOString()
     },
-    { headers: { 'cache-control': 'no-store' } }
+    {
+      status: api === 'ok' ? 200 : 503,
+      headers: { 'cache-control': 'no-store' }
+    }
   );
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useSyncExternalStore } from 'react';
+import reportClientError from '../utils/reportClientError.ts';
 
 type Props = {
   error: Error & { digest?: string };
@@ -32,7 +33,7 @@ const messages = {
 // self-contained: no theme provider, no dictionary hook, inline styles only.
 export default function GlobalError({ error, reset }: Props) {
   useEffect(() => {
-    console.error(error);
+    reportClientError(error, 'global-error');
   }, [error]);
 
   const lang = useSyncExternalStore(subscribe, getBrowserLang, getServerLang);

--- a/src/components/common/ClientErrorReporter.tsx
+++ b/src/components/common/ClientErrorReporter.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+import reportClientError from '../../utils/reportClientError.ts';
+
+export default function ClientErrorReporter() {
+  useEffect(() => {
+    const onError = (event: ErrorEvent) => {
+      reportClientError(event.error ?? event.message, 'window');
+    };
+    const onRejection = (event: PromiseRejectionEvent) => {
+      reportClientError(event.reason, 'unhandledrejection');
+    };
+
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onRejection);
+
+    return () => {
+      window.removeEventListener('error', onError);
+      window.removeEventListener('unhandledrejection', onRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,32 @@
+import type { Instrumentation } from 'next';
+
+// The telemetry export only sees console output, so the error is serialized
+// as one JSON line the log backend can index by field.
+export const onRequestError: Instrumentation.onRequestError = (
+  error,
+  request,
+  context
+) => {
+  const detail =
+    error instanceof Error
+      ? { name: error.name, message: error.message, stack_trace: error.stack }
+      : { message: String(error) };
+  const digest =
+    typeof error === 'object' && error !== null && 'digest' in error
+      ? String(error.digest)
+      : undefined;
+
+  console.error(
+    JSON.stringify({
+      kind: 'request-error',
+      ...detail,
+      digest,
+      // The query can carry credentials such as the email sign-in code.
+      path: request.path.split('?', 1)[0],
+      method: request.method,
+      routePath: context.routePath,
+      routeType: context.routeType,
+      renderSource: context.renderSource
+    })
+  );
+};

--- a/src/utils/reportClientError.ts
+++ b/src/utils/reportClientError.ts
@@ -1,0 +1,45 @@
+const MAX_REPORTS_PER_PAGE = 5;
+const MAX_STACK_LENGTH = 4000;
+
+// Browsers fire this for layout loops that resolve on the next frame; it is
+// not actionable and would crowd out real errors.
+const IGNORED_MESSAGE = /ResizeObserver loop/;
+
+let reported = 0;
+
+export default function reportClientError(
+  error: unknown,
+  source: string
+): void {
+  console.error(error);
+
+  const detail =
+    error instanceof Error
+      ? {
+          message: error.message,
+          stack: error.stack?.slice(0, MAX_STACK_LENGTH),
+          digest: (error as { digest?: string }).digest
+        }
+      : { message: String(error) };
+
+  if (
+    reported >= MAX_REPORTS_PER_PAGE ||
+    IGNORED_MESSAGE.test(detail.message)
+  ) {
+    return;
+  }
+
+  reported += 1;
+
+  fetch('/api/errors', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    keepalive: true,
+    // The query can carry credentials such as the email sign-in code.
+    body: JSON.stringify({
+      ...detail,
+      source,
+      url: location.origin + location.pathname
+    })
+  }).catch(() => {});
+}

--- a/synthetics/README.md
+++ b/synthetics/README.md
@@ -1,0 +1,13 @@
+# qoodish-web-synthetics
+
+A Cloudflare Worker that checks production every 30 minutes with a real browser through Browser Rendering. Each run verifies `/api/health`, the top page, and a public map detail page on the `TARGET_ORIGIN` configured in `wrangler.jsonc`, and fails the scheduled invocation when any check does.
+
+A failed run surfaces as an exception in the worker's logs, which the telemetry export sends to the destinations named in `wrangler.jsonc`. Alerting on it lives there, alongside an alert for the absence of successful runs.
+
+## Deploy
+
+Workers Builds deploys the worker from `master`, so a merge is the release. To deploy the checked-out revision from a machine that is logged in to Cloudflare:
+
+```bash
+pnpm cf:deploy
+```

--- a/synthetics/wrangler.jsonc
+++ b/synthetics/wrangler.jsonc
@@ -7,7 +7,15 @@
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": false,
   "observability": {
-    "enabled": true
+    "enabled": true,
+    "traces": {
+      "enabled": true,
+      "destinations": ["grafana-traces"]
+    },
+    "logs": {
+      "enabled": true,
+      "destinations": ["grafana-logs"]
+    }
   },
   "browser": {
     "binding": "BROWSER"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,8 +18,18 @@
       "service": "prod-qoodish-web"
     }
   ],
+  // The destinations are registered in the dashboard under these names; the
+  // worker name tells the environments apart on the receiving side.
   "observability": {
-    "enabled": true
+    "enabled": true,
+    "traces": {
+      "enabled": true,
+      "destinations": ["grafana-traces"]
+    },
+    "logs": {
+      "enabled": true,
+      "destinations": ["grafana-logs"]
+    }
   },
   "r2_buckets": [
     {


### PR DESCRIPTION
# Summary

Closes the "nobody gets paged" gap with configuration rather than code: server and client errors are logged as structured JSON lines, every worker exports its traces and logs through Cloudflare's built-in OpenTelemetry export to destinations registered in the dashboard (Grafana Cloud), where the alert rules live, and `/api/health` now probes the API and answers 503 when it is unreachable instead of a hardcoded "ok".

# Motivation

The launch-readiness audit found that production errors were invisible: `console.error` on the client stayed in the user's browser, server errors carried no route context, the synthetic checks only turned a cron run red in the dashboard, and the health endpoint returned 200/"ok" even with the backend down. Cloudflare stores logs and traces but has no alerting for Workers, so evaluation and notification have to happen in a backend that receives the export. Earlier revisions of this PR built that path by hand (a Tail Worker posting to a webhook) and then as an OpenTelemetry Collector in a Cloudflare Container forwarding to Google Cloud; both carried more moving parts than the problem warrants. Cloudflare's export to one of its supported destinations is configuration only, and Grafana Cloud's free tier covers alert rules with Slack delivery, including an alert on missing data for the synthetics cron. The API keeps its existing Google Cloud telemetry for now; joining the two on one trace is a later, config-only change on the API's collector sidecar, not something this PR needs.

# Changes

- `src/instrumentation.ts`: `onRequestError` writes one JSON line per server failure with `message`, `stack_trace`, digest, path, method, route path, route type, and render source. The path is recorded without its query string, because the email-link sign-in carries its `oobCode` there.
- `POST /api/errors`: same-origin check and an 8 KiB cap enforced on the request stream (Content-Length rejected up front, bytes counted per chunk, reader cancelled with 413), then the report is logged in the same shape as the server-side line so one query covers both. The route is public, so a WAF rate limiting rule on the path is what bounds scripted callers (dashboard configuration, not code). `reportClientError` posts from `error.tsx`, `global-error.tsx`, and a `ClientErrorReporter` that listens for `error` / `unhandledrejection`, capped at 5 reports per page load and ignoring `ResizeObserver loop` noise; the page URL it sends is origin plus pathname, for the same reason as above.
- `wrangler.jsonc` (main worker and `synthetics/`): `observability.traces` and `observability.logs` enabled with the destinations `grafana-traces` and `grafana-logs`. The destinations are shared by production, dev, and synthetics; the worker name identifies the source on the receiving side, and the endpoint and credentials live only in the Cloudflare dashboard.
- `/api/health`: probes `${API_ENDPOINT}/healthcheck` with a 5 s timeout and answers 503 with `status: "degraded"` plus `checks.api` when it fails. The body still carries the SHA, and the post-deploy workflow reads it without curl's fail flag so a degraded answer still identifies the deployed commit.
- `synthetics/README.md` describes the worker, where its failures surface, and that Workers Builds deploys it from `master` (the `cf:deploy` script stays for deploying a checked-out revision by hand). The root README only loses the `$` prompts from its command blocks; the operational notes live in this description. No new workspace, dependency, or workflow step.

# Testing

- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm --filter qoodish-web-synthetics typecheck` — all pass
- `pnpm test` — 123 tests pass
- `wrangler deploy --dry-run` for the main worker (production and `--env dev`) and for `synthetics/` — configs accepted
- `pnpm install --frozen-lockfile` — the lockfile is unchanged from master
- The account is on the Workers Paid plan, and the automatic dev deploys of this branch succeeded while the destination names were not registered yet, so a deploy does not validate destination names. Nothing is exported until the names resolve, which is why the procedure below registers the destinations first.
- Verified end to end on the dev worker: with the destinations registered, its traces and logs arrive in Grafana Cloud with `service_name="dev-qoodish-web"`, `deployment_environment_name="dev"`, and `detected_level` on the error lines. The alert rules on top of it are dashboard configuration and are listed below.

# Release procedure

The export is a Workers Paid feature, which this account has. Export events are included up to 10 million a month, with per-event billing beyond that starting 2026-10-01.

1. In Grafana Cloud, create an access policy scoped to the stack with `traces:write` and `logs:write`, and a token under it for the Cloudflare export. The stack's OTLP gateway is `https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp`, and the OTLP connection page shows the instance ID next to it.
2. In the Cloudflare dashboard (Workers & Pages → Observability → Telemetry), register the two destinations under exactly these names (they are case-sensitive):

   | Name | Type | Endpoint | Header |
   |---|---|---|---|
   | `grafana-traces` | Traces | `https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp/v1/traces` | `Authorization: Basic <base64 of instanceId:token>` |
   | `grafana-logs` | Logs | `https://otlp-gateway-prod-ap-northeast-0.grafana.net/otlp/v1/logs` | same |

   The gateway takes Basic authentication; a `Bearer` header is rejected. Production, dev, and synthetics share the destinations; the worker name (`prod-qoodish-web`, `dev-qoodish-web`, `qoodish-web-synthetics`) identifies the source as `service.name`. The dev worker deployed from this branch is the first end-to-end check: its traces and logs should appear in Grafana Cloud, and each destination should report deliveries on the dashboard.
3. In Grafana Cloud, wire Alerting to Slack (a Grafana IRM integration of type Grafana Alerting with a contact point, the default notification policy pointing at it) and create three Loki alert rules, evaluated every minute with no pending period:

   | Rule | Query | Condition | No data |
   |---|---|---|---|
   | prod-qoodish-web errors | `sum(count_over_time({service_name="prod-qoodish-web"} \| detected_level="error" [5m]))` | above 0 | Normal |
   | synthetics failed | `sum(count_over_time({service_name="qoodish-web-synthetics"} \| detected_level="error" [35m]))` | above 0 | Normal |
   | synthetics no success | `sum(count_over_time({service_name="qoodish-web-synthetics"} \|= "ok: " [90m]))` | below 3 | Alerting |

   The third rule fires until the synthetics worker has run with the export enabled, so pause it until the merge below has deployed and its first cron run has logged.
4. In the Cloudflare dashboard, add a WAF rate limiting rule for `POST /api/errors`, since the route is public and the code no longer limits it.
5. Merge. Workers Builds deploys both `prod-qoodish-web` and `qoodish-web-synthetics` from `master` with the export enabled; confirm `{service_name="prod-qoodish-web"}` and `{service_name="qoodish-web-synthetics"}` in Grafana Cloud, then unpause the third rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDHCp8y33AKGaguZwqor3A